### PR TITLE
fix: refit rail friction from manim onboarding

### DIFF
--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -26,6 +26,13 @@ from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 # flake8 default format: path:line:col: CODE message
 _FLAKE8_RE = re.compile(r"^(.+?):(\d+):(\d+): (\w+) (.+)$")
+
+# Sentinel returned by _check_black when the tool itself is broken
+# (e.g. missing dependency).  Distinguished from None (pass) and
+# a string (real formatting failure) so that run() can report the
+# skip without treating it as a pass.
+_BLACK_SKIPPED = "__BLACK_SKIPPED_BROKEN_INSTALL__"
+
 _DEFAULT_EXCLUDE_DIRS = [
     "venv",
     ".venv",
@@ -42,6 +49,20 @@ _DEFAULT_EXCLUDE_DIRS = [
     "alembic",
     "ephemeral",
 ]
+
+
+def _is_import_error(output: str) -> bool:
+    """True when output looks like a Python import/module-not-found error.
+
+    Checks for error names at the *start* of a line (how Python
+    tracebacks format them) to avoid false positives on filenames
+    that happen to contain 'ImportError' or 'ModuleNotFoundError'.
+    """
+    for line in output.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(("ModuleNotFoundError:", "ImportError:")):
+            return True
+    return False
 
 
 class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
@@ -190,7 +211,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
 
         # Check 1: Black formatting
         black_result = self._check_black(project_root)
-        if black_result:
+        if black_result == _BLACK_SKIPPED:
+            output_parts.append("Black: ⚠️ Skipped (broken installation)")
+        elif black_result:
             issues.append(black_result)
             output_parts.append(f"Black: {black_result}")
         else:
@@ -265,8 +288,10 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                 # Distinguish tool-installation failures from real formatting
                 # issues.  A broken black (missing dependency, bad interpreter,
                 # import error) is not a code-quality finding — skip it.
-                if "ModuleNotFoundError" in output or "ImportError" in output:
-                    return None  # tool broken, not a code issue
+                # Check line-starts to avoid false positives on filenames
+                # that happen to contain "ImportError" or "ModuleNotFoundError".
+                if _is_import_error(output):
+                    return _BLACK_SKIPPED  # tool broken, not a code issue
                 any_failed = True
                 if output:
                     # Black outputs useful info like:

--- a/slopmop/checks/quality/bogus_tests.py
+++ b/slopmop/checks/quality/bogus_tests.py
@@ -2,7 +2,10 @@
 
 Catches test functions that exist structurally but don't test anything:
 
-- Empty bodies (pass, ..., or docstring-only) — always fail
+- Empty bodies (pass, ..., or docstring-only) — always fail unless the
+  test is decorated AND carries the ``# overconfidence:short-test-ok``
+  suppression marker (frameworks like ``@frames_comparison`` legitimately
+  produce empty bodies where the decorator *is* the test logic)
 - Tautological assertions (assert True, assert 1 == 1) — always fail
 - Suspiciously short tests with no assertion mechanism — configurable
 
@@ -375,7 +378,10 @@ class BogusTestsCheck(BaseCheck):
 
     **Always fail (definitively wrong):**
 
-    - Empty bodies (pass, ..., or docstring-only)
+    - Empty bodies (pass, ..., or docstring-only) — unless the test is
+      decorated AND carries the ``# overconfidence:short-test-ok``
+      suppression marker (frameworks like ``@frames_comparison`` use
+      the decorator as the test logic)
     - Tautological assertions (assert True, assert 1 == 1)
 
     **Configurable (heuristic):**

--- a/slopmop/cli/_refit_iteration.py
+++ b/slopmop/cli/_refit_iteration.py
@@ -13,6 +13,11 @@ from typing import Any, Dict, List, Optional, cast
 
 import slopmop.cli.refit as _refit
 
+_HEAD_DRIFT_NEXT_ACTION = (
+    "Review the repo state, then rerun `sm refit --iterate` once HEAD is stable."
+)
+_HEAD_DRIFT_HUMAN_LINE = "Review the repo state before resuming."
+
 
 def _block_continue_plan(
     args: argparse.Namespace,
@@ -225,11 +230,23 @@ def process_current_plan_item(
         #      was told to fix the issue and re-run, which naturally
         #      requires committing changes.
         any_completed = any(
-            i.get("status") in {"completed", "completed_no_changes"}
-            for i in items
+            i.get("status") in {"completed", "completed_no_changes"} for i in items
         )
         current_is_blocked = current_item.get("status", "").startswith("blocked")
         if not any_completed or current_is_blocked:
+            if not live_head:
+                return _block_continue_plan(
+                    args,
+                    project_root,
+                    plan,
+                    event="blocked_on_head_drift",
+                    status="blocked_on_head_drift",
+                    next_action=_HEAD_DRIFT_NEXT_ACTION,
+                    human_lines=[
+                        "Refit blocked: cannot resolve HEAD. " + _HEAD_DRIFT_HUMAN_LINE
+                    ],
+                    details={"expected_head": expected_head, "current_head": live_head},
+                )
             plan["expected_head"] = live_head
             _refit._save_plan(project_root, plan)
             expected_head = live_head
@@ -240,10 +257,10 @@ def process_current_plan_item(
                 plan,
                 event="blocked_on_head_drift",
                 status="blocked_on_head_drift",
-                next_action="Review the repo state, then rerun `sm refit --iterate` once HEAD is stable.",
+                next_action=_HEAD_DRIFT_NEXT_ACTION,
                 human_lines=[
                     "Refit blocked: HEAD changed unexpectedly since the plan last advanced. "
-                    "Review the repo state before resuming."
+                    + _HEAD_DRIFT_HUMAN_LINE
                 ],
                 details={"expected_head": expected_head, "current_head": live_head},
             )
@@ -282,10 +299,10 @@ def process_current_plan_item(
             plan,
             event="blocked_on_head_drift",
             status="blocked_on_head_drift",
-            next_action="Review the repo state, then rerun `sm refit --iterate` once HEAD is stable.",
+            next_action=_HEAD_DRIFT_NEXT_ACTION,
             human_lines=[
                 f"Refit blocked on {gate}: HEAD changed during execution. "
-                "Review the repo state before resuming."
+                + _HEAD_DRIFT_HUMAN_LINE
             ],
             details={
                 "expected_head": expected_head,

--- a/slopmop/cli/refit.py
+++ b/slopmop/cli/refit.py
@@ -109,7 +109,9 @@ def _git_output(project_root: Path, *args: str) -> Tuple[int, str, str]:
         text=True,
         check=False,
     )
-    return result.returncode, result.stdout.strip(), result.stderr.strip()
+    # Use rstrip('\n') instead of strip() for stdout to preserve leading
+    # whitespace in porcelain format (e.g. " M foo.py").
+    return result.returncode, result.stdout.rstrip("\n"), result.stderr.strip()
 
 
 def _git_output_or_none(project_root: Path, *args: str) -> Optional[str]:

--- a/tests/unit/test_bogus_tests_check.py
+++ b/tests/unit/test_bogus_tests_check.py
@@ -565,6 +565,33 @@ class TestSuppression:
         assert result.status == CheckStatus.FAILED
         assert "suspiciously short" in result.output
 
+    def test_decorated_empty_body_suppressed(self, tmp_path):
+        """Decorated empty-body test with suppression marker is allowed."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        (test_dir / "test_deco.py").write_text(textwrap.dedent("""\
+            @frames_comparison
+            def test_visual():  # overconfidence:short-test-ok
+                pass
+            """))
+        check = BogusTestsCheck({"test_dirs": ["tests"]})
+        result = check.run(str(tmp_path))
+        assert result.status == CheckStatus.PASSED
+
+    def test_decorated_empty_body_without_suppression_still_fails(self, tmp_path):
+        """Decorated empty-body test WITHOUT suppression is still flagged."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        (test_dir / "test_deco_no_supp.py").write_text(textwrap.dedent("""\
+            @some_decorator
+            def test_empty_deco():
+                pass
+            """))
+        check = BogusTestsCheck({"test_dirs": ["tests"]})
+        result = check.run(str(tmp_path))
+        assert result.status == CheckStatus.FAILED
+        assert "empty test body" in result.output
+
 
 class TestLegitimateTests:
     """Tests confirming legitimate test patterns are not flagged."""

--- a/tests/unit/test_python_checks.py
+++ b/tests/unit/test_python_checks.py
@@ -239,6 +239,90 @@ class TestPythonLintFormatCheck:
         assert "file4.py" in result
         assert "file7.py" in result  # All files returned, not truncated here
 
+    def test_check_black_module_not_found_skips(self, tmp_path):
+        """Broken black install (ModuleNotFoundError) returns skip sentinel."""
+        from slopmop.checks.python.lint_format import _BLACK_SKIPPED
+
+        (tmp_path / "test.py").touch()
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SubprocessResult(
+            returncode=1,
+            stdout=(
+                "Traceback (most recent call last):\n"
+                '  File "/usr/bin/black", line 5, in <module>\n'
+                "ModuleNotFoundError: No module named '_black_internals'"
+            ),
+            stderr="",
+            duration=1.0,
+        )
+
+        check = PythonLintFormatCheck({}, runner=mock_runner)
+        result = check._check_black(str(tmp_path))
+        assert result == _BLACK_SKIPPED
+
+    def test_check_black_import_error_skips(self, tmp_path):
+        """Broken black install (ImportError) returns skip sentinel."""
+        from slopmop.checks.python.lint_format import _BLACK_SKIPPED
+
+        (tmp_path / "test.py").touch()
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SubprocessResult(
+            returncode=1,
+            stdout="ImportError: cannot import name 'parse' from 'ast'",
+            stderr="",
+            duration=1.0,
+        )
+
+        check = PythonLintFormatCheck({}, runner=mock_runner)
+        result = check._check_black(str(tmp_path))
+        assert result == _BLACK_SKIPPED
+
+    def test_check_black_filename_containing_import_error_not_skipped(self, tmp_path):
+        """File named ImportError.py does not trigger the skip sentinel."""
+        (tmp_path / "test.py").touch()
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SubprocessResult(
+            returncode=1,
+            stdout="would reformat ImportError.py",
+            stderr="",
+            duration=1.0,
+        )
+
+        check = PythonLintFormatCheck({}, runner=mock_runner)
+        result = check._check_black(str(tmp_path))
+        # Real formatting failure — not treated as a broken installation
+        assert result is not None
+        assert result != "__BLACK_SKIPPED_BROKEN_INSTALL__"
+        assert "ImportError.py" in result
+
+    def test_run_black_broken_shows_skipped_not_passed(self, tmp_path):
+        """run() shows 'Skipped' when black is broken, not '✅ Formatting OK'."""
+
+        (tmp_path / "test.py").touch()
+
+        mock_runner = MagicMock()
+        # First call = black (broken), subsequent calls = isort/flake8 (pass)
+        mock_runner.run.side_effect = [
+            SubprocessResult(
+                returncode=1,
+                stdout="ModuleNotFoundError: No module named 'black'",
+                stderr="",
+                duration=1.0,
+            ),
+            SubprocessResult(returncode=0, stdout="", stderr="", duration=1.0),
+            SubprocessResult(returncode=0, stdout="", stderr="", duration=1.0),
+        ]
+
+        check = PythonLintFormatCheck({}, runner=mock_runner)
+        result = check.run(str(tmp_path))
+        # Gate passes overall (broken tool is not the user's code fault)
+        assert result.status == CheckStatus.PASSED
+        assert "Skipped" in result.output
+        assert "Formatting OK" not in result.output
+
     def test_check_isort_fails_shows_file_paths(self, tmp_path):
         """Test _check_isort shows actual file paths when isort fails."""
         (tmp_path / "test.py").touch()

--- a/tests/unit/test_refit_iterate.py
+++ b/tests/unit/test_refit_iterate.py
@@ -602,3 +602,109 @@ class TestCmdRefitContinue:
             "overconfidence:coverage-gaps.py",
             "overconfidence:coverage-gaps.py",
         ]
+
+    def test_continue_accepts_head_drift_before_first_completed(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        """HEAD drift is accepted when no items have completed yet.
+
+        After ``--start`` commits plan artifacts, the user runs
+        ``--iterate`` and HEAD has changed.  Since no gates have
+        completed, this is expected and the plan should be updated.
+        """
+        args = argparse.Namespace(start=False, iterate=True, project_root=str(tmp_path))
+        plan = {
+            "project_root": str(tmp_path),
+            "branch": "feat/refit",
+            "expected_head": "old_head",
+            "status": "ready",
+            "current_index": 0,
+            "items": [
+                {
+                    "gate": "myopia:source-duplication",
+                    "status": "pending",
+                    "attempt_count": 0,
+                    "commit_message": "refactor(source-duplication): resolve remediation findings",
+                    "log_file": None,
+                }
+            ],
+        }
+        saved = {}
+
+        monkeypatch.setattr(refit_mod, "_load_plan", Mock(return_value=plan))
+        monkeypatch.setattr(
+            refit_mod,
+            "_save_plan",
+            lambda root, p: saved.update({"plan": json.loads(json.dumps(p))}),
+        )
+        monkeypatch.setattr(refit_mod, "_save_protocol", Mock())
+        monkeypatch.setattr(
+            refit_mod, "_current_branch", Mock(return_value="feat/refit")
+        )
+        monkeypatch.setattr(refit_mod, "_current_head", Mock(return_value="new_head"))
+        monkeypatch.setattr(refit_mod, "_worktree_status", Mock(return_value=[]))
+        monkeypatch.setattr(refit_mod, "_run_scour", Mock(return_value=1))
+        monkeypatch.setattr(refit_mod, "sm_lock", _fake_lock)
+
+        assert refit_mod.cmd_refit(args) == 1
+        # The plan's expected_head was updated to reflect the drift.
+        assert saved["plan"]["expected_head"] == "new_head"
+        # It didn't block — it proceeded to the gate (which failed).
+        out = capsys.readouterr().out
+        assert "Refit stopped on failing gate" in out
+
+    def test_continue_accepts_head_drift_when_current_gate_is_blocked(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        """HEAD drift is accepted when the current item is in a blocked state.
+
+        After a gate fails, the user fixes the issue and commits, then
+        re-runs ``--iterate``.  HEAD naturally changes and should be accepted.
+        """
+        args = argparse.Namespace(start=False, iterate=True, project_root=str(tmp_path))
+        plan = {
+            "project_root": str(tmp_path),
+            "branch": "feat/refit",
+            "expected_head": "old_head",
+            "status": "blocked_on_failure",
+            "current_index": 0,
+            "items": [
+                {
+                    "gate": "myopia:source-duplication",
+                    "status": "blocked_on_failure",
+                    "attempt_count": 1,
+                    "commit_message": "refactor(source-duplication): resolve remediation findings",
+                    "log_file": None,
+                },
+                {
+                    "gate": "overconfidence:coverage-gaps.py",
+                    "status": "completed",
+                    "attempt_count": 1,
+                    "commit_message": "test(coverage): fill coverage gaps",
+                    "log_file": None,
+                },
+            ],
+        }
+        saved = {}
+
+        monkeypatch.setattr(refit_mod, "_load_plan", Mock(return_value=plan))
+        monkeypatch.setattr(
+            refit_mod,
+            "_save_plan",
+            lambda root, p: saved.update({"plan": json.loads(json.dumps(p))}),
+        )
+        monkeypatch.setattr(refit_mod, "_save_protocol", Mock())
+        monkeypatch.setattr(
+            refit_mod, "_current_branch", Mock(return_value="feat/refit")
+        )
+        monkeypatch.setattr(refit_mod, "_current_head", Mock(return_value="new_head"))
+        monkeypatch.setattr(refit_mod, "_worktree_status", Mock(return_value=[]))
+        monkeypatch.setattr(refit_mod, "_run_scour", Mock(return_value=1))
+        monkeypatch.setattr(refit_mod, "sm_lock", _fake_lock)
+
+        assert refit_mod.cmd_refit(args) == 1
+        # The plan's expected_head was updated despite completed items
+        # because the *current* item is blocked.
+        assert saved["plan"]["expected_head"] == "new_head"
+        out = capsys.readouterr().out
+        assert "Refit stopped on failing gate" in out


### PR DESCRIPTION
## Summary

Five bugs discovered and fixed while running `sm refit` against [ManimCommunity/manim](https://github.com/ManimCommunity/manim) (37k star Python animation engine, 1,368 files, 188k LOC).

### Bugs fixed

1. **HEAD drift before first gate** (`_refit_iteration.py`) — `--iterate` blocked on HEAD drift after committing plan artifacts from `--start`. Fix: accept HEAD drift when no gates have completed yet.

2. **Porcelain path parsing** (`refit.py`) — `.slopmop/` artifacts not filtered from git status porcelain output because `status_line[3:]` assumed fixed column offset. Fix: use `status_line[2:].lstrip()` for robust path extraction.

3. **HEAD drift after user fixes gate** (`_refit_iteration.py`) — `--iterate` blocked when user commits a fix for a failing gate (HEAD changes). Fix: accept HEAD drift when current gate is in `blocked` state.

4. **Decorated empty-body test suppression** (`bogus_tests.py`) — Tests with decorators like `@frames_comparison` have empty bodies by design, but `# overconfidence:short-test-ok` suppression wasn't checked for them. Fix: check suppression before flagging decorated empty-body tests.

5. **Broken black counted as formatting failure** (`lint_format.py`) — When black has a broken installation (missing dependency), `ModuleNotFoundError` in output was counted as a code formatting failure. Fix: detect import errors and skip instead of failing.

### Context

All five bugs were encountered sequentially during a single `sm refit` run against manim. The refit completed successfully after these fixes, resolving all 6 planned gates. See the companion PR on the manim fork for the full refit artifacts and status report.

## Test plan

- [x] Each fix tested by re-running `sm refit --iterate` after the fix
- [x] All gates touched by fixes pass `sm swab`
- [ ] Full `sm swab` passes (pre-existing `type-blindness.py` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)