### PR TITLE
chore: bump version to 0.15.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.14.1"
+version = "0.15.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.15.0

**Bump type:** `minor` (0.14.1 → 0.15.0)

### Changes since v0.14.1

f3bf272 Merge pull request #147 from ScienceIsNeato/fix/sm-env-release-perms
27f82f6 fix: finish PR 147 review cleanup
bbfbb5d test: close PR 147 review gaps
af4db5a fix: make release reruns idempotent
bcdf034 Merge pull request #146 from ScienceIsNeato/fix/sm-env-release-perms
ebaf1f5 Apply Bugbot follow-up fixes
1af8763 Restore prepare-release to github.token after enabling repo Actions PR permissions
cc04624 chore: update release scripts and status
fd174d8 fix: update sm_env perms and release workflow
563034d Merge pull request #144 from ScienceIsNeato/feat/backlog-batch-134-113-96
3bd66d8 Focused commit: Update JavaScript linting/formatting checks, CLI validation, and subprocess runner with associated unit tests and status update
b70d7dd fix: address third round of bugbot comments on PR #144
5245107 fix: address second round of bugbot comments on PR #144
2a5a52c fix: address bugbot review comments on PR #144
4cdb440 style: fix import formatting (isort split)
0af8911 fix: address scour failures - dep vulns and diff coverage
b9f3a6d feat: backlog batch #134 #113 #96

### Post-merge steps

After merging this PR, GitHub Actions will automatically detect the version
bump on `main` and run `release.yml`, which will:
1. Run quality gates
2. Build the package
3. Publish to PyPI
4. Create the version tag and GitHub Release with auto-generated notes
