### PR TITLE
chore: bump version to 0.8.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.8.0"
+version = "0.8.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.8.1

**Bump type:** `patch` (0.8.0 → 0.8.1)

### Changes since v0.8.0

95ce941 Merge pull request #91 from ScienceIsNeato/feat/queueit-dogfood-followup
e3d1b96 fix: --no-cache writes fresh results back to cache
9c3191c fix: address PR review feedback
5c0fb18 refactor: rename Dart gates to flaw-centric naming convention
270ce55 fix: align DartFormatCheck scope with per-package execution
204048c fix: ESLint expect gate handles TypeScript and ESM files (#94)
d7985c5 fix: remove walk-forward terminal gate
27ee817 fix: guard Flutter permission-error check behind failure path
bc4ae86 fix: accurate timeout messages and deduplicate Flutter constant
849e0dc ci: add Docker integration test job to primary workflow
1719199 fix: docker integration tests — ESLint no-config, timeout, fixtures
ff72dfa fix: error on unknown gate names instead of silent no-op
b97754c chore: merge main and regenerate stale docs
d8b5fb5 fix: finish PR green-up
7ed1c36 fix: address PR feedback
8e58689 feat: upstream flutter dogfood fixes

### Post-merge steps

After merging this PR, the release is triggered by pushing the tag:

```bash
git checkout main && git pull
git tag v0.8.1 && git push origin v0.8.1
```

This will trigger the `release.yml` workflow which:
1. Runs quality gates
2. Builds the package
3. Publishes to PyPI
4. Creates a GitHub Release with auto-generated notes
