### PR TITLE
chore: bump version to 0.3.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.2.1"
+version = "0.3.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}

--- a/slopmop/__init__.py
+++ b/slopmop/__init__.py
@@ -1,3 +1,3 @@
 """Slop-Mop: Quality gates for AI-assisted codebases."""
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
Version bump for v0.3.0 PyPI release. Once merged, tag `v0.3.0` will be pushed to trigger the release pipeline.

**Changes since v0.2.1:**
- feat: redesign bogus test detection with pytest.raises support (#37)
- feat: gate-dodging check (#37)
- fix: enable all commit-profile gates in --self CI validation (#38)