### PR TITLE
ci: increase self-validation coverage threshold to 80%

### DIFF
--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -373,9 +373,9 @@ def cmd_validate(args: argparse.Namespace) -> int:
         if "tests" in base_config["python"]["gates"]:
             base_config["python"]["gates"]["tests"]["test_dirs"] = ["tests"]
 
-        # Set coverage threshold for self-validation (we're still building coverage)
+        # Set coverage threshold for self-validation
         if "coverage" in base_config["python"]["gates"]:
-            base_config["python"]["gates"]["coverage"]["threshold"] = 60
+            base_config["python"]["gates"]["coverage"]["threshold"] = 80
 
         # Write temp config
         temp_config_file.write_text(json.dumps(base_config, indent=2) + "\n")


### PR DESCRIPTION
## Summary
Raises the `--self` validation coverage threshold from 60% to 80%.

## Changes
- Update coverage threshold in `sm.py` self-validation config
- Current coverage: 80.74% (passes threshold)

## Coverage Status
The project already meets the 80% threshold. Key areas with room for improvement:
- `slopmop/checks/javascript/coverage.py` (37%)
- `slopmop/core/config.py` (36%)
- `slopmop/checks/python/coverage.py` (65%)
- `slopmop/sm.py` (64%)

These can be addressed in follow-up PRs to build buffer above the threshold.