### PR TITLE
fix: install slopmop package in release workflow quality gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e .
 
       - name: Build string-duplication tool
         run: |


### PR DESCRIPTION
The release.yml quality gate only did `pip install -r requirements.txt` but never installed slopmop itself, causing `python -m slopmop.sm validate --self` to fail with `PackageNotFoundError`.

Changed to `pip install -e .` to match slopmop.yml.