### PR TITLE
fix: verify feedback before buff status goes green

### DIFF
--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -45,6 +45,40 @@ _RESOLUTION_SCENARIOS = {
 _POST_CI_FEEDBACK_CHECK_NAMES = {"cursor bugbot"}
 
 
+def _has_post_ci_feedback_check(checks: list[dict[str, Any]]) -> bool:
+    """Return whether a late-comment review bot is present in the check set."""
+
+    return any(
+        str(check.get("name", "")).strip().lower() in _POST_CI_FEEDBACK_CHECK_NAMES
+        for check in checks
+    )
+
+
+def _render_status_feedback_blocker(
+    feedback_result: CheckResult, *, no_checks: bool
+) -> int:
+    """Render unresolved or unverifiable feedback for buff status/watch."""
+
+    if feedback_result.status == CheckStatus.FAILED:
+        if no_checks:
+            print(
+                "Buff status blocked: no CI checks found, but unresolved PR review threads remain."
+            )
+        else:
+            print(
+                "Buff status blocked: CI checks are clean, but unresolved PR review threads remain."
+            )
+        if feedback_result.output:
+            print(feedback_result.output)
+        print("Next step: run 'sm buff inspect' to take the next review batch.")
+        return 1
+
+    print("Buff status error: could not verify unresolved PR feedback.")
+    if feedback_result.error:
+        print(f"ERROR: {feedback_result.error}")
+    return 1
+
+
 def _parse_optional_int(value: str | None, label: str) -> int | None:
     """Parse an optional integer CLI token."""
 
@@ -559,6 +593,13 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
             return 2 if "not found" in error.lower() else 1
 
         if not checks:
+            feedback_result = _run_pr_feedback_gate(resolved_pr, str(project_root))
+            if feedback_result.status != CheckStatus.PASSED:
+                return _render_status_feedback_blocker(
+                    feedback_result,
+                    no_checks=True,
+                )
+
             print("ℹ️  No CI checks found for this PR")
             print("   (CI workflow may not be set up yet)")
             return 0
@@ -569,6 +610,7 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
         if failed:
             _print_failed_status(completed, in_progress, failed)
             if watch and in_progress:
+                settled_post_ci_feedback = False
                 print(f"⏳ Waiting {interval}s before next check...")
                 time.sleep(interval)
                 print()
@@ -589,11 +631,7 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
         if (
             watch
             and not settled_post_ci_feedback
-            and any(
-                str(check.get("name", "")).strip().lower()
-                in _POST_CI_FEEDBACK_CHECK_NAMES
-                for check in checks
-            )
+            and _has_post_ci_feedback_check(checks)
         ):
             settled_post_ci_feedback = True
             print(
@@ -604,19 +642,11 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
             continue
 
         feedback_result = _run_pr_feedback_gate(resolved_pr, str(project_root))
-        if feedback_result.status == CheckStatus.FAILED:
-            print(
-                "Buff status blocked: CI checks are clean, but unresolved PR review threads remain."
+        if feedback_result.status != CheckStatus.PASSED:
+            return _render_status_feedback_blocker(
+                feedback_result,
+                no_checks=False,
             )
-            if feedback_result.output:
-                print(feedback_result.output)
-            print("Next step: run 'sm buff inspect' to take the next review batch.")
-            return 1
-        if feedback_result.status == CheckStatus.ERROR:
-            print("Buff status error: could not verify unresolved PR feedback.")
-            if feedback_result.error:
-                print(f"ERROR: {feedback_result.error}")
-            return 1
 
         _print_success_status(completed, total)
         return 0

--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -42,6 +42,8 @@ _RESOLUTION_SCENARIOS = {
     "needs_human_feedback",
 }
 
+_POST_CI_FEEDBACK_CHECK_NAMES = {"cursor bugbot"}
+
 
 def _parse_optional_int(value: str | None, label: str) -> int | None:
     """Parse an optional integer CLI token."""
@@ -547,6 +549,8 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
     print("=" * 60)
     print()
 
+    settled_post_ci_feedback = False
+
     while True:
         checks, error = _fetch_checks(project_root, resolved_pr)
 
@@ -574,11 +578,44 @@ def _cmd_buff_status(pr_number: int | None, watch: bool, interval: int) -> int:
         if in_progress:
             _print_in_progress_status(completed, in_progress)
             if watch:
+                settled_post_ci_feedback = False
                 print(f"⏳ Waiting {interval}s before next check...")
                 time.sleep(interval)
                 print()
                 continue
             print("💡 Use 'sm buff watch' to poll until complete")
+            return 1
+
+        if (
+            watch
+            and not settled_post_ci_feedback
+            and any(
+                str(check.get("name", "")).strip().lower()
+                in _POST_CI_FEEDBACK_CHECK_NAMES
+                for check in checks
+            )
+        ):
+            settled_post_ci_feedback = True
+            print(
+                "⏳ CI checks are complete. Waiting one extra interval for review feedback to settle..."
+            )
+            time.sleep(interval)
+            print()
+            continue
+
+        feedback_result = _run_pr_feedback_gate(resolved_pr, str(project_root))
+        if feedback_result.status == CheckStatus.FAILED:
+            print(
+                "Buff status blocked: CI checks are clean, but unresolved PR review threads remain."
+            )
+            if feedback_result.output:
+                print(feedback_result.output)
+            print("Next step: run 'sm buff inspect' to take the next review batch.")
+            return 1
+        if feedback_result.status == CheckStatus.ERROR:
+            print("Buff status error: could not verify unresolved PR feedback.")
+            if feedback_result.error:
+                print(f"ERROR: {feedback_result.error}")
             return 1
 
         _print_success_status(completed, total)

--- a/tests/unit/test_buff_inspect_and_status.py
+++ b/tests/unit/test_buff_inspect_and_status.py
@@ -307,3 +307,109 @@ class TestBuffStatusCommand:
 
         assert buff_mod.cmd_buff(args) == 1
         assert "Selected working PR #92 is stale" in capsys.readouterr().out
+
+    def test_cmd_buff_status_blocks_on_unresolved_feedback(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(
+                return_value=_feedback_result(
+                    CheckStatus.FAILED,
+                    output="PR #85 has unresolved review threads.",
+                )
+            ),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "CI checks are clean, but unresolved PR review threads remain." in out
+        assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_watch_waits_once_for_post_ci_feedback_settle(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "neutral",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+            },
+        ]
+        fetch_checks = Mock(side_effect=[(checks, ""), (checks, "")])
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "Waiting one extra interval for review feedback to settle" in out
+        assert "CI CLEAN" in out
+        assert fetch_checks.call_count == 2
+        feedback_gate.assert_called_once_with(85, "/repo")
+        sleep_mock.assert_called_once_with(7)

--- a/tests/unit/test_buff_inspect_and_status.py
+++ b/tests/unit/test_buff_inspect_and_status.py
@@ -413,3 +413,168 @@ class TestBuffStatusCommand:
         assert fetch_checks.call_count == 2
         feedback_gate.assert_called_once_with(85, "/repo")
         sleep_mock.assert_called_once_with(7)
+
+    def test_cmd_buff_status_no_checks_still_blocks_on_unresolved_feedback(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=([], "")))
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(
+                return_value=_feedback_result(
+                    CheckStatus.FAILED,
+                    output="PR #85 has unresolved review threads.",
+                )
+            ),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "no CI checks found, but unresolved PR review threads remain" in out
+        assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_status_blocks_when_feedback_not_verified(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=_feedback_result(CheckStatus.SKIPPED)),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "Buff status error: could not verify unresolved PR feedback." in out
+        assert "CI CLEAN" not in out
+
+    def test_cmd_buff_watch_resets_settle_flag_after_failed_pending_poll(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        passing_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "neutral",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+            },
+        ]
+        failed_pending_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "fail",
+                "state": "FAILURE",
+                "link": "https://example.test/fail",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://cursor.com/docs/bugbot",
+            },
+        ]
+        fetch_checks = Mock(
+            side_effect=[
+                (passing_checks, ""),
+                (failed_pending_checks, ""),
+                (passing_checks, ""),
+                (passing_checks, ""),
+            ]
+        )
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert (
+            out.count("Waiting one extra interval for review feedback to settle") == 2
+        )
+        assert fetch_checks.call_count == 4
+        feedback_gate.assert_called_once_with(85, "/repo")
+        assert sleep_mock.call_count == 3

