### PR TITLE
fix: make release reruns idempotent

### DIFF
--- a/.github/workflows/slopmop.yml
+++ b/.github/workflows/slopmop.yml
@@ -35,7 +35,7 @@ jobs:
         run: pip install -e ".[all]"
 
       - name: Run validator and doctor unit tests
-        run: python -m pytest tests/unit/test_subprocess_validator.py tests/unit/test_doctor.py tests/unit/test_doctor_checks.py -v
+        run: python -m pytest tests/unit/test_subprocess_validator.py tests/unit/test_doctor.py tests/unit/test_doctor_checks.py tests/unit/test_release_script.py -v
 
   dogfood:
     name: Final Dogfood Sanity Check (blocking)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,31 @@
 # Project Status
 
+## 2026-04-24 Delta: release rerun idempotency for existing remote branch
+
+Branch: `fix/sm-env-release-perms`
+
+**Work completed:**
+- Hardened `scripts/release.sh` so reruns no longer fail late on
+  `git push` when `origin/release/vX.Y.Z` already exists from a prior partial
+  run.
+- Added remote release-branch detection before local branch creation/push.
+- Reuse path now:
+  - fetches the existing remote release branch
+  - verifies its `pyproject.toml` version matches the expected target version
+  - skips re-bumping/re-pushing when the branch is already correct
+- Added open-PR reuse so reruns return success with the existing release PR URL
+  instead of failing on duplicate PR creation.
+- Added regression coverage in `tests/unit/test_release_script.py` for the exact
+  rerun case: remote release branch exists, local branch does not, and the
+  script should create the PR without pushing again.
+
+**Validation:**
+- `pytest tests/unit/test_release_script.py -q` ✅
+- `bash -n scripts/release.sh` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit, push branch, and update the existing PR with the rerun fix.
+
 ## 2026-04-23 Delta: sm_env review follow-up + prepare-release token fix
 
 Branch: `fix/sm-env-release-perms`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,23 @@
 # Project Status
 
+## 2026-04-24 Delta: PR 147 buff follow-up
+
+Branch: `fix/sm-env-release-perms`
+
+**Work completed:**
+- Investigated PR #147 review thread about `existing_pr_url` in `scripts/release.sh`.
+  - Verified with a live `gh pr list --jq '.[0].url'` probe that no-match output is
+    an empty string in this environment, so the reported `null` early-exit bug did
+    not reproduce.
+- Extended `tests/unit/test_release_script.py` with explicit coverage for the
+  existing-open-PR reuse path, asserting that reruns reuse the PR URL and do not
+  invoke `gh pr create` again.
+- Updated `.github/workflows/slopmop.yml` so CI's explicit unit-test list now
+  includes `tests/unit/test_release_script.py`.
+
+**Next:** Run focused validation, then resolve PR #147 review threads with code
+evidence for the testing fixes and probe evidence for the invalid logic comment.
+
 ## 2026-04-24 Delta: release rerun idempotency for existing remote branch
 
 Branch: `fix/sm-env-release-perms`

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,14 +9,22 @@ Branch: `fix/sm-env-release-perms`
   - Verified with a live `gh pr list --jq '.[0].url'` probe that no-match output is
     an empty string in this environment, so the reported `null` early-exit bug did
     not reproduce.
+- Hardened `scripts/release.sh` anyway by making the `gh --jq` filter explicit:
+  `'.[0].url // empty'`.
 - Extended `tests/unit/test_release_script.py` with explicit coverage for the
   existing-open-PR reuse path, asserting that reruns reuse the PR URL and do not
   invoke `gh pr create` again.
+- Removed the unused `log_path` parameter from the fake-`gh` test helper.
 - Updated `.github/workflows/slopmop.yml` so CI's explicit unit-test list now
   includes `tests/unit/test_release_script.py`.
 
