### PR TITLE
chore: bump version to 0.11.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.10.1"
+version = "0.11.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.11.0

**Bump type:** `minor` (0.10.1 → 0.11.0)

### Changes since v0.10.1

113e2ac Merge pull request #114 from ScienceIsNeato/feat/refit-rail
9923d0e fix: normalize help text indentation in sm --help
1dcfb5a fix: update Copilot SKILL.md to use current refit CLI flags
4922536 fix(tests): remove self-skipping from integration test
6e7261e refactor(tests): split iterate tests into test_refit_iterate.py
a1d4c08 refactor(validate): extract _should_skip_repo_lock helper
1155aa5 refactor: move MissingDependencyError to exceptions module, remove type:ignore
2207f54 refactor: extract container paths to constants, remove jargon
9fe4cd1 refactor(refit): rewrite templates, rename CLI args, extract iteration module
0bc03a9 fix: filter .slopmop artifacts from worktree status and fix porcelain parsing
d8f8e3c fix: exclude .slopmop from refit commits and remove dead code
d86519a fix: tighten refit scenario artifact detection
aef5984 fix: close first refit review batch
9dcc930 Add refit rail integration scaffolding and validation fixes

### Post-merge steps

After merging this PR, GitHub Actions will automatically detect the version
bump on `main` and run `release.yml`, which will:
1. Run quality gates
2. Build the package
3. Publish to PyPI
4. Create the version tag and GitHub Release with auto-generated notes
