### PR TITLE
chore: bump version to 0.6.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.5.0"
+version = "0.6.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.6.0

**Bump type:** `minor` (0.5.0 → 0.6.0)

### Changes since v0.5.0

271a5e3 feat: custom gates, multi-language detection, and beta hardening [MODEL_B] (#62)

### Post-merge steps

After merging this PR, the release is triggered by pushing the tag:

```bash
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
```

This will trigger the `release.yml` workflow which:
1. Runs quality gates
2. Builds the package
3. Publishes to PyPI
4. Creates a GitHub Release with auto-generated notes
