### PR TITLE
fix: detect-secrets scan no longer rewrites .secrets.baseline on every run

### DIFF
--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -624,14 +624,49 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                 return SecuritySubResult("semgrep", False, result.stderr[-300:])
             return SecuritySubResult("semgrep", True, "Scan completed")
 
-    def _run_detect_secrets(self, project_root: str) -> SecuritySubResult:
-        """Run detect-secrets hook."""
-        # Check for baseline file
-        config_file = self.config.get("config_file_path")
+    def _load_detect_secrets_allowlist(self, project_root: str) -> set[tuple[str, str]]:
+        """Load known (path, hashed_secret) pairs from the existing baseline file.
 
+        Returns an empty set if no baseline exists or if it cannot be parsed.
+        Never writes to the file — this is a read-only operation.
+        """
+        config_file = self.config.get("config_file_path")
+        if not config_file:
+            return set()
+        baseline_path = Path(project_root) / config_file
+        if not baseline_path.exists():
+            return set()
+        try:
+            baseline_raw: dict[str, Any] = json.loads(
+                baseline_path.read_text(encoding="utf-8")
+            )
+            baseline_results: dict[str, Any] = baseline_raw.get("results", {})
+            if not isinstance(baseline_results, dict):
+                return set()
+            known: set[tuple[str, str]] = set()
+            for bpath, bsecrets in baseline_results.items():
+                bpath_str: str = str(bpath)
+                if isinstance(bsecrets, list):
+                    for bs in cast(List[Any], bsecrets):
+                        if isinstance(bs, dict) and "hashed_secret" in bs:
+                            bs_dict: Dict[str, Any] = cast(Dict[str, Any], bs)
+                            known.add((bpath_str, str(bs_dict["hashed_secret"])))
+            return known
+        except (json.JSONDecodeError, OSError):
+            return set()
+
+    def _run_detect_secrets(self, project_root: str) -> SecuritySubResult:
+        """Run detect-secrets scan without touching the baseline file.
+
+        We intentionally do NOT pass ``--baseline`` to the ``scan`` command.
+        Passing ``--baseline`` causes detect-secrets to rewrite the file with
+        a fresh ``generated_at`` timestamp even when no secrets changed, which
+        pollutes the working tree and turns read-only validation into a commit
+        obligation.  We instead load the baseline ourselves and use its
+        ``results`` block as a read-only allowlist.
+        """
         cmd = [sys.executable, "-m", "detect_secrets", "scan"]
-        if config_file:
-            cmd.extend(["--baseline", config_file])
+        # No --baseline flag here — that would rewrite the file on every run.
 
         result = self._run_command(cmd, cwd=project_root, timeout=60)
 
@@ -643,6 +678,11 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                     report = cast(dict[str, Any], report_loaded)
                 else:
                     report = {}
+
+                # Build a read-only allowlist from the existing baseline file.
+                # Keys: (normalized_path, hashed_secret) — secrets already known/accepted.
+                known = self._load_detect_secrets_allowlist(project_root)
+
                 detected_any = report.get("results", {})
                 detected = (
                     cast(dict[str, Any], detected_any)
@@ -668,6 +708,10 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                             secrets.append(cast(dict[str, Any], secret_any))
                     filtered: list[dict[str, Any]] = []
                     for secret in secrets:
+                        # Skip if already present in the baseline allowlist.
+                        hashed = str(secret.get("hashed_secret", ""))
+                        if (path, hashed) in known:
+                            continue
                         if not self._is_detect_secrets_false_positive(
                             project_root, path, secret, line_cache
                         ):
@@ -688,19 +732,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                         f"  Potential secret in {path}: {', '.join(types)}"
                     )
                 detail = "\n".join(detail_lines)
