### PR TITLE
fix: repair timing history and stale gate applicability

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,30 @@
 # Project Status
 
+## 2026-04-24 Delta: requirements-only repos no longer activate Python gates
+
+Branch: `friction`
+
+**Work completed:**
+- Tightened Python project heuristics so `requirements.txt` alone no longer
+  marks a repo as Python for slop-mop detection and applicability.
+- Aligned three surfaces to use the same rule:
+  - `slopmop/cli/detection.py` for `sm init`
+  - `slopmop/checks/mixins.py` for Python gate applicability
+  - `slopmop/checks/quality/config_debt.py` for `silenced-gates`
+- Added regressions so requirements-only repos without `.py` files:
+  - do not detect as Python during init
+  - do not make Python gates applicable at runtime
+  - do not trigger stale Python disabled-gate warnings
+- Updated Python-check tests that previously used `requirements.txt` as the
+  only Python-project marker.
+
+**Validation:**
+- `pytest tests/unit/test_detection.py tests/unit/test_base_check.py tests/unit/test_config_debt_check.py tests/unit/test_python_checks.py -q` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit this barnacle fix on `friction`, then either rerun `sm init`
+in fogofdog with this build or take the next barnacle.
+
 ## 2026-04-24 Delta: timing history ignores cached and failed runs
 
 Branch: `friction`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,24 @@
 # Project Status
 
+## 2026-04-24 Delta: PR 149 final follow-up on shared exclude dirs
+
+Branch: `friction`
+
+**Work completed:**
+- Deduplicated the detection-layer excluded-directory set by aliasing
+  `slopmop/cli/detection.py` to the shared Python source exclusion set defined
+  in `slopmop/checks/mixins.py`.
+- Kept the detection-local `_DETECTION_EXCLUDED_DIRS` name so existing detection
+  call sites still read clearly while future exclusion changes stay in one place.
+- Added a regression test proving detection and the mixin helper share the same
+  exclusion set object.
+
+**Validation:**
+- `pytest tests/unit/test_detection.py -q` ✅
+
+**Next:** Commit and push this final thread fix, resolve the last PR #149
+comment, and rerun `sm buff watch`.
+
 ## 2026-04-24 Delta: PR 149 follow-up on detection module structure
 
 Branch: `friction`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,25 @@
 # Project Status
 
+## 2026-04-24 Delta: PR 149 follow-up on detection module structure
+
+Branch: `friction`
+
+**Work completed:**
+- Moved the Python detection helper import back below the module docstring in
+  `slopmop/cli/detection.py` so the file keeps its module documentation and a
+  single canonical mixins import block.
+- Removed the duplicated Python excluded-directory constant from
+  `slopmop/checks/quality/config_debt.py` so the quick config-debt probe uses
+  the shared mixin defaults instead of a copied set.
+- Added a regression test proving the detection module keeps its top-level
+  docstring intact.
+
+**Validation:**
+- `pytest tests/unit/test_detection.py tests/unit/test_config_debt_check.py -q` ✅
+
+**Next:** Commit and push this final PR #149 follow-up, resolve the remaining
+review threads, and re-enter `sm buff watch`.
+
 ## 2026-04-24 Delta: PR 149 review follow-up on Python detection helpers
 
 Branch: `friction`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,27 @@
 # Project Status
 
+## 2026-04-24 Delta: timing history ignores cached and failed runs
+
+Branch: `friction`
+
+**Work completed:**
+- Tightened `slopmop/reporting/display/dynamic.py` so historical timing samples are
+  only persisted for completed, non-cached checks with trustworthy terminal
+  statuses.
+- Excluded failed and cached results from `.slopmop/timings.json` updates so ETA
+  history only learns from real full executions.
+- Added regression coverage in `tests/unit/test_display_timings.py` to prove:
+  - failed checks do not get persisted to timing history
+  - cached checks do not create or refresh timing-history files
+
+**Validation:**
+- `pytest tests/unit/test_display_timings.py -q` ✅
+- `./sm swab -g overconfidence:type-blindness.py` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit this barnacle fix on `friction`, then take the next reported
+barnacle.
+
 ## 2026-04-24 Delta: PR 147 buff follow-up
 
 Branch: `fix/sm-env-release-perms`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,28 @@
 # Project Status
 
+## 2026-04-24 Delta: stale init applicability now repaired via upgrade migration
+
+Branch: `friction`
+
+**Work completed:**
+- Added a built-in upgrade migration in `slopmop/migrations/__init__.py` that
+  disables built-in gates which are no longer applicable under current slop-mop
+  heuristics.
+- Chose the upgrade migration rail for this barnacle instead of telling users to
+  rerun `sm init` as a repair step.
+- Added migration coverage proving requirements-only repos without Python source:
+  - have stale Python gates turned off during upgrade
+  - keep JavaScript gates enabled
+  - preserve Python gates for real Python repos
+
+**Validation:**
+- `pytest tests/unit/test_upgrade_migrations.py -q` ✅
+- `./sm swab -g overconfidence:type-blindness.py` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit this migration fix on `friction`, then decide separately whether
+  a doctor repair command is still worth adding for already-upgraded repos.
+
 ## 2026-04-24 Delta: requirements-only repos no longer activate Python gates
 
 Branch: `friction`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,23 @@
 # Project Status
 
