### PR TITLE
chore: bump version to 0.10.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.10.0"
+version = "0.10.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.10.1

**Bump type:** `patch` (0.10.0 → 0.10.1)

### Changes since v0.10.0

(no previous tag found)

### Post-merge steps

After merging this PR, GitHub Actions will automatically detect the version
bump on `main` and run `release.yml`, which will:
1. Run quality gates
2. Build the package
3. Publish to PyPI
4. Create the version tag and GitHub Release with auto-generated notes
