### PR TITLE
fix: tool discovery for pip installs and Playwright false positives

### DIFF
--- a/slopmop/checks/quality/bogus_tests.py
+++ b/slopmop/checks/quality/bogus_tests.py
@@ -41,6 +41,9 @@ ASSERTION_HELPERS: Set[str] = {
     "assert_any_call",
     "assert_has_calls",
     "assert_not_called",
+    # Playwright / BDD-style assertion entry points
+    # e.g. expect(page.locator("h1")).to_be_visible()
+    "expect",
 }
 
 


### PR DESCRIPTION
## Summary

Two fixes for pip-installed slop-mop users:

### 1. find-duplicate-strings tool discovery (`duplicate_strings.py`)

**Problem:** `_get_tool_path()` navigated from `__file__` up 4 parent dirs to find `tools/find-duplicate-strings/`. This works in a git checkout but fails for pip installs where the package lives in `site-packages/slopmop/...` with no `tools/` directory nearby.

**Fix:** `_get_tool_path()` now searches 3 locations in order:
1. Target project's `tools/` directory (works when project vendors the tool)
2. slopmop package source tree (works in git checkout)
3. Global npm installation via `shutil.which` (works for `npm install -g`)

Also:
- `_build_command()` handles both `.js` files (prefixed with `node`) and global binaries (direct invocation)
- `_get_strip_docstrings_path()` searches 2 locations with `Optional[Path]` return
- All path methods accept `project_root` parameter for flexible resolution

### 2. Playwright `expect()` false positives (`bogus_tests.py`)

**Problem:** Python bogus-tests checker flagged Playwright E2E tests as having "no assertions." Playwright uses `expect(locator).to_be_visible()` — no `assert` keyword, no "assert" in method names, nothing in `ASSERTION_HELPERS`.

The JS bogus-tests checker already handled `expect()` via `EXPECT_PATTERN`. The Python checker lacked parity.

**Fix:** Added `"expect"` to `ASSERTION_HELPERS`. One-line fix, 35 lines of new tests covering sync and async Playwright patterns.

## Testing

- 834 unit tests passing
- `sm validate commit` — all 12 gates green
- New tests for Playwright `expect()` (sync + async)
- Updated `duplicate_strings` test mocks to match new `Optional[Path]` signatures