-                # detect-secrets: per-file Findings (line_number available)
-                sarif: List[Finding] = []
-                for path, secrets in real_secrets.items():
-                    for s in secrets:
-                        ln = s.get("line_number")
-                        sarif.append(
-                            Finding(
-                                message=f"Potential secret: {s.get('type', '?')}",
-                                level=FindingLevel.ERROR,
-                                file=path,
-                                line=ln if isinstance(ln, int) else None,
-                            )
-                        )
+                sarif = self._build_detect_secrets_sarif(real_secrets)
                 return SecuritySubResult("detect-secrets", False, detail, sarif)
             except json.JSONDecodeError:
                 return SecuritySubResult("detect-secrets", True, "Scan completed")
@@ -710,6 +742,25 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
             False,
             result.output[-300:] if result.output else "Scan failed",
         )
+
+    @staticmethod
+    def _build_detect_secrets_sarif(
+        real_secrets: dict[str, list[dict[str, Any]]],
+    ) -> List[Finding]:
+        """Build SARIF findings from detect-secrets results."""
+        sarif: List[Finding] = []
+        for path, secrets in real_secrets.items():
+            for s in secrets:
+                ln = s.get("line_number")
+                sarif.append(
+                    Finding(
+                        message=f"Potential secret: {s.get('type', '?')}",
+                        level=FindingLevel.ERROR,
+                        file=path,
+                        line=ln if isinstance(ln, int) else None,
+                    )
+                )
+        return sarif
 
 
 class SecurityCheck(SecurityLocalCheck):

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -624,11 +624,23 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                 return SecuritySubResult("semgrep", False, result.stderr[-300:])
             return SecuritySubResult("semgrep", True, "Scan completed")
 
+    @staticmethod
+    def _normalize_ds_path(path: str) -> str:
+        """Normalize a detect-secrets path for consistent comparison.
+
+        detect-secrets may report paths as ``./config.py`` or ``config.py`` and
+        uses backslashes on Windows.  Normalise to a bare forward-slash path so
+        allowlist lookups are separator- and prefix-independent.
+        """
+        return str(path).replace("\\", "/").lstrip("./")
+
     def _load_detect_secrets_allowlist(self, project_root: str) -> set[tuple[str, str]]:
-        """Load known (path, hashed_secret) pairs from the existing baseline file.
+        """Load known (normalized_path, hashed_secret) pairs from the baseline.
 
         Returns an empty set if no baseline exists or if it cannot be parsed.
         Never writes to the file — this is a read-only operation.
+        Paths are normalized via :meth:`_normalize_ds_path` so that
+        ``./foo/bar.py`` and ``foo/bar.py`` are treated as the same entry.
         """
         config_file = self.config.get("config_file_path")
         if not config_file:
@@ -645,15 +657,57 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                 return set()
             known: set[tuple[str, str]] = set()
             for bpath, bsecrets in baseline_results.items():
-                bpath_str: str = str(bpath)
+                norm_bpath = self._normalize_ds_path(str(bpath))
                 if isinstance(bsecrets, list):
                     for bs in cast(List[Any], bsecrets):
                         if isinstance(bs, dict) and "hashed_secret" in bs:
                             bs_dict: Dict[str, Any] = cast(Dict[str, Any], bs)
-                            known.add((bpath_str, str(bs_dict["hashed_secret"])))
+                            known.add((norm_bpath, str(bs_dict["hashed_secret"])))
             return known
         except (json.JSONDecodeError, OSError):
             return set()
+
+    def _create_plugin_config_baseline(self, project_root: str) -> Optional[str]:
+        """Write a temp baseline carrying plugin/filter config (no results).
+
+        ``detect-secrets scan --baseline <file>`` reads its plugin and filter
+        configuration from the baseline rather than using defaults.  We can't
+        pass the real baseline because that rewrites ``generated_at``.  Instead
+        we write a throwaway file inside ``.slopmop/`` (which is git-ignored)
+        that contains only the config blocks and an empty ``results`` dict.
+        detect-secrets will update that temp file on its own — we don't care.
+
+        Returns the temp file path, or ``None`` when no baseline config is found.
+        """
+        config_file = self.config.get("config_file_path")
+        if not config_file:
+            return None
+        baseline_path = Path(project_root) / config_file
+        if not baseline_path.exists():
+            return None
+        try:
+            baseline_raw: dict[str, Any] = json.loads(
+                baseline_path.read_text(encoding="utf-8")
+            )
+            plugins_used: Any = baseline_raw.get("plugins_used", [])
+            filters_used: Any = baseline_raw.get("filters_used", [])
+            if not plugins_used and not filters_used:
+                return None
+            tmp_baseline: dict[str, Any] = {
+                "custom_plugin_paths": baseline_raw.get("custom_plugin_paths", []),
+                "exclude": baseline_raw.get("exclude", {"files": None, "lines": None}),
+                "filters_used": filters_used,
+                "plugins_used": plugins_used,
+                "results": {},
+                "version": baseline_raw.get("version", ""),
+            }
+            slopmop_dir = Path(project_root) / ".slopmop"
+            slopmop_dir.mkdir(exist_ok=True)
+            tmp_path = slopmop_dir / "detect-secrets-plugin-config.json"
+            tmp_path.write_text(json.dumps(tmp_baseline, indent=2), encoding="utf-8")
+            return str(tmp_path)
+        except (json.JSONDecodeError, OSError):
+            return None
 
     def _run_detect_secrets(self, project_root: str) -> SecuritySubResult:
         """Run detect-secrets scan without touching the baseline file.
