### PR TITLE
fix: reduce upgrade/failure output verbosity

### DIFF
--- a/slopmop/cli/upgrade.py
+++ b/slopmop/cli/upgrade.py
@@ -22,7 +22,7 @@ from slopmop.migrations import planned_upgrade_migrations, run_upgrade_migration
 PACKAGE_NAME = "slopmop"
 PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 BACKUP_DIR_NAME = "backups"
-VALIDATION_VERB = "scour"
+VALIDATION_VERB = "swab"
 NO_MIGRATIONS = "none"
 SOURCE_CHECKOUT_UPGRADE_ERROR = (
     "sm upgrade must be run from an installed slopmop package, not from a "

--- a/slopmop/reporting/adapters.py
+++ b/slopmop/reporting/adapters.py
@@ -295,9 +295,11 @@ class ConsoleAdapter:
                     print("   ▸ after fixing: " + r.per_gate_verify_command(res.name))
 
     def _render_first_to_fix_hint(self) -> None:
-        """Call out the first blocking gate explicitly when one exists."""
+        """Call out the first blocking gate explicitly when 2+ failures exist."""
         first_gate = self.report.first_to_fix
         if not first_gate:
+            return
+        if len(self.report.failed) + len(self.report.errored) < 2:
             return
         print(f"🎯 Fix First: {first_gate}")
         log_path = self.report.per_gate_log_file(first_gate)

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -28,7 +28,6 @@ Actions annotations) slot in without touching enrichment logic.
 """
 
 import os
-import textwrap
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -134,10 +133,8 @@ JSON_SCHEMA_VERSION = "slopmop/v2"
 def _structured_console_lines(
     result: CheckResult,
     *,
-    details_path: Optional[str],
     verify_command: str,
     max_findings: int,
-    max_instructions: int,
 ) -> List[str]:
     """Return compact structured guidance lines for console output."""
     findings = result.findings[:max_findings]
@@ -150,21 +147,6 @@ def _structured_console_lines(
     if len(result.findings) > len(findings):
         lines.append(f"     ... and {len(result.findings) - len(findings)} more")
 
-    if result.why_it_matters:
-        lines.append("   WHY IT MATTERS:")
-        for wrapped in textwrap.wrap(result.why_it_matters, width=66):
-            lines.append(f"     {wrapped}")
-
-    instructions = [f.fix_strategy for f in findings if f.fix_strategy]
-    if not instructions and result.fix_suggestion:
-        instructions = [result.fix_suggestion]
-    if instructions:
-        lines.append("   EXACTLY WHAT TO DO:")
-        for index, instruction in enumerate(instructions[:max_instructions], start=1):
-            lines.append(f"     {index}. {instruction}")
-
-    if details_path:
-        lines.append(f"   FULL DETAILS: {details_path}")
     lines.append(f"   AFTER FIXING: {verify_command}")
     return lines
 
@@ -294,10 +276,8 @@ class RunReport:
         if result.why_it_matters and result.findings:
             return _structured_console_lines(
                 result,
-                details_path=self.per_gate_log_file(result.name),
                 verify_command=self.per_gate_verify_command(result.name),
                 max_findings=5 if self.verbose else 3,
-                max_instructions=5 if self.verbose else 3,
             )
         return self._output_preview_lines(result)
 

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -567,8 +567,7 @@ class TestConsoleAdapter:
         ConsoleAdapter(report).render()
         out = capsys.readouterr().out
         assert "SLOP DETECTED" in out
-        assert "Fix First: myopia:code-sprawl" in out
-        assert "inspect details: .slopmop/logs/myopia_code-sprawl.log" in out
+        assert "Fix First: myopia:code-sprawl" not in out
         assert "after fixing: sm swab -g myopia:code-sprawl" in out
         assert "myopia:code-sprawl" in out
         assert "Move BigClass" in out
@@ -625,9 +624,9 @@ class TestConsoleAdapter:
         ConsoleAdapter(report).render()
         out = capsys.readouterr().out
         assert "WHAT'S BROKEN:" in out
-        assert "WHY IT MATTERS:" in out
-        assert "EXACTLY WHAT TO DO:" in out
-        assert "FULL DETAILS: .slopmop/logs/overconfidence_type-blindness.py.log" in out
+        assert "WHY IT MATTERS:" not in out
+        assert "EXACTLY WHAT TO DO:" not in out
+        assert "FULL DETAILS:" not in out
         assert "AFTER FIXING: sm swab -g overconfidence:type-blindness.py" in out
 
     def test_success_path_warns_on_time_budget_skips(self, capsys) -> None:


### PR DESCRIPTION
Friction report from a real upgrade attempt on loopcloser.

Three issues observed:

**`sm upgrade` ran `sm scour` for validation** — scour is the pre-PR
comprehensive sweep. Using it as a post-install sanity check is wrong:
it runs all PR-level gates (unresolved comments, diff coverage) and takes
much longer than needed. Swab is the right tool.

**Failure output talks down** — `WHY IT MATTERS:` and `EXACTLY WHAT TO DO:`
add ~5 lines that restate what the finding already says. Every failure
carries its own context; the extra headers are noise aimed at someone
who has never seen the tool before.

**"Fix First" duplicates with a single failure** — when there is exactly
one failing gate, the banner block and the per-gate block below it show
the same gate name, log path, and fix command twice. The banner now only
fires for 2+ failures, where sequencing actually matters.
