### PR TITLE
chore: bump version to 0.6.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.6.0"
+version = "0.6.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.6.1

**Bump type:** `patch` (0.6.0 → 0.6.1)

### Changes since v0.6.0

ebd1c68 Merge pull request #80 from ScienceIsNeato/feat/two-tier-arch-MODEL_B
3567d99 fix: address latest PR #80 review feedback
1a61eba fix: harden PR advisory workflow outputs
182c5ab fix: address remaining PR #80 feedback
3b06dd5 fix: address PR commentary follow-ups
f9babf9 ci: add PR comment advisory check run
7e0c704 feat: remove aliases and improve swab scheduling and cache UX
9f29c35 fix: resolve PTY friction across all CLI output
18dd86e feat: add --no-cache flag to bypass fingerprint caching
a8b48dd fix: hook writes structured JSON for LLM consumption
3dcdde6 feat: fingerprint-based result caching
ceb149c test: add unit tests to close diff-coverage gap
87a4a24 fix: address PR #80 review comments (round 3)
4caae5c fix: remove 13 unnecessary type-ignore/noqa annotations
ab84534 fix: remove prescriptive ignore-comment language from gate output
91b1506 feat: consistent role badges across all verbs
5cb13af feat: add repo-level mutex lock for sm runs
d947ec9 fix: address PR #80 review comments (round 2)
ede8eb2 fix: CI workflow dependency installation
85eefd4 fix: address PR #80 review comments
02db405 feat: port prescriptive fix_strategy + AST resolution from MODEL_A
c1f6af9 fix: port cross-cutting fixes from MODEL_A
676769d fix: environment-coupled tests, setup.sh standalone detection
10d0ec1 chore: ignore .claude/ session state
38831e5 docs+fix: thesis tagline + dead ConsoleReporter params
41346c0 fix: second-round review findings (Bugbot, low-severity)
7d7b67c fix: address PR review findings (Copilot + Bugbot)
3f513c3 feat: surface CheckRole in sm status dashboard [MODEL_B]
ccd1e30 fix: resolve slop-mop friction surfaced during two-tier work [MODEL_B]
f31cca3 feat: two-tier architecture, fix_strategy, unified output pipeline [MODEL_B]
b6606cb Merge pull request #73 from ScienceIsNeato/feat/sarif-output-MODEL_B
95d21dc Merge pull request #75 from ScienceIsNeato/revert-74-feat/sarif-output-MODEL_A
893a411 Revert "feat: SARIF 2.1.0 output for GitHub Code Scanning [MODEL_A]"
ac39849 Merge pull request #74 from ScienceIsNeato/feat/sarif-output-MODEL_A
cb8ea57 fix: install mypy in CI and handle missing tool gracefully
bc6ba34 fix: convert location-less Findings to per-file
9e78250 fix: address all PR #73 review comments
1805b96 feat(code-sprawl): anti-squeeze hardening + SARIF CI fixes
200e423 fix: break SARIF→Code-Scanning→pr-comments feedback loop [MODEL_A]
f8874b1 feat: structured Findings on JS gates + friction fixes [MODEL_A]
36921b9 refactor: fix friction I papered over instead of addressing
b3cf966 fix: GitHub SARIF ingester requires locations on every result [MODEL_A]
87a446e fix(sarif): CI install from checkout + rail for missing findings
ce11951 feat: SARIF 2.1.0 output for GitHub Code Scanning [MODEL_A]
1dcb1be feat: SARIF 2.1.0 output for GitHub Code Scanning [MODEL_B]

### Post-merge steps

After merging this PR, the release is triggered by pushing the tag:

```bash
git checkout main && git pull
git tag v0.6.1 && git push origin v0.6.1
```

This will trigger the `release.yml` workflow which:
1. Runs quality gates
2. Builds the package
3. Publishes to PyPI
4. Creates a GitHub Release with auto-generated notes
