### PR TITLE
refactor: pattern-based python version allowlist

### DIFF
--- a/slopmop/subprocess/validator.py
+++ b/slopmop/subprocess/validator.py
@@ -34,8 +34,10 @@ class CommandValidator:
     # Patterns for executables that follow a predictable naming scheme
     # (e.g. python3.14, python3.15) so we don't need to update a list
     # every time a new point release ships.
+    # NOTE: Uses \Z (not $) because $ matches before a trailing \n,
+    # which would let "python3.13\n" through a security boundary.
     ALLOWED_EXECUTABLE_PATTERNS: List[re.Pattern[str]] = [
-        re.compile(r"^python3\.\d+$"),
+        re.compile(r"^python3\.\d+\Z"),
     ]
 
     # Whitelist of allowed executables

--- a/tests/unit/test_subprocess_validator.py
+++ b/tests/unit/test_subprocess_validator.py
@@ -111,5 +111,11 @@ class TestCommandValidator:
     def test_rejects_python_lookalikes_via_pattern(self):
         """Executable names that look like python but aren't should be rejected."""
         validator = CommandValidator()
-        for bad in ["python3.", "python3.x", "python4.0", "python3.13.1"]:
+        for bad in [
+            "python3.",
+            "python3.x",
+            "python4.0",
+            "python3.13.1",
+            "python3.13\n",
+        ]:
             assert validator.is_allowed(bad) is False


### PR DESCRIPTION
## Summary

Replaces the hardcoded `python3.9`-`python3.13` entries in `CommandValidator.ALLOWED_EXECUTABLES` with a regex pattern that matches any current or future `python3.X` version automatically.

## Problem

Every new Python point release required manually adding an entry to the frozen set. Anyone using a newer Python (e.g. `python3.14`) would get a `SecurityError` until the list was updated - a maintenance treadmill for zero security benefit.

## Solution

- Added `ALLOWED_EXECUTABLE_PATTERNS` class attribute - a list of compiled regex patterns for executable names that follow predictable naming schemes
- Extracted `_is_executable_allowed()` to centralise the set + pattern check, used by `validate()`, `is_allowed()`, and full-path resolution
- Removed the five hardcoded `python3.9`-`python3.13` entries
- Uses `\Z` (not `$`) for strict end-of-string matching in the security boundary

**Security posture unchanged** - the threat model prevents running arbitrary binaries (`curl`, `rm`, etc.), not specific Python point releases. The pattern is anchored and only matches `python3.<digits>`.

## Tests

- `test_allows_versioned_python_via_pattern`: validates `python3.9`, `python3.13`, `python3.14`, `python3.20`
- `test_rejects_python_lookalikes_via_pattern`: rejects `python3.`, `python3.x`, `python4.0`, `python3.13.1`, `python3.13\n`