### PR TITLE
chore: release v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.4.1"
+version = "0.5.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.5.0

Version bump from 0.4.1 to 0.5.0 for PyPI release.

### What's New in v0.5.0

This release contains the full swab/scour overhaul from PR #54:

- **Gate Renames (26 checks)**: All gates renamed to descriptive filenames (e.g. complexity -> complexity-creep.py)
- **Profile -> Level Terminology**: sm swab (every commit) / sm scour (deeper, pre-push/PR)
- **Display Refinements**: Category-level aggregate time, progress bar at bottom, sparkline fixes
- **Status Dashboard Redesign**: sm status is now a pure observatory/dashboard (no gate execution)
- **README Auto-Generation + Stale-Docs Gate**: New gate catches README tables drifting from source of truth
- **Deploy Gate Removal**: Removed bespoke deploy gate, custom gates deferred to #53
- **PR Gate Default Change**: pr:ignored-feedback now defaults to warn instead of fail

### Post-Merge Instructions

```bash
git checkout main && git pull
git tag v0.5.0 && git push origin v0.5.0
```

This triggers the release workflow to publish to PyPI and create a GitHub Release.