+## 2026-04-24 Delta: PR 149 final follow-up on empty exclude sets
+
+Branch: `friction`
+
+**Work completed:**
+- Fixed `has_python_source_files()` in `slopmop/checks/mixins.py` so an explicit
+  empty `exclude_dirs` set no longer falls back to the default exclusion list.
+- Preserved the default behavior for `None` while restoring the typed meaning of
+  `set()` as “exclude nothing.”
+- Added regression coverage proving an explicit empty exclude set allows Python
+  files under otherwise excluded directories to be seen.
+
+**Validation:**
+- `pytest tests/unit/test_base_check.py -q` ✅
+
+**Next:** Commit and push this final thread fix, resolve the last PR #149
+comment, and rerun `sm buff watch`.
+
 ## 2026-04-24 Delta: PR 149 final follow-up on shared exclude dirs
 
 Branch: `friction`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,27 @@
 # Project Status
 
+## 2026-04-24 Delta: PR 149 review follow-up on Python detection helpers
+
+Branch: `friction`
+
+**Work completed:**
+- Tightened the follow-up to the requirements-only Python detection fix after PR
+  review on #149.
+- Simplified `looks_like_python_project()` so it no longer contains dead code or
+  redundant Python-source traversals.
+- Reworked init-time and config-debt Python detection to keep `requirements.txt`
+  as weak evidence via bounded scans instead of broad recursive repo walks.
+- Added regressions proving excluded directories like `node_modules/` do not make
+  requirements-only repos look like Python.
+
+**Validation:**
+- `pytest tests/unit/test_detection.py tests/unit/test_base_check.py tests/unit/test_config_debt_check.py -q` ✅
+- `./sm swab -g overconfidence:type-blindness.py` ✅
+- `./sm swab` ✅ (17/17 checks passed)
+
+**Next:** Commit and push this PR #149 review follow-up, then resolve the
+remaining review threads via `sm buff`.
+
 ## 2026-04-24 Delta: stale init applicability now repaired via upgrade migration
 
 Branch: `friction`

