### PR TITLE
chore: bump version to 0.1.0 for first PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.0.0"
+version = "0.1.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}

--- a/slopmop/__init__.py
+++ b/slopmop/__init__.py
@@ -1,3 +1,3 @@
 """Slop-Mop: Quality gates for AI-assisted codebases."""
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"


### PR DESCRIPTION
Version bump for the first PyPI release. Once merged, tag `v0.1.0` will be pushed to trigger the release pipeline.