--- a/tests/unit/test_sm_cli.py
+++ b/tests/unit/test_sm_cli.py
@@ -684,7 +684,15 @@ class TestBuffStatus:
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
                 with patch("slopmop.cli.buff.resolve_pr_number", return_value=1):
                     with patch("slopmop.cli.buff._fetch_checks", return_value=([], "")):
-                        result = cmd_buff(args)
+                        with patch(
+                            "slopmop.cli.buff._run_pr_feedback_gate",
+                            return_value=CheckResult(
+                                name="myopia:ignored-feedback",
+                                status=CheckStatus.PASSED,
+                                duration=0.01,
+                            ),
+                        ):
+                            result = cmd_buff(args)
 
         captured = capsys.readouterr()
         assert result == 0

--- a/tests/unit/test_sm_cli.py
+++ b/tests/unit/test_sm_cli.py
@@ -22,6 +22,7 @@ from slopmop.cli.hooks import (
 )
 from slopmop.cli.init import prompt_user, prompt_yes_no
 from slopmop.cli.scan_triage import TriageError
+from slopmop.core.result import CheckResult, CheckStatus
 from slopmop.sm import load_config, main, setup_logging
 
 
@@ -612,7 +613,15 @@ class TestBuffStatus:
                     with patch(
                         "slopmop.cli.buff._fetch_checks", return_value=(checks, "")
                     ):
-                        result = cmd_buff(args)
+                        with patch(
+                            "slopmop.cli.buff._run_pr_feedback_gate",
+                            return_value=CheckResult(
+                                name="myopia:ignored-feedback",
+                                status=CheckStatus.PASSED,
+                                duration=0.01,
+                            ),
+                        ):
+                            result = cmd_buff(args)
 
         captured = capsys.readouterr()
         assert result == 0


### PR DESCRIPTION
## Summary

- stop `sm buff status/watch` from declaring success based only on CI checks
- run the ignored-feedback gate before reporting a clean PR state
- add one extra settle interval after `Cursor Bugbot` completes so late review threads are less likely to slip through

## Validation

- python -m pytest tests/unit/test_buff_inspect_and_status.py tests/unit/test_buff_workflow_actions.py tests/unit/test_sm_cli.py::TestBuffStatus::test_ci_with_explicit_pr_number -q
- sm swab