--- a/slopmop/checks/mixins.py
+++ b/slopmop/checks/mixins.py
@@ -105,7 +105,7 @@ def has_python_source_files(
     first match instead of paying for a full recursive glob.
     """
     root = Path(project_root)
-    excluded = exclude_dirs or _PYTHON_SOURCE_EXCLUDE_DIRS
+    excluded = exclude_dirs if exclude_dirs is not None else _PYTHON_SOURCE_EXCLUDE_DIRS
 
     for dirpath, dirnames, filenames in os.walk(root):
         rel_parts = Path(dirpath).relative_to(root).parts

--- a/slopmop/checks/mixins.py
+++ b/slopmop/checks/mixins.py
@@ -81,6 +81,28 @@ def has_project_venv(project_root: str | Path) -> bool:
     return False
 
 
+def has_python_source_files(project_root: str | Path) -> bool:
+    """Return True when the repo contains at least one Python source file."""
+    return any(Path(project_root).rglob("*.py"))
+
+
+def looks_like_python_project(project_root: str | Path) -> bool:
+    """Return True for repos with strong Python evidence.
+
+    ``requirements.txt`` is treated as a weak signal: it only counts when the
+    repo also contains Python source files. This avoids enabling Python gates in
+    JS/TS repos that carry a requirements file for incidental tooling.
+    """
+    root = Path(project_root)
+    if any(
+        (root / marker).exists() for marker in ("setup.py", "pyproject.toml", "Pipfile")
+    ):
+        return True
+    if has_python_source_files(root):
+        return True
+    return (root / "requirements.txt").exists() and has_python_source_files(root)
+
+
 def resolve_project_python(project_root: str | Path) -> tuple[str, str]:
     """Return ``(python_path, source)`` for *project_root*.
 
@@ -430,8 +452,7 @@ class PythonCheckMixin:
 
     def has_python_files(self, project_root: str) -> bool:
         """Check if project has Python files."""
-        root = Path(project_root)
-        return any(root.rglob("*.py"))
+        return has_python_source_files(project_root)
 
     def has_setup_py(self, project_root: str) -> bool:
         """Check if project has setup.py."""
@@ -447,12 +468,7 @@ class PythonCheckMixin:
 
     def is_python_project(self, project_root: str) -> bool:
         """Check if this is a Python project."""
-        return (
-            self.has_python_files(project_root)
-            or self.has_setup_py(project_root)
-            or self.has_pyproject_toml(project_root)
-            or self.has_requirements_txt(project_root)
-        )
+        return looks_like_python_project(project_root)
 
     def skip_reason(self, project_root: str) -> str:
         """Return reason for skipping Python checks."""

--- a/slopmop/checks/mixins.py
+++ b/slopmop/checks/mixins.py
@@ -40,6 +40,18 @@ from slopmop.core.result import (
 )
 
 logger = logging.getLogger(__name__)
+_PYTHON_SOURCE_EXCLUDE_DIRS = {
+    ".git",
+    "node_modules",
+    "venv",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".slopmop",
+}
 
 # ---------------------------------------------------------------------------
 # Free-function project introspection helpers
@@ -81,26 +93,47 @@ def has_project_venv(project_root: str | Path) -> bool:
     return False
 
 
-def has_python_source_files(project_root: str | Path) -> bool:
-    """Return True when the repo contains at least one Python source file."""
-    return any(Path(project_root).rglob("*.py"))
+def has_python_source_files(
+    project_root: str | Path,
+    *,
+    exclude_dirs: set[str] | None = None,
+    max_depth: int | None = None,
+) -> bool:
+    """Return True when the repo contains at least one Python source file.
+
+    Uses ``os.walk`` so callers can prune known junk directories and stop at the
+    first match instead of paying for a full recursive glob.
+    """
+    root = Path(project_root)
+    excluded = exclude_dirs or _PYTHON_SOURCE_EXCLUDE_DIRS
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_parts = Path(dirpath).relative_to(root).parts
+        depth = len(rel_parts)
+        if max_depth is not None and depth >= max_depth:
+            dirnames[:] = []
+        else:
+            dirnames[:] = [name for name in dirnames if name not in excluded]
+
+        if any(name.endswith(".py") for name in filenames):
+            return True
+
+    return False
 
 
 def looks_like_python_project(project_root: str | Path) -> bool:
     """Return True for repos with strong Python evidence.
 
-    ``requirements.txt`` is treated as a weak signal: it only counts when the
-    repo also contains Python source files. This avoids enabling Python gates in
-    JS/TS repos that carry a requirements file for incidental tooling.
+    ``requirements.txt`` alone is too weak: JS/TS repos often carry one for
+    incidental tooling. Runtime Python gates should matter when we see Python
+    source, or one of the strong Python manifests.
     """
     root = Path(project_root)
     if any(
         (root / marker).exists() for marker in ("setup.py", "pyproject.toml", "Pipfile")
     ):
         return True
-    if has_python_source_files(root):
-        return True
-    return (root / "requirements.txt").exists() and has_python_source_files(root)
+    return has_python_source_files(root)
 
 
 def resolve_project_python(project_root: str | Path) -> tuple[str, str]:

--- a/slopmop/checks/quality/config_debt.py
+++ b/slopmop/checks/quality/config_debt.py
@@ -37,18 +37,6 @@ from slopmop.checks.mixins import has_python_source_files
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 logger = logging.getLogger(__name__)
-_PYTHON_CONFIG_DEBT_EXCLUDED_DIRS = {
-    ".git",
-    "node_modules",
-    "venv",
-    ".venv",
-    "__pycache__",
-    "build",
-    "dist",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".slopmop",
-}
 _PYTHON_CONFIG_DEBT_MAX_DEPTH = 4
 
 CONFIG_FILE = ".sb_config.json"
@@ -68,11 +56,7 @@ def _has_python_markers(root: Path) -> bool:
             return True
     if not (root / "requirements.txt").exists():
         return False
-    return has_python_source_files(
-        root,
-        exclude_dirs=_PYTHON_CONFIG_DEBT_EXCLUDED_DIRS,
-        max_depth=_PYTHON_CONFIG_DEBT_MAX_DEPTH,
-    )
+    return has_python_source_files(root, max_depth=_PYTHON_CONFIG_DEBT_MAX_DEPTH)
 
 
 def _has_javascript_markers(root: Path) -> bool:

--- a/slopmop/checks/quality/config_debt.py
+++ b/slopmop/checks/quality/config_debt.py
@@ -33,6 +33,7 @@ from slopmop.checks.base import (
     RemediationChurn,
     ToolContext,
 )
+from slopmop.checks.mixins import looks_like_python_project
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 logger = logging.getLogger(__name__)
@@ -48,11 +49,8 @@ _LANGUAGE_SUFFIXES: Dict[str, str] = {
 
 
 def _has_python_markers(root: Path) -> bool:
-    """Quick check for Python project markers (no full file scan)."""
-    for marker in ("setup.py", "pyproject.toml", "requirements.txt", "Pipfile"):
-        if (root / marker).exists():
-            return True
-    return False
+    """Quick check for whether Python gates should matter in this repo."""
+    return looks_like_python_project(root)
 
 
 def _has_javascript_markers(root: Path) -> bool:

--- a/slopmop/checks/quality/config_debt.py
+++ b/slopmop/checks/quality/config_debt.py
@@ -33,10 +33,23 @@ from slopmop.checks.base import (
     RemediationChurn,
     ToolContext,
 )
-from slopmop.checks.mixins import looks_like_python_project
+from slopmop.checks.mixins import has_python_source_files
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 logger = logging.getLogger(__name__)
+_PYTHON_CONFIG_DEBT_EXCLUDED_DIRS = {
+    ".git",
+    "node_modules",
+    "venv",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".slopmop",
+}
+_PYTHON_CONFIG_DEBT_MAX_DEPTH = 4
 
 CONFIG_FILE = ".sb_config.json"
 
@@ -50,7 +63,16 @@ _LANGUAGE_SUFFIXES: Dict[str, str] = {
 
 def _has_python_markers(root: Path) -> bool:
     """Quick check for whether Python gates should matter in this repo."""
-    return looks_like_python_project(root)
+    for marker in ("setup.py", "pyproject.toml", "Pipfile"):
+        if (root / marker).exists():
+            return True
+    if not (root / "requirements.txt").exists():
+        return False
+    return has_python_source_files(
+        root,
+        exclude_dirs=_PYTHON_CONFIG_DEBT_EXCLUDED_DIRS,
+        max_depth=_PYTHON_CONFIG_DEBT_MAX_DEPTH,
+    )
 
 
 def _has_javascript_markers(root: Path) -> bool:

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from slopmop.checks.base import find_tool
-from slopmop.checks.mixins import discover_supabase_deno_test_glob
+from slopmop.checks.mixins import (
+    discover_supabase_deno_test_glob,
+    looks_like_python_project,
+)
 
 # Tools required by specific checks: (tool_name, check_name, install_command)
 # Used during `sm init` to auto-disable checks whose tools aren't available.
@@ -233,8 +236,7 @@ def _detect_python(
     if detected_languages is not None:
         return bool(detected_languages & _PYTHON_LANGS)
 
-    py_indicators = ["setup.py", "pyproject.toml", "requirements.txt", "Pipfile"]
-    return any((project_root / p).exists() for p in py_indicators)
+    return looks_like_python_project(project_root)
 
 
 def _detect_javascript(

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from slopmop.checks.base import find_tool
 from slopmop.checks.mixins import (
+    _PYTHON_SOURCE_EXCLUDE_DIRS,
     discover_supabase_deno_test_glob,
     has_python_source_files,
 )
@@ -73,18 +74,7 @@ _C_CPP_LANGS = {
 }
 _DART_LANGS = {"dart"}
 _SCC_SUMMARY_ROWS = {"total", "totals", "sum", "header"}
-_DETECTION_EXCLUDED_DIRS = {
-    ".git",
-    "node_modules",
-    "venv",
-    ".venv",
-    "__pycache__",
-    "build",
-    "dist",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".slopmop",
-}
+_DETECTION_EXCLUDED_DIRS = _PYTHON_SOURCE_EXCLUDE_DIRS
 _MAX_NESTED_SCAN_DEPTH = 4
 
 

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -1,8 +1,3 @@
-from slopmop.checks.mixins import (
-    discover_supabase_deno_test_glob,
-    has_python_source_files,
-)
-
 """Project type detection for slop-mop CLI."""
 
 import json
@@ -13,6 +8,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, cast
 from slopmop.checks.base import find_tool
 from slopmop.checks.mixins import (
     discover_supabase_deno_test_glob,
+    has_python_source_files,
 )
 
 # Tools required by specific checks: (tool_name, check_name, install_command)

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -1,3 +1,8 @@
+from slopmop.checks.mixins import (
+    discover_supabase_deno_test_glob,
+    has_python_source_files,
+)
+
 """Project type detection for slop-mop CLI."""
 
 import json
@@ -8,7 +13,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple, cast
 from slopmop.checks.base import find_tool
 from slopmop.checks.mixins import (
     discover_supabase_deno_test_glob,
-    looks_like_python_project,
 )
 
 # Tools required by specific checks: (tool_name, check_name, install_command)
@@ -220,8 +224,10 @@ def _detect_python(
 ) -> bool:
     """Check for Python project indicators.
 
-    Manifest fallback.  We do NOT glob ``**/*.py`` because real-world
-    polyglot repos routinely ship stray Python utility scripts:
+    Manifest fallback. Strong manifests (`setup.py`, `pyproject.toml`,
+    `Pipfile`) count immediately. `requirements.txt` is weaker evidence, so we
+    only treat it as Python when a bounded source scan also finds `.py` files
+    outside excluded junk directories.
 
     * curl/             — test-case generators in tests/*.py
     * pocketbase/       — doc-build scripts
@@ -236,7 +242,18 @@ def _detect_python(
     if detected_languages is not None:
         return bool(detected_languages & _PYTHON_LANGS)
 
-    return looks_like_python_project(project_root)
+    strong_indicators = ["setup.py", "pyproject.toml", "Pipfile"]
+    if any((project_root / indicator).exists() for indicator in strong_indicators):
+        return True
+
+    if not (project_root / "requirements.txt").exists():
+        return False
+
+    return has_python_source_files(
+        project_root,
+        exclude_dirs=_DETECTION_EXCLUDED_DIRS,
+        max_depth=_MAX_NESTED_SCAN_DEPTH,
+    )
 
 
 def _detect_javascript(

--- a/slopmop/migrations/__init__.py
+++ b/slopmop/migrations/__init__.py
@@ -250,6 +250,73 @@ def _rename_swabbing_time(project_root: Path) -> None:
     config_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+# ===================================================================
+# Migration: sync-built-in-gate-applicability (0.15.0 → 0.15.1)
+# ===================================================================
+
+
+def _sync_built_in_gate_applicability(project_root: Path) -> None:
+    """Disable built-in gates that are no longer applicable for this repo.
+
+    This is intentionally one-way: it turns stale enabled gates off when the
+    current applicability rules say they should not run. It does NOT auto-enable
+    newly applicable gates, which remains an intentional opt-in config action.
+    """
+    config_path = project_root / _CONFIG_FILE
+    if not config_path.exists():
+        return
+
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+        data: Dict[str, Any] = json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    if not isinstance(data, dict):
+        return
+
+    from slopmop.checks import ensure_checks_registered
+    from slopmop.core.registry import get_registry
+
+    ensure_checks_registered()
+    registry = get_registry()
+
+    changed = False
+
+    for full_name_any in registry.list_checks():
+        if not isinstance(full_name_any, str) or ":" not in full_name_any:
+            continue
+        full_name = full_name_any
+        category, gate_name = full_name.split(":", 1)
+
+        category_raw = data.get(category)
+        if not isinstance(category_raw, dict):
+            continue
+        category_dict = cast(Dict[str, Any], category_raw)
+        gates_value: object = category_dict.get("gates")
+        if not isinstance(gates_value, dict) or gate_name not in gates_value:
+            continue
+        gates_dict = cast(Dict[str, Any], gates_value)
+
+        gate_cfg_value: object = gates_dict.get(gate_name)
+        if not isinstance(gate_cfg_value, dict):
+            continue
+        gate_cfg = cast(Dict[str, Any], gate_cfg_value)
+
+        check = registry.get_check(full_name, data)
+        if check is None or check.is_applicable(str(project_root)):
+            continue
+
+        if gate_cfg.get("enabled") is False:
+            continue
+
+        gate_cfg["enabled"] = False
+        changed = True
+
+    if changed:
+        config_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -272,6 +339,12 @@ _MIGRATIONS: List[UpgradeMigration] = [
         min_version="0.14.1",
         max_version="0.15.0",
         apply=_rename_swabbing_time,
+    ),
+    UpgradeMigration(
+        key="sync-built-in-gate-applicability",
+        min_version="0.15.0",
+        max_version="0.15.1",
+        apply=_sync_built_in_gate_applicability,
     ),
 ]
 

--- a/slopmop/reporting/display/dynamic.py
+++ b/slopmop/reporting/display/dynamic.py
@@ -39,6 +39,11 @@ from slopmop.reporting.display.renderer import (
 from slopmop.reporting.display.state import CheckDisplayInfo, DisplayState
 from slopmop.reporting.timings import TimingStats, load_timings, save_timings
 
+_TIMING_HISTORY_STATUSES = {
+    CheckStatus.PASSED,
+    CheckStatus.WARNED,
+}
+
 
 class DynamicDisplay:
     """Dynamic terminal display with live updates.
@@ -112,18 +117,20 @@ class DynamicDisplay:
         Args:
             project_root: Project root directory
         """
-        durations = {
-            name: info.duration
-            for name, info in self._checks.items()
-            if info.state == DisplayState.COMPLETED and info.duration > 0
-        }
-        results = {
-            name: info.result.status.value
-            for name, info in self._checks.items()
-            if info.state == DisplayState.COMPLETED
-            and info.duration > 0
-            and info.result is not None
-        }
+        durations: Dict[str, float] = {}
+        results: Dict[str, str] = {}
+        for name, info in self._checks.items():
+            result = info.result
+            if (
+                info.state != DisplayState.COMPLETED
+                or info.duration <= 0
+                or result is None
+                or result.cached
+                or result.status not in _TIMING_HISTORY_STATUSES
+            ):
+                continue
+            durations[name] = info.duration
+            results[name] = result.status.value
         if durations:
             save_timings(project_root, durations, results=results)
 

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -12,7 +12,11 @@ from slopmop.checks.base import (
     ToolContext,
     find_tool,
 )
-from slopmop.checks.mixins import JavaScriptCheckMixin, PythonCheckMixin
+from slopmop.checks.mixins import (
+    JavaScriptCheckMixin,
+    PythonCheckMixin,
+    has_python_source_files,
+)
 from slopmop.core.result import CheckResult, CheckStatus
 
 
@@ -437,6 +441,13 @@ class TestPythonCheckMixin:
         nested.mkdir(parents=True)
         (nested / "tool.py").touch()
         assert self.mixin.has_python_files(str(tmp_path)) is False
+
+    def test_has_python_source_files_honors_empty_exclude_set(self, tmp_path):
+        """An explicit empty exclude set should disable directory exclusions."""
+        nested = tmp_path / "node_modules" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "tool.py").touch()
+        assert has_python_source_files(tmp_path, exclude_dirs=set()) is True
 
     def test_has_setup_py_true(self, tmp_path):
         """Test has_setup_py returns True when setup.py exists."""

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -431,6 +431,13 @@ class TestPythonCheckMixin:
         (subdir / "test.py").touch()
         assert self.mixin.has_python_files(str(tmp_path)) is True
 
+    def test_has_python_files_ignores_excluded_dirs(self, tmp_path):
+        """Excluded junk dirs should not make a repo look like Python."""
+        nested = tmp_path / "node_modules" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "tool.py").touch()
+        assert self.mixin.has_python_files(str(tmp_path)) is False
+
     def test_has_setup_py_true(self, tmp_path):
         """Test has_setup_py returns True when setup.py exists."""
         (tmp_path / "setup.py").touch()

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -468,9 +468,15 @@ class TestPythonCheckMixin:
         (tmp_path / "pyproject.toml").touch()
         assert self.mixin.is_python_project(str(tmp_path)) is True
 
-    def test_is_python_project_with_requirements(self, tmp_path):
-        """Test is_python_project returns True with requirements.txt."""
+    def test_is_python_project_false_with_requirements_only(self, tmp_path):
+        """requirements.txt alone should not enable Python gates."""
         (tmp_path / "requirements.txt").touch()
+        assert self.mixin.is_python_project(str(tmp_path)) is False
+
+    def test_is_python_project_with_requirements_and_py_files(self, tmp_path):
+        """requirements.txt plus Python files should count as Python."""
+        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "main.py").touch()
         assert self.mixin.is_python_project(str(tmp_path)) is True
 
     def test_is_python_project_with_py_files(self, tmp_path):

--- a/tests/unit/test_config_debt_check.py
+++ b/tests/unit/test_config_debt_check.py
@@ -173,6 +173,23 @@ class TestStaleApplicability:
         findings = check_stale_applicability(tmp_path, config, set())
         assert findings == []
 
+    def test_requirements_with_python_only_in_excluded_dir_stays_absent(
+        self, tmp_path: Path
+    ):
+        """Excluded dirs should not make config debt think Python is present."""
+        (tmp_path / "requirements.txt").write_text("pytest\n")
+        nested = tmp_path / "node_modules" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "tool.py").write_text("print('hi')\n")
+        config = {
+            "laziness": {
+                "enabled": True,
+                "gates": {"sloppy-formatting.py": {"enabled": False}},
+            },
+        }
+        findings = check_stale_applicability(tmp_path, config, set())
+        assert findings == []
+
     def test_no_finding_when_gate_enabled(self, tmp_path: Path):
         """Gate is enabled → no debt."""
         _make_python_project(tmp_path)

--- a/tests/unit/test_config_debt_check.py
+++ b/tests/unit/test_config_debt_check.py
@@ -159,6 +159,20 @@ class TestStaleApplicability:
         findings = check_stale_applicability(tmp_path, config, set())
         assert findings == []
 
+    def test_requirements_only_does_not_trigger_python_stale_warning(
+        self, tmp_path: Path
+    ):
+        """requirements.txt alone should not count as Python for stale config debt."""
+        (tmp_path / "requirements.txt").write_text("pytest\n")
+        config = {
+            "laziness": {
+                "enabled": True,
+                "gates": {"sloppy-formatting.py": {"enabled": False}},
+            },
+        }
+        findings = check_stale_applicability(tmp_path, config, set())
+        assert findings == []
+
     def test_no_finding_when_gate_enabled(self, tmp_path: Path):
         """Gate is enabled → no debt."""
         _make_python_project(tmp_path)

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import slopmop.cli.detection as detection_module
 from slopmop.cli.detection import _normalize_language_key, detect_project_type
+
+
+def test_detection_module_keeps_docstring() -> None:
+    """The module docstring should stay at the top of detection.py."""
+    assert detection_module.__doc__ == "Project type detection for slop-mop CLI."
 
 
 class TestDetectProjectType:

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -26,9 +26,16 @@ class TestDetectProjectType:
         assert result["has_python"] is True
         assert result["has_pytest"] is True
 
-    def test_detects_python_project_from_requirements(self, tmp_path):
-        """Detects Python from requirements.txt."""
+    def test_requirements_alone_does_not_imply_python_project(self, tmp_path):
+        """requirements.txt alone is too weak to enable Python gates."""
         (tmp_path / "requirements.txt").write_text("flask==2.0")
+        result = detect_project_type(tmp_path)
+        assert result["has_python"] is False
+
+    def test_detects_python_project_from_requirements_and_py_files(self, tmp_path):
+        """requirements.txt plus Python sources should detect Python."""
+        (tmp_path / "requirements.txt").write_text("flask==2.0")
+        (tmp_path / "app.py").write_text("print('hi')\n")
         result = detect_project_type(tmp_path)
         assert result["has_python"] is True
 

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -6,12 +6,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import slopmop.cli.detection as detection_module
+from slopmop.checks.mixins import _PYTHON_SOURCE_EXCLUDE_DIRS
 from slopmop.cli.detection import _normalize_language_key, detect_project_type
 
 
 def test_detection_module_keeps_docstring() -> None:
     """The module docstring should stay at the top of detection.py."""
     assert detection_module.__doc__ == "Project type detection for slop-mop CLI."
+
+
+def test_detection_uses_shared_excluded_dir_set() -> None:
+    """Detection and Python source scans should not carry diverging exclude sets."""
+    assert detection_module._DETECTION_EXCLUDED_DIRS is _PYTHON_SOURCE_EXCLUDE_DIRS
 
 
 class TestDetectProjectType:

--- a/tests/unit/test_detection.py
+++ b/tests/unit/test_detection.py
@@ -39,6 +39,17 @@ class TestDetectProjectType:
         result = detect_project_type(tmp_path)
         assert result["has_python"] is True
 
+    def test_requirements_with_python_only_in_excluded_dir_stays_non_python(
+        self, tmp_path
+    ):
+        """requirements.txt should ignore Python files tucked under excluded dirs."""
+        (tmp_path / "requirements.txt").write_text("flask==2.0")
+        nested = tmp_path / "node_modules" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "tool.py").write_text("print('hi')\n")
+        result = detect_project_type(tmp_path)
+        assert result["has_python"] is False
+
     def test_detects_javascript_project(self, tmp_path):
         """Detects JavaScript from package.json."""
         (tmp_path / "package.json").write_text("{}")

--- a/tests/unit/test_display_timings.py
+++ b/tests/unit/test_display_timings.py
@@ -40,6 +40,48 @@ class TestDisplayTimingPersistence:
         timings_file = tmp_path / ".slopmop" / "timings.json"
         assert not timings_file.exists()
 
+    def test_save_historical_timings_skips_failed_checks(self, tmp_path) -> None:
+        """Failed checks should not contribute bogus timing history."""
+        display = DynamicDisplay(quiet=True)
+
+        display.on_check_start("test:passed")
+        display.on_check_complete(
+            CheckResult(name="test:passed", status=CheckStatus.PASSED, duration=2.5)
+        )
+        display.on_check_start("test:failed")
+        display.on_check_complete(
+            CheckResult(name="test:failed", status=CheckStatus.FAILED, duration=8.0)
+        )
+
+        display.save_historical_timings(str(tmp_path))
+
+        timings_file = tmp_path / ".slopmop" / "timings.json"
+        data = json.loads(timings_file.read_text())
+
+        assert "test:passed" in data
+        assert "test:failed" not in data
+
+    def test_save_historical_timings_skips_cached_checks(self, tmp_path) -> None:
+        """Cached checks should never refresh timing history timestamps."""
+        display = DynamicDisplay(quiet=True)
+
+        display._checks["test:cached"] = CheckDisplayInfo(
+            name="test:cached",
+            state=DisplayState.COMPLETED,
+            result=CheckResult(
+                name="test:cached",
+                status=CheckStatus.PASSED,
+                duration=2.5,
+                cached=True,
+            ),
+            duration=2.5,
+        )
+
+        display.save_historical_timings(str(tmp_path))
+
+        timings_file = tmp_path / ".slopmop" / "timings.json"
+        assert not timings_file.exists()
+
     def test_load_historical_timings(self, tmp_path) -> None:
         """Test load_historical_timings loads timing data."""
         timings_dir = tmp_path / ".slopmop"

--- a/tests/unit/test_python_checks.py
+++ b/tests/unit/test_python_checks.py
@@ -138,13 +138,13 @@ class TestPythonTestsCheck:
 
     def test_skip_reason_python_project_not_applicable_message(self, tmp_path):
         """Skip reason uses the generic applicable message for Python projects."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonTestsCheck({})
         assert check.skip_reason(str(tmp_path)) == "Python tests check not applicable"
 
     def test_run_fails_when_no_python_tests_exist(self, tmp_path):
         """No test files should fail with explicit fix guidance."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonTestsCheck({})
         result = check.run(str(tmp_path))
         assert result.status == CheckStatus.FAILED
@@ -363,7 +363,7 @@ class TestPythonCoverageCheck:
 
     def test_is_applicable_python_project(self, tmp_path):
         """Test is_applicable returns True for Python project with tests."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         (tmp_path / "tests").mkdir()
         (tmp_path / "tests" / "test_example.py").write_text("def test_one(): pass")
         check = PythonCoverageCheck({})
@@ -475,7 +475,7 @@ class TestPythonCoverageCheck:
 
     def test_skip_reason_python_project_not_applicable_message(self, tmp_path):
         """Skip reason uses coverage-specific generic message for Python projects."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonCoverageCheck({})
         assert (
             check.skip_reason(str(tmp_path)) == "Python coverage check not applicable"
@@ -483,7 +483,7 @@ class TestPythonCoverageCheck:
 
     def test_run_fails_when_no_python_tests_exist(self, tmp_path):
         """No tests should fail before coverage parsing with actionable guidance."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonCoverageCheck({})
         result = check.run(str(tmp_path))
         assert result.status == CheckStatus.FAILED
@@ -1075,13 +1075,13 @@ class TestPythonDiffCoverageCheck:
 
     def test_skip_reason_python_project_not_applicable_message(self, tmp_path):
         """Skip reason uses diff-coverage specific generic message for Python projects."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonDiffCoverageCheck({})
         assert check.skip_reason(str(tmp_path)) == "Diff coverage check not applicable"
 
     def test_run_fails_when_no_python_tests_exist(self, tmp_path):
         """No tests should fail before invoking diff-cover."""
-        (tmp_path / "requirements.txt").touch()
+        (tmp_path / "pyproject.toml").touch()
         check = PythonDiffCoverageCheck({})
         result = check.run(str(tmp_path))
         assert result.status == CheckStatus.FAILED

--- a/tests/unit/test_upgrade_migrations.py
+++ b/tests/unit/test_upgrade_migrations.py
@@ -8,6 +8,7 @@ from slopmop.migrations import (
     _rename_dart_gates,
     _rename_source_duplication,
     _rename_swabbing_time,
+    _sync_built_in_gate_applicability,
     planned_upgrade_migrations,
     run_upgrade_migrations,
 )
@@ -118,6 +119,10 @@ class TestMigrationRegistry:
     def test_rename_source_duplication_is_registered(self):
         keys = planned_upgrade_migrations("0.11.0", "0.11.1")
         assert "rename-source-duplication-gates" in keys
+
+    def test_sync_built_in_gate_applicability_is_registered(self):
+        keys = planned_upgrade_migrations("0.15.0", "0.15.1")
+        assert "sync-built-in-gate-applicability" in keys
 
 
 class TestRenameSourceDuplication:
@@ -387,3 +392,82 @@ class TestRenameDartGates:
         assert "rename-dart-gates" in applied
         result = self._read_config(tmp_path)
         assert result["disabled_gates"] == ["overconfidence:untested-code.dart"]
+
+
+class TestSyncBuiltInGateApplicability:
+    def _write_config(self, tmp_path: Path, data: dict) -> None:
+        (tmp_path / ".sb_config.json").write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _read_config(self, tmp_path: Path) -> dict:
+        return json.loads((tmp_path / ".sb_config.json").read_text(encoding="utf-8"))
+
+    def test_disables_python_gates_for_requirements_only_repo(self, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+        (tmp_path / "package.json").write_text("{}\n", encoding="utf-8")
+        self._write_config(
+            tmp_path,
+            {
+                "laziness": {
+                    "enabled": True,
+                    "gates": {
+                        "sloppy-formatting.py": {"enabled": True},
+                        "sloppy-formatting.js": {"enabled": True},
+                    },
+                },
+                "overconfidence": {
+                    "enabled": True,
+                    "gates": {
+                        "untested-code.py": {"enabled": True, "test_dirs": ["tests"]},
+                    },
+                },
+            },
+        )
+
+        _sync_built_in_gate_applicability(tmp_path)
+        result = self._read_config(tmp_path)
+
+        assert result["laziness"]["gates"]["sloppy-formatting.py"]["enabled"] is False
+        assert result["overconfidence"]["gates"]["untested-code.py"]["enabled"] is False
+        assert result["laziness"]["gates"]["sloppy-formatting.js"]["enabled"] is True
+
+    def test_preserves_python_gates_for_real_python_repo(self, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+        (tmp_path / "main.py").write_text("print('hi')\n", encoding="utf-8")
+        self._write_config(
+            tmp_path,
+            {
+                "laziness": {
+                    "enabled": True,
+                    "gates": {
+                        "sloppy-formatting.py": {"enabled": True},
+                    },
+                },
+            },
+        )
+
+        _sync_built_in_gate_applicability(tmp_path)
+        result = self._read_config(tmp_path)
+
+        assert result["laziness"]["gates"]["sloppy-formatting.py"]["enabled"] is True
+
+    def test_end_to_end_via_registry(self, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+        self._write_config(
+            tmp_path,
+            {
+                "laziness": {
+                    "enabled": True,
+                    "gates": {
+                        "sloppy-formatting.py": {"enabled": True},
+                    },
+                },
+            },
+        )
+
+        applied = run_upgrade_migrations(tmp_path, "0.15.0", "0.15.1")
+
+        assert "sync-built-in-gate-applicability" in applied
+        result = self._read_config(tmp_path)
+        assert result["laziness"]["gates"]["sloppy-formatting.py"]["enabled"] is False


### PR DESCRIPTION
## Summary
- ignore cached and failed timing samples so ETA history only learns from real runs
- stop requirements-only repos from enabling Python gates when there is no Python source
- repair stale built-in gate applicability on upgrade instead of telling users to rerun init

## Validation
- pytest tests/unit/test_display_timings.py -q
- pytest tests/unit/test_detection.py tests/unit/test_base_check.py tests/unit/test_config_debt_check.py tests/unit/test_python_checks.py -q
- pytest tests/unit/test_upgrade_migrations.py -q
- ./sm swab

## Context
These changes came out of live dogfooding against fogofdog-frontend, where stale applicability and timing-history behavior were creating bad guidance.
