### PR TITLE
chore: bump version to 0.2.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.2.0"
+version = "0.2.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
Patch release for pip-install fixes and Playwright false positive fix. Once merged, tag `v0.2.1` will be pushed to trigger the release pipeline.