### PR TITLE
chore: bump version to 0.4.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.4.0"
+version = "0.4.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.4.1

**Bump type:** `patch` (0.4.0 → 0.4.1)

### Changes since v0.4.0

58f1d32 fix: auto-detect non-interactive terminal in sm init (#48)

### Post-merge steps

After merging this PR, the release is triggered by pushing the tag:

```bash
git checkout main && git pull
git tag v0.4.1 && git push origin v0.4.1
```

This will trigger the `release.yml` workflow which:
1. Runs quality gates
2. Builds the package
3. Publishes to PyPI
4. Creates a GitHub Release with auto-generated notes
