### PR TITLE
chore: bump version to 0.4.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.3.0"
+version = "0.4.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
Version bump for v0.4.0 PyPI release. Once merged, tag `v0.4.0` will be pushed to trigger the release pipeline.

**Changes since v0.3.0:**
- feat: release script + JS eslint expect-expect check with integration tests (#41)
- fix: v0.3.0 release bugs (#40)