### PR TITLE
fix: sync __init__.py version to 0.2.1

### DIFF
--- a/slopmop/__init__.py
+++ b/slopmop/__init__.py
@@ -1,3 +1,3 @@
 """Slop-Mop: Quality gates for AI-assisted codebases."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
The v0.2.1 release pipeline failed because `__init__.py` still had `0.2.0`. This syncs it to match `pyproject.toml`. Once merged, I'll delete the old tag, re-tag, and push to re-trigger the release.