@@ -662,13 +716,30 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
         Passing ``--baseline`` causes detect-secrets to rewrite the file with
         a fresh ``generated_at`` timestamp even when no secrets changed, which
         pollutes the working tree and turns read-only validation into a commit
-        obligation.  We instead load the baseline ourselves and use its
-        ``results`` block as a read-only allowlist.
+        obligation.  Instead we:
+
+        1. Write a *throwaway* baseline to ``.slopmop/`` (git-ignored) that
+           carries the real baseline's ``plugins_used`` / ``filters_used`` but
+           an empty ``results`` dict.  Passing that file via ``--baseline``
+           makes detect-secrets use the same plugin configuration as the
+           project without touching the real ``.secrets.baseline``.
+        2. Load the real baseline's ``results`` block as a read-only allowlist
+           so previously-accepted secrets are suppressed.
         """
         cmd = [sys.executable, "-m", "detect_secrets", "scan"]
-        # No --baseline flag here — that would rewrite the file on every run.
+        # Pass a throwaway baseline so the plugin/filter config from the real
+        # baseline is honoured. detect-secrets will rewrite the throwaway file
+        # (updating its generated_at), but the real .secrets.baseline is never
+        # touched, so the working tree stays clean.
+        tmp_baseline_path = self._create_plugin_config_baseline(project_root)
+        if tmp_baseline_path:
+            cmd.extend(["--baseline", tmp_baseline_path])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=60)
+        try:
+            result = self._run_command(cmd, cwd=project_root, timeout=60)
+        finally:
+            if tmp_baseline_path:
+                Path(tmp_baseline_path).unlink(missing_ok=True)
 
         if result.success:
             try:
@@ -689,35 +760,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
                     if isinstance(detected_any, dict)
                     else {}
                 )
-                real_secrets: dict[str, list[dict[str, Any]]] = {}
-                line_cache: dict[str, list[str]] = {}
-                for path_any, secrets_any in detected.items():
-                    if not isinstance(path_any, str):
-                        continue
-                    path = path_any
-                    if self._is_path_excluded_for_detect_secrets(path):
-                        continue
-                    if "constants.py" in path:
-                        continue
-                    if not isinstance(secrets_any, list):
-                        continue
-                    secrets: list[dict[str, Any]] = []
-                    secrets_raw = cast(list[Any], secrets_any)
-                    for secret_any in secrets_raw:
-                        if isinstance(secret_any, dict):
-                            secrets.append(cast(dict[str, Any], secret_any))
-                    filtered: list[dict[str, Any]] = []
-                    for secret in secrets:
-                        # Skip if already present in the baseline allowlist.
-                        hashed = str(secret.get("hashed_secret", ""))
-                        if (path, hashed) in known:
-                            continue
-                        if not self._is_detect_secrets_false_positive(
-                            project_root, path, secret, line_cache
-                        ):
-                            filtered.append(secret)
-                    if filtered:
-                        real_secrets[path] = filtered
+                real_secrets = self._filter_known_secrets(detected, known, project_root)
                 if not real_secrets:
                     return SecuritySubResult(
                         "detect-secrets", True, "No secrets detected"
@@ -742,6 +785,49 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
             False,
             result.output[-300:] if result.output else "Scan failed",
         )
+
+    def _filter_known_secrets(
+        self,
+        detected: dict[str, Any],
+        known: set[tuple[str, str]],
+        project_root: str,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Filter raw scan findings against the baseline allowlist.
+
+        Returns only the secrets that are genuinely new — not present in
+        ``known`` (baseline allowlist) and not matching a known false-positive
+        pattern.  Paths are normalized so ``./foo.py`` matches ``foo.py``.
+        """
+        real_secrets: dict[str, list[dict[str, Any]]] = {}
+        line_cache: dict[str, list[str]] = {}
+        for path_any, secrets_any in detected.items():
+            if not isinstance(path_any, str):
+                continue
+            path = path_any
+            norm_path = self._normalize_ds_path(path)
+            if self._is_path_excluded_for_detect_secrets(path):
+                continue
+            if "constants.py" in path:
+                continue
+            if not isinstance(secrets_any, list):
+                continue
+            secrets: list[dict[str, Any]] = [
+                cast(dict[str, Any], s)
+                for s in cast(list[Any], secrets_any)
+                if isinstance(s, dict)
+            ]
+            filtered: list[dict[str, Any]] = []
+            for secret in secrets:
+                hashed = str(secret.get("hashed_secret", ""))
+                if (norm_path, hashed) in known:
+                    continue
+                if not self._is_detect_secrets_false_positive(
+                    project_root, path, secret, line_cache
+                ):
+                    filtered.append(secret)
+            if filtered:
+                real_secrets[path] = filtered
+        return real_secrets
 
     @staticmethod
     def _build_detect_secrets_sarif(

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -644,9 +644,13 @@ class TestRunDetectSecrets:
 
         assert result.passed is False
 
-    def test_detect_secrets_with_baseline(self, tmp_path):
-        """Test _run_detect_secrets uses baseline config."""
-        check = SecurityLocalCheck({"config_file_path": "/path/to/baseline.json"})
+    def test_detect_secrets_never_passes_baseline_flag(self, tmp_path):
+        """detect-secrets scan must NOT receive --baseline — that causes file rewrites."""
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(
+            json.dumps({"generated_at": "2026-01-01T00:00:00Z", "results": {}})
+        )
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
         mock_result = MagicMock()
         mock_result.success = True
         mock_result.output = json.dumps({"results": {}})
@@ -655,8 +659,116 @@ class TestRunDetectSecrets:
             check._run_detect_secrets(str(tmp_path))
 
         call_args = mock_run.call_args[0][0]
-        assert "--baseline" in call_args
-        assert "/path/to/baseline.json" in call_args
+        assert "--baseline" not in call_args, (
+            "Passing --baseline to detect-secrets scan rewrites the file on every run, "
+            "turning read-only validation into a commit obligation."
+        )
+
+    def test_detect_secrets_baseline_file_not_modified(self, tmp_path):
+        """Running the security check must NOT modify the .secrets.baseline file."""
+        original_content = json.dumps(
+            {"generated_at": "2026-01-01T00:00:00Z", "results": {}}, indent=2
+        )
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(original_content)
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = json.dumps({"results": {}})
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            check._run_detect_secrets(str(tmp_path))
+
+        assert (
+            baseline.read_text() == original_content
+        ), ".secrets.baseline was modified during a read-only security scan"
+
+    def test_detect_secrets_baseline_allowlist_suppresses_known_hashes(self, tmp_path):
+        """Secrets already in the baseline allowlist should not be reported."""
+        hashed = "abc123def456"  # pragma: allowlist secret
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(
+            json.dumps(
+                {
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "results": {
+                        "config.py": [
+                            {
+                                "type": "Secret Keyword",
+                                "hashed_secret": hashed,
+                                "line_number": 5,
+                            }  # pragma: allowlist secret
+                        ]
+                    },
+                }
+            )
+        )
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        # Scan finds the same secret — but it's in the baseline so should be suppressed
+        mock_result.output = json.dumps(
+            {
+                "results": {
+                    "config.py": [
+                        {
+                            "type": "Secret Keyword",
+                            "hashed_secret": hashed,
+                            "line_number": 5,
+                        }  # pragma: allowlist secret
+                    ]
+                }
+            }
+        )
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.passed is True, "Secret already in baseline should be suppressed"
+
+    def test_detect_secrets_new_secret_not_in_baseline_reported(self, tmp_path):
+        """A new secret not in the baseline should still be reported."""
+        known_hash = "aaaaaaaaaaaa"  # pragma: allowlist secret
+        new_hash = "bbbbbbbbbbbb"  # pragma: allowlist secret
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(
+            json.dumps(
+                {
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "results": {
+                        "config.py": [
+                            {
+                                "type": "Secret Keyword",
+                                "hashed_secret": known_hash,
+                                "line_number": 3,
+                            }  # pragma: allowlist secret
+                        ]
+                    },
+                }
+            )
+        )
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = json.dumps(
+            {
+                "results": {
+                    "config.py": [
+                        {
+                            "type": "Secret Keyword",
+                            "hashed_secret": new_hash,
+                            "line_number": 7,
+                        }  # pragma: allowlist secret
+                    ]
+                }
+            }
+        )
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.passed is False
+        assert "config.py" in result.findings
 
 
 class TestSecurityCheck:

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from slopmop.checks.security import (
@@ -644,8 +645,14 @@ class TestRunDetectSecrets:
 
         assert result.passed is False
 
-    def test_detect_secrets_never_passes_baseline_flag(self, tmp_path):
-        """detect-secrets scan must NOT receive --baseline — that causes file rewrites."""
+    def test_detect_secrets_never_passes_real_baseline_flag(self, tmp_path):
+        """detect-secrets scan must NOT receive the real .secrets.baseline as --baseline.
+
+        Passing the real baseline causes detect-secrets to rewrite the file on
+        every run (updated ``generated_at``), turning read-only validation into
+        a commit obligation.  When a temp plugin-config file is used, ``--baseline``
+        may be present but must point elsewhere.
+        """
         baseline = tmp_path / ".secrets.baseline"
         baseline.write_text(
             json.dumps({"generated_at": "2026-01-01T00:00:00Z", "results": {}})
@@ -654,15 +661,23 @@ class TestRunDetectSecrets:
         mock_result = MagicMock()
         mock_result.success = True
         mock_result.output = json.dumps({"results": {}})
+        captured_cmd: list[str] = []
 
-        with patch.object(check, "_run_command", return_value=mock_result) as mock_run:
+        def _capture(cmd: list[str], **kwargs: Any) -> MagicMock:  # type: ignore[misc]
+            captured_cmd.extend(cmd)
+            return mock_result
+
+        with patch.object(check, "_run_command", side_effect=_capture):
             check._run_detect_secrets(str(tmp_path))
 
-        call_args = mock_run.call_args[0][0]
-        assert "--baseline" not in call_args, (
-            "Passing --baseline to detect-secrets scan rewrites the file on every run, "
-            "turning read-only validation into a commit obligation."
-        )
+        real_baseline_path = str(tmp_path / ".secrets.baseline")
+        if "--baseline" in captured_cmd:
+            idx = captured_cmd.index("--baseline")
+            passed = captured_cmd[idx + 1]
+            assert passed != real_baseline_path, (
+                "The real .secrets.baseline must never be passed as --baseline to "
+                "detect-secrets scan — that rewrites the file on every run."
+            )
 
     def test_detect_secrets_baseline_file_not_modified(self, tmp_path):
         """Running the security check must NOT modify the .secrets.baseline file."""
@@ -769,6 +784,99 @@ class TestRunDetectSecrets:
 
         assert result.passed is False
         assert "config.py" in result.findings
+
+    def test_detect_secrets_path_dotslash_normalized(self, tmp_path):
+        """Baseline key './config.py' must suppress a scan finding of 'config.py'."""
+        hashed = "abc123def456"  # pragma: allowlist secret
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(
+            json.dumps(
+                {
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "results": {
+                        "./config.py": [
+                            {
+                                "type": "Secret Keyword",
+                                "hashed_secret": hashed,
+                                "line_number": 5,
+                            }  # pragma: allowlist secret
+                        ]
+                    },
+                }
+            )
+        )
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        # Scan reports the same hash under bare path (no leading ./)
+        mock_result.output = json.dumps(
+            {
+                "results": {
+                    "config.py": [
+                        {
+                            "type": "Secret Keyword",
+                            "hashed_secret": hashed,
+                            "line_number": 5,
+                        }  # pragma: allowlist secret
+                    ]
+                }
+            }
+        )
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.passed is True, (
+            "'./config.py' in baseline should match 'config.py' from scan report "
+            "(path normalization strips leading './')"
+        )
+
+    def test_detect_secrets_plugin_config_passed_via_temp_baseline(self, tmp_path):
+        """When the baseline has plugins_used, --baseline must point to a temp file.
+
+        The real .secrets.baseline must not be passed because detect-secrets
+        rewrites it; a throwaway temp file inside .slopmop/ carries the plugin
+        config instead.
+        """
+        baseline_content = {
+            "generated_at": "2026-01-01T00:00:00Z",
+            "plugins_used": [{"name": "HexHighEntropyString", "hex_limit": 3.0}],
+            "filters_used": [],
+            "results": {},
+        }
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(json.dumps(baseline_content))
+
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.output = json.dumps({"results": {}})
+        captured_cmd: list[str] = []
+
+        def _capture(cmd: list[str], **kwargs: Any) -> MagicMock:  # type: ignore[misc]
+            captured_cmd.extend(cmd)
+            return mock_result
+
+        with patch.object(check, "_run_command", side_effect=_capture):
+            check._run_detect_secrets(str(tmp_path))
+
+        assert (
+            "--baseline" in captured_cmd
+        ), "--baseline should be in cmd when baseline has plugins_used"
+        idx = captured_cmd.index("--baseline")
+        passed_path = captured_cmd[idx + 1]
+        real_baseline = str(tmp_path / ".secrets.baseline")
+        assert (
+            passed_path != real_baseline
+        ), "The real .secrets.baseline must never be the --baseline argument"
+        # Temp file must have been cleaned up
+        from pathlib import Path as _Path
+
+        assert not _Path(
+            passed_path
+        ).exists(), "Temp plugin-config baseline must be deleted after the scan"
+        # Real baseline must be unmodified
+        assert json.loads(baseline.read_text()) == baseline_content
 
 
 class TestSecurityCheck:


### PR DESCRIPTION
Running `detect-secrets scan --baseline .secrets.baseline` rewrites the
file on every invocation (updates `generated_at` timestamp), making
read-only validation commands dirty the working tree.

### Root Cause

`detect-secrets scan --baseline <file>` merges fresh scan results back into
the baseline file and always updates `generated_at`, even when no secrets
changed. Using this flag in a read-only validation gate is the wrong tool.

### Fix

Remove `--baseline` from the scan command. Load the baseline file
ourselves via `_load_detect_secrets_allowlist()` and use its `results`
block as a read-only `(path, hashed_secret)` set. Fresh scan findings
are filtered against this set before being reported.

`_build_detect_secrets_sarif()` extracted as a static helper to keep
`_run_detect_secrets` under the 100-line limit.

### Tests

4 regression tests in `test_security_checks.py`:
- `test_detect_secrets_never_passes_baseline_flag`
- `test_detect_secrets_baseline_file_not_modified`
- `test_detect_secrets_baseline_allowlist_suppresses_known_hashes`
- `test_detect_secrets_new_secret_not_in_baseline_reported`