-**Next:** Run focused validation, then resolve PR #147 review threads with code
-evidence for the testing fixes and probe evidence for the invalid logic comment.
+**Validation:**
+- `pytest tests/unit/test_release_script.py -q` ✅
+- `bash -n scripts/release.sh` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit, push branch, resolve the remaining PR #147 threads, then rerun
+`sm buff inspect 147` / `sm buff watch 147`.
 
 ## 2026-04-24 Delta: release rerun idempotency for existing remote branch
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -50,7 +50,7 @@ existing_pr_url() {
         --base main \
         --state open \
         --json url \
-        --jq '.[0].url' \
+    --jq '.[0].url // empty' \
         2>/dev/null || true
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -34,6 +34,26 @@ usage() {
     exit 1
 }
 
+pyproject_version_from_stream() {
+    python3 -c "
+import sys
+import tomllib
+
+print(tomllib.loads(sys.stdin.read())['project']['version'])
+"
+}
+
+existing_pr_url() {
+    local branch_name="$1"
+    gh pr list \
+        --head "$branch_name" \
+        --base main \
+        --state open \
+        --json url \
+        --jq '.[0].url' \
+        2>/dev/null || true
+}
+
 # ── Validate input ───────────────────────────────────────
 
 BUMP="${1:-}"
@@ -88,6 +108,10 @@ TAG_NAME="v${NEW_VERSION}"
 
 echo "🔼 Bump: $BUMP → $NEW_VERSION"
 
+# ── Build changelog from main before any branch switching ───────────────
+
+CHANGELOG=$(git log --oneline "v${CURRENT_VERSION}..HEAD" 2>/dev/null || echo "(no previous tag found)")
+
 # ── Ensure no tag or branch collision ────────────────────
 
 if git rev-parse "$TAG_NAME" &>/dev/null 2>&1; then
@@ -95,17 +119,31 @@ if git rev-parse "$TAG_NAME" &>/dev/null 2>&1; then
 fi
 
 if git rev-parse --verify "$BRANCH_NAME" &>/dev/null 2>&1; then
-    die "Branch $BRANCH_NAME already exists. Delete it first."
+    die "Branch $BRANCH_NAME already exists locally. Delete it first or switch away from it."
+fi
+
+REMOTE_BRANCH_EXISTS=false
+if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+    REMOTE_BRANCH_EXISTS=true
 fi
 
 # ── Create release branch ───────────────────────────────
 
-git checkout -b "$BRANCH_NAME"
+if [[ "$REMOTE_BRANCH_EXISTS" == "true" ]]; then
+    echo "ℹ️  Remote branch $BRANCH_NAME already exists. Reusing it..."
+    git fetch origin "$BRANCH_NAME" >/dev/null 2>&1 || die "Could not fetch existing remote branch $BRANCH_NAME"
 
-# ── Bump version in pyproject.toml ───────────────────────
+    REMOTE_VERSION="$(git show FETCH_HEAD:pyproject.toml 2>/dev/null | pyproject_version_from_stream 2>/dev/null || true)"
+    if [[ "$REMOTE_VERSION" != "$NEW_VERSION" ]]; then
+        die "Remote branch $BRANCH_NAME already exists but targets version ${REMOTE_VERSION:-unknown}, not $NEW_VERSION. Inspect or delete the branch first."
+    fi
+else
+    git checkout -b "$BRANCH_NAME"
 
-# Use python to do a precise in-place replacement (no sed portability issues)
-python3 -c "
+    # ── Bump version in pyproject.toml ───────────────────────
+
+    # Use python to do a precise in-place replacement (no sed portability issues)
+    python3 -c "
 import re, pathlib
 p = pathlib.Path('pyproject.toml')
 text = p.read_text()
@@ -120,29 +158,26 @@ p.write_text(text)
 print('✅ pyproject.toml updated')
 "
 
-# ── Verify the bump ─────────────────────────────────────
+    # ── Verify the bump ─────────────────────────────────────
 
-VERIFY_VERSION=$(python3 -c "
+    VERIFY_VERSION=$(python3 -c "
 import tomllib
 with open('pyproject.toml', 'rb') as f:
     print(tomllib.load(f)['project']['version'])
 ")
 
-if [[ "$VERIFY_VERSION" != "$NEW_VERSION" ]]; then
-    die "Version verification failed: expected $NEW_VERSION, got $VERIFY_VERSION"
+    if [[ "$VERIFY_VERSION" != "$NEW_VERSION" ]]; then
+        die "Version verification failed: expected $NEW_VERSION, got $VERIFY_VERSION"
+    fi
+
+    # ── Commit + push ────────────────────────────────────────
+
+    git add pyproject.toml
+    git commit -m "chore: bump version to ${NEW_VERSION} for PyPI release"
+
+    echo "🚀 Pushing $BRANCH_NAME..."
+    git push -u origin "$BRANCH_NAME"
 fi
-
-# ── Generate changelog snippet ───────────────────────────
-
-CHANGELOG=$(git log --oneline "v${CURRENT_VERSION}..HEAD" 2>/dev/null || echo "(no previous tag found)")
-
-# ── Commit + push ────────────────────────────────────────
-
-git add pyproject.toml
-git commit -m "chore: bump version to ${NEW_VERSION} for PyPI release"
-
-echo "🚀 Pushing $BRANCH_NAME..."
-git push -u origin "$BRANCH_NAME"
 
 # ── Create PR ────────────────────────────────────────────
 
@@ -168,6 +203,20 @@ PR_BODY_FILE=".tmp/release_pr_body.md"
 PR_ERROR_FILE=".tmp/release_pr_error.log"
 
 echo "$PR_BODY" > "$PR_BODY_FILE"
+
+EXISTING_PR_URL="$(existing_pr_url "$BRANCH_NAME")"
+if [[ -n "$EXISTING_PR_URL" ]]; then
+    rm -f "$PR_BODY_FILE" "$PR_ERROR_FILE"
+    echo ""
+    echo "════════════════════════════════════════════════════════════"
+    echo "✅ Release v${NEW_VERSION} prepared!"
+    echo ""
+    echo "   PR:     $EXISTING_PR_URL"
+    echo "   Branch: $BRANCH_NAME"
+    echo "   Note:   Reused existing open release PR"
+    echo "════════════════════════════════════════════════════════════"
+    exit 0
+fi
 
 set +e
 PR_URL=$(gh pr create \

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -113,6 +113,9 @@ def _write_fake_gh(fake_bin: Path, log_path: Path) -> None:
         "set -eu\n"
         'printf \'%s\\n\' "$*" >> "$GH_LOG"\n'
         'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then\n'
+        '  if [ -n "${GH_EXISTING_PR_URL:-}" ]; then\n'
+        "    printf '%s\\n' \"$GH_EXISTING_PR_URL\"\n"
+        "  fi\n"
         "  exit 0\n"
         "fi\n"
         'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then\n'
@@ -168,3 +171,50 @@ def test_release_script_reuses_existing_remote_branch_on_rerun(tmp_path: Path) -
     gh_calls = gh_log.read_text(encoding="utf-8").splitlines()
     assert any(call.startswith("pr list ") for call in gh_calls)
     assert any(call.startswith("pr create ") for call in gh_calls)
+
+
+@pytest.mark.skipif(
+    not (_HAS_BASH and _HAS_GIT),
+    reason="bash and git are required for release.sh regression coverage",
+)
+def test_release_script_reuses_existing_open_pr_without_creating_another(
+    tmp_path: Path,
+) -> None:
+    work = _init_release_repo(tmp_path)
+    release_sha = _create_remote_release_branch(work, "release/v0.15.0", "0.15.0")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    gh_log = tmp_path / "gh.log"
+    _write_fake_gh(fake_bin, gh_log)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["GH_LOG"] = str(gh_log)
+    env["GH_EXISTING_PR_URL"] = "https://example.test/pr/existing"
+
+    result = _run_release_command(work, "bash", "scripts/release.sh", "minor", env=env)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "https://example.test/pr/existing" in result.stdout
+    assert "Reused existing open release PR" in result.stdout
+    assert "Pushing release/v0.15.0" not in result.stdout
+
+    current_branch = _checked(
+        work, "git", "branch", "--show-current", label="git branch --show-current"
+    )
+    assert current_branch == "main"
+
+    remote_head = _checked(
+        work,
+        "git",
+        "ls-remote",
+        "origin",
+        "refs/heads/release/v0.15.0",
+        label="git ls-remote release",
+    ).split()[0]
+    assert remote_head == release_sha
+
+    gh_calls = gh_log.read_text(encoding="utf-8").splitlines()
+    assert any(call.startswith("pr list ") for call in gh_calls)
+    assert not any(call.startswith("pr create ") for call in gh_calls)

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -106,7 +106,7 @@ def _create_remote_release_branch(work: Path, branch_name: str, version: str) ->
     return release_sha
 
 
-def _write_fake_gh(fake_bin: Path, log_path: Path) -> None:
+def _write_fake_gh(fake_bin: Path) -> None:
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         "#!/bin/sh\n"
@@ -140,7 +140,7 @@ def test_release_script_reuses_existing_remote_branch_on_rerun(tmp_path: Path) -
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     gh_log = tmp_path / "gh.log"
-    _write_fake_gh(fake_bin, gh_log)
+    _write_fake_gh(fake_bin)
 
     env = os.environ.copy()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
@@ -186,7 +186,7 @@ def test_release_script_reuses_existing_open_pr_without_creating_another(
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     gh_log = tmp_path / "gh.log"
-    _write_fake_gh(fake_bin, gh_log)
+    _write_fake_gh(fake_bin)
 
     env = os.environ.copy()
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -1,0 +1,170 @@
+"""Regression coverage for scripts/release.sh."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_RELEASE_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release.sh"
+_HAS_BASH = shutil.which("bash") is not None
+_HAS_GIT = shutil.which("git") is not None
+
+
+def _run_release_command(
+    cwd: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _checked(
+    cwd: Path,
+    *args: str,
+    label: str,
+    env: dict[str, str] | None = None,
+) -> str:
+    result = _run_release_command(cwd, *args, env=env)
+    assert (
+        result.returncode == 0
+    ), f"{label} failed ({result.returncode}): {result.stderr or result.stdout}"
+    return result.stdout.strip()
+
+
+def _write_pyproject(path: Path, version: str) -> None:
+    path.write_text(
+        "[project]\n" 'name = "slopmop"\n' f'version = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def _init_release_repo(tmp_path: Path) -> Path:
+    origin = tmp_path / "origin.git"
+    work = tmp_path / "work"
+
+    _checked(tmp_path, "git", "init", "--bare", str(origin), label="git init --bare")
+    _checked(tmp_path, "git", "clone", str(origin), str(work), label="git clone")
+    _checked(work, "git", "checkout", "-b", "main", label="git checkout -b main")
+    _checked(
+        work,
+        "git",
+        "config",
+        "user.email",
+        "release@test.local",
+        label="git config email",
+    )
+    _checked(
+        work,
+        "git",
+        "config",
+        "user.name",
+        "Release Test",
+        label="git config name",
+    )
+
+    (work / "scripts").mkdir()
+    shutil.copy2(_RELEASE_SCRIPT, work / "scripts" / "release.sh")
+    _write_pyproject(work / "pyproject.toml", "0.14.1")
+
+    _checked(
+        work, "git", "add", "pyproject.toml", "scripts/release.sh", label="git add"
+    )
+    _checked(work, "git", "commit", "-m", "initial", label="git commit")
+    _checked(work, "git", "push", "-u", "origin", "main", label="git push main")
+    return work
+
+
+def _create_remote_release_branch(work: Path, branch_name: str, version: str) -> str:
+    _checked(work, "git", "checkout", "-b", branch_name, label="git checkout release")
+    _write_pyproject(work / "pyproject.toml", version)
+    _checked(work, "git", "add", "pyproject.toml", label="git add release")
+    _checked(
+        work,
+        "git",
+        "commit",
+        "-m",
+        f"chore: bump version to {version}",
+        label="git commit release",
+    )
+    release_sha = _checked(
+        work, "git", "rev-parse", "HEAD", label="git rev-parse release"
+    )
+    _checked(work, "git", "push", "-u", "origin", branch_name, label="git push release")
+    _checked(work, "git", "checkout", "main", label="git checkout main")
+    _checked(work, "git", "branch", "-D", branch_name, label="git branch -D")
+    return release_sha
+
+
+def _write_fake_gh(fake_bin: Path, log_path: Path) -> None:
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        'printf \'%s\\n\' "$*" >> "$GH_LOG"\n'
+        'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then\n'
+        "  printf '%s\\n' 'https://example.test/pr/123'\n"
+        "  exit 0\n"
+        "fi\n"
+        "printf 'unexpected gh args: %s\\n' \"$*\" >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+
+@pytest.mark.skipif(
+    not (_HAS_BASH and _HAS_GIT),
+    reason="bash and git are required for release.sh regression coverage",
+)
+def test_release_script_reuses_existing_remote_branch_on_rerun(tmp_path: Path) -> None:
+    work = _init_release_repo(tmp_path)
+    release_sha = _create_remote_release_branch(work, "release/v0.15.0", "0.15.0")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    gh_log = tmp_path / "gh.log"
+    _write_fake_gh(fake_bin, gh_log)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["GH_LOG"] = str(gh_log)
+
+    result = _run_release_command(work, "bash", "scripts/release.sh", "minor", env=env)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "Remote branch release/v0.15.0 already exists. Reusing it" in result.stdout
+    assert "https://example.test/pr/123" in result.stdout
+    assert "Pushing release/v0.15.0" not in result.stdout
+
+    current_branch = _checked(
+        work, "git", "branch", "--show-current", label="git branch --show-current"
+    )
+    assert current_branch == "main"
+
+    remote_head = _checked(
+        work,
+        "git",
+        "ls-remote",
+        "origin",
+        "refs/heads/release/v0.15.0",
+        label="git ls-remote release",
+    ).split()[0]
+    assert remote_head == release_sha
+
+    gh_calls = gh_log.read_text(encoding="utf-8").splitlines()
+    assert any(call.startswith("pr list ") for call in gh_calls)
+    assert any(call.startswith("pr create ") for call in gh_calls)


### PR DESCRIPTION
- reuse existing remote release branches during reruns
- add regression coverage for release.sh rerun behavior