### PR TITLE
feat: auto-add .slopmop/ to project .gitignore on init and refit

### DIFF
--- a/slopmop/cli/init.py
+++ b/slopmop/cli/init.py
@@ -625,6 +625,12 @@ def cmd_init(args: argparse.Namespace) -> int:
 
     _write_config(config_file, project_root, base_config, detected, config)
 
+    # Ensure .slopmop/ is gitignored so ephemeral state is never committed
+    from slopmop.utils import ensure_slopmop_gitignored
+
+    if ensure_slopmop_gitignored(project_root):
+        print("📝 Added .slopmop/ to .gitignore")
+
     # Show project dashboard so the user sees current state
     print("─" * 60)
 

--- a/slopmop/cli/refit.py
+++ b/slopmop/cli/refit.py
@@ -688,6 +688,11 @@ def _cmd_refit_start(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # Ensure .slopmop/ is gitignored before scour populates it
+    from slopmop.utils import ensure_slopmop_gitignored
+
+    ensure_slopmop_gitignored(project_root)
+
     artifact_path = _initial_scour_path(project_root)
     exit_code = _run_scour(project_root, artifact_path)
     if exit_code not in {0, 1}:

--- a/slopmop/utils/__init__.py
+++ b/slopmop/utils/__init__.py
@@ -1,0 +1,36 @@
+"""Shared utility functions for slop-mop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SLOPMOP_GITIGNORE_ENTRY = ".slopmop/"
+_SLOPMOP_GITIGNORE_COMMENT = "# slop-mop working directory (machine-local state)"
+
+
+def ensure_slopmop_gitignored(project_root: Path) -> bool:
+    """Idempotently add ``.slopmop/`` to the project's ``.gitignore``.
+
+    Returns ``True`` if the entry was added, ``False`` if it was already
+    present or the line already appears in the file.
+    """
+    gitignore = project_root / ".gitignore"
+
+    if gitignore.exists():
+        content = gitignore.read_text(encoding="utf-8")
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped == _SLOPMOP_GITIGNORE_ENTRY:
+                return False
+        # Ensure we start on a new line
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += f"\n{_SLOPMOP_GITIGNORE_COMMENT}\n{_SLOPMOP_GITIGNORE_ENTRY}\n"
+        gitignore.write_text(content, encoding="utf-8")
+    else:
+        gitignore.write_text(
+            f"{_SLOPMOP_GITIGNORE_COMMENT}\n{_SLOPMOP_GITIGNORE_ENTRY}\n",
+            encoding="utf-8",
+        )
+
+    return True

--- a/tests/unit/test_ensure_gitignore.py
+++ b/tests/unit/test_ensure_gitignore.py
@@ -1,0 +1,60 @@
+"""Tests for slopmop.utils.ensure_slopmop_gitignored."""
+
+from pathlib import Path
+
+from slopmop.utils import ensure_slopmop_gitignored
+
+
+def test_creates_gitignore_when_missing(tmp_path: Path) -> None:
+    assert ensure_slopmop_gitignored(tmp_path) is True
+    content = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ".slopmop/" in content
+
+
+def test_appends_to_existing_gitignore(tmp_path: Path) -> None:
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("node_modules/\n", encoding="utf-8")
+    assert ensure_slopmop_gitignored(tmp_path) is True
+    content = gitignore.read_text(encoding="utf-8")
+    assert "node_modules/" in content
+    assert ".slopmop/" in content
+
+
+def test_idempotent_when_already_present(tmp_path: Path) -> None:
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(".slopmop/\n", encoding="utf-8")
+    assert ensure_slopmop_gitignored(tmp_path) is False
+    # Content unchanged — no duplicate entry
+    content = gitignore.read_text(encoding="utf-8")
+    assert content.count(".slopmop/") == 1
+
+
+def test_handles_entry_with_surrounding_whitespace(tmp_path: Path) -> None:
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("  .slopmop/  \n", encoding="utf-8")
+    assert ensure_slopmop_gitignored(tmp_path) is False
+
+
+def test_does_not_match_partial_entry(tmp_path: Path) -> None:
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("not-.slopmop/\n", encoding="utf-8")
+    assert ensure_slopmop_gitignored(tmp_path) is True
+    content = gitignore.read_text(encoding="utf-8")
+    # Should have both the original and the new entry
+    assert "not-.slopmop/" in content
+    assert content.count(".slopmop/") == 2  # partial + real
+
+
+def test_appends_newline_when_file_lacks_trailing_newline(tmp_path: Path) -> None:
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("*.pyc", encoding="utf-8")  # no trailing newline
+    assert ensure_slopmop_gitignored(tmp_path) is True
+    content = gitignore.read_text(encoding="utf-8")
+    assert "*.pyc\n" in content
+    assert ".slopmop/" in content
+
+
+def test_includes_comment_in_new_gitignore(tmp_path: Path) -> None:
+    ensure_slopmop_gitignored(tmp_path)
+    content = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "# slop-mop working directory" in content


### PR DESCRIPTION
## Problem

Neither `sm init` nor `sm refit --start` touched the target project's `.gitignore`. This meant the `.slopmop/` directory — which holds ~20+ ephemeral files (locks, caches, logs, refit plans, buff memory, timings, baselines) — could end up committed to the target repo.

The existing `_is_slopmop_artifact()` filter in `refit.py` was a defensive workaround for this gap, stripping `.slopmop/` paths from porcelain output. The root cause was never addressed.

## Solution

Add an idempotent `ensure_slopmop_gitignored()` utility that:
- Appends `.slopmop/` to the project's `.gitignore` (with a descriptive comment)
- Creates `.gitignore` if it doesn't exist
- No-ops if the entry is already present (handles whitespace variants)
- Does **not** touch partial matches (e.g. `not-.slopmop/`)

### Call sites
- **`sm init`** — after writing `.sb_config.json`, prints confirmation if entry was added
- **`sm refit --start`** — before the initial scour populates `.slopmop/refit/`

### Scope note
`.sb_config.json` is intentionally **not** gitignored — it's the project config (like `.eslintrc`) and belongs in the repo.

## Tests

7 unit tests covering:
- Creates `.gitignore` when missing
- Appends to existing `.gitignore`
- Idempotent when already present
- Handles whitespace around entry
- Does not match partial entries
- Handles files without trailing newline
- Includes descriptive comment

16/16 swab gates green.