### PR TITLE
chore: single-source version from pyproject.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,19 +85,10 @@ jobs:
       - name: Verify package version matches tag
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"  # strip leading 'v'
-          INIT_VERSION=$(python -c "import slopmop; print(slopmop.__version__)")
           TOML_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          FAIL=0
-          if [ "$INIT_VERSION" != "$TOML_VERSION" ]; then
-            echo "❌ __init__.py ($INIT_VERSION) and pyproject.toml ($TOML_VERSION) disagree"
-            FAIL=1
-          fi
           if [ "$TAG_VERSION" != "$TOML_VERSION" ]; then
             echo "❌ Tag ($TAG_VERSION) does not match pyproject.toml ($TOML_VERSION)"
-            FAIL=1
-          fi
-          if [ $FAIL -ne 0 ]; then
-            echo "   Update both slopmop/__init__.py and pyproject.toml to match the tag."
+            echo "   Update pyproject.toml to match the tag."
             exit 1
           fi
           echo "✅ Version match: $TAG_VERSION"

--- a/slopmop/__init__.py
+++ b/slopmop/__init__.py
@@ -1,3 +1,5 @@
 """Slop-Mop: Quality gates for AI-assisted codebases."""
 
-__version__ = "0.2.1"
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("slopmop")


### PR DESCRIPTION
Eliminates the dual-maintenance version problem that caused the v0.2.1 release failure.

**Changes:**
- `__init__.py` now uses `importlib.metadata.version()` instead of a hardcoded string
- Release pipeline simplified — only checks tag vs `pyproject.toml` (they can't disagree anymore)

Going forward, version bumps only need to touch `pyproject.toml`.