### PR TITLE
chore: bump version to 0.9.0 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.8.1"
+version = "0.9.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.9.0

Bump from `0.8.1` to `0.9.0`.

### Highlights since v0.8.1
- baseline snapshot filtering landed
- remediation ordering is now first-class across executor, reporting, and buff triage
- `sm status` got workflow/CI awareness
- gate reasoning is now structured and documented
- agent install/help and custom-gate flows got sharper
- follow-up PR review fixes landed across executor, validate, stale-docs, and pyright overlay behavior

### Validation
- `sm swab`
- `sm scour`

### Post-merge
After this PR merges:

```bash
git checkout main && git pull
git tag v0.9.0 && git push origin v0.9.0
```
