### PR TITLE
docs: add coverage-ready badges

### DIFF
--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -168,27 +168,35 @@ jobs:
           path: slopmop-results.json
 
       - name: Verify coverage report exists
+        if: always()
         run: |
-          test -f coverage.xml
+          if [ -f coverage.xml ]; then
+            echo "coverage.xml found; coverage upload steps can run."
+          else
+            echo "coverage.xml was not produced by sm scour; skipping coverage upload."
+          fi
 
       - name: Upload coverage report
+        if: always() && hashFiles('coverage.xml') != ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
 
       - name: Upload coverage to Codecov
+        if: always() && hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v5
+        continue-on-error: true
         with:
           files: coverage.xml
           use_oidc: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Summarise SARIF failures
         # When scour fails, parse the SARIF and surface the top
         # failing rule IDs directly in the check output so reviewers
         # don't have to click through to the Security tab.
-        if: steps.scour.outcome == 'failure'
+        if: always() && steps.scour.outcome == 'failure'
         run: |
           source .venv/bin/activate
           python3 scripts/summarize_scour_failure.py \
@@ -203,7 +211,7 @@ jobs:
         # Without this, continue-on-error above would let everything
         # through.  The SARIF is uploaded either way — this just
         # controls the green/red check mark.
-        if: steps.scour.outcome == 'failure'
+        if: always() && steps.scour.outcome == 'failure'
         run: |
           if [ -f .scour-failure-summary.txt ]; then
             echo "::group::Scour failure summary"

--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -67,19 +67,24 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-# upload-sarif needs security-events: write.  actions: read lets it
-# correlate the upload with the workflow run.  contents: read is the
-# bare minimum for checkout.
+# upload-sarif needs security-events: write. actions: read lets it correlate
+# the upload with the workflow run. contents: read is the bare minimum for
+# checkout. Jobs that need narrower permissions add them at the job level.
 permissions:
   contents: read
   security-events: write
   actions: read
-  id-token: write
 
 jobs:
   scan:
     name: Primary Code Scanning Gate (blocking)
     runs-on: ubuntu-latest
+    # Codecov OIDC only belongs on the job that uploads coverage.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -74,6 +74,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  id-token: write
 
 jobs:
   scan:
@@ -165,6 +166,23 @@ jobs:
         with:
           name: slopmop-results
           path: slopmop-results.json
+
+      - name: Verify coverage report exists
+        run: |
+          test -f coverage.xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          use_oidc: true
+          fail_ci_if_error: true
 
       - name: Summarise SARIF failures
         # When scour fails, parse the SARIF and surface the top

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # 🪣 Slop-Mop
 
 <p>
-  <a href="https://pypi.org/project/slopmop/"><img src="https://img.shields.io/pypi/v/slopmop.svg" alt="PyPI version"/></a>
   <a href="https://github.com/ScienceIsNeato/slop-mop/actions/workflows/slopmop-sarif.yml"><img src="https://github.com/ScienceIsNeato/slop-mop/actions/workflows/slopmop-sarif.yml/badge.svg" alt="Primary code scanning gate"/></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"/></a>
-  <a href="https://github.com/ScienceIsNeato/slop-mop/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Attribution-blue.svg" alt="License"/></a>
+  <a href="https://codecov.io/gh/ScienceIsNeato/slop-mop"><img src="https://codecov.io/gh/ScienceIsNeato/slop-mop/branch/main/graph/badge.svg" alt="Coverage"/></a>
+  <a href="https://pypi.org/project/slopmop/"><img src="https://img.shields.io/pypi/v/slopmop.svg" alt="PyPI version"/></a>
+  <a href="https://pypi.org/project/slopmop/"><img src="https://img.shields.io/pypi/pyversions/slopmop.svg" alt="Python versions"/></a>
+  <a href="https://github.com/ScienceIsNeato/slop-mop/releases"><img src="https://img.shields.io/github/v/release/ScienceIsNeato/slop-mop?display_name=tag&amp;sort=semver" alt="Latest GitHub release"/></a>
+  <a href="https://github.com/ScienceIsNeato/slop-mop/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Slop--Mop%20Attribution%20v1.0-blue.svg" alt="License"/></a>
 </p>
 
 Slop-mop is a quality gate runner for AI-assisted codebases.

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,6 +11,8 @@ Branch: `docs/badges-and-coverage`
 - Added Codecov upload for the existing `coverage.xml` output in the primary
   workflow, authenticated with GitHub OIDC.
 - Documented coverage badge requirements in `docs/CI.md`.
+- Addressed PR #151 feedback by making coverage publication conditional and
+  non-blocking while hardening SARIF verdict steps with `always()` guards.
 
 **Validation so far:**
 - `./sm swab -g overconfidence:untested-code.py --no-cache` ✅
@@ -21,8 +23,13 @@ Branch: `docs/badges-and-coverage`
 - Workflow/docs diagnostics clean ✅
 - `./sm swab` ✅
 - `./sm scour` ✅ (non-blocking dependency-risk warning remains)
+- PR #151 workflow feedback fix diagnostics clean ✅
+- `./sm swab` after feedback fix ✅
+- `./sm scour` after feedback fix ✅ (expected unresolved PR feedback warning
+  until threads are resolved; non-blocking dependency-risk warning remains)
 
-**Next:** Create the badge follow-up PR and run the `sm buff` rail.
+**Next:** Commit/push the PR #151 feedback fix, resolve review threads, and
+re-run `sm buff`.
 
 ## 2026-04-26 Delta: PR 150 README continuity follow-up
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,7 +22,7 @@ Branch: `docs/badges-and-coverage`
 - `./sm swab` ✅
 - `./sm scour` ✅ (non-blocking dependency-risk warning remains)
 
-**Next:** Commit and push the branch for the badge follow-up PR.
+**Next:** Create the badge follow-up PR and run the `sm buff` rail.
 
 ## 2026-04-26 Delta: PR 150 README continuity follow-up
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,29 @@
 # Project Status
 
+## 2026-04-26 Delta: Badge and coverage follow-up
+
+Branch: `docs/badges-and-coverage`
+
+**Work completed:**
+- Started the badge follow-up from updated `main` after PR #150 merged.
+- Updated the README badge block to keep the primary gate, PyPI, Python
+  versions, license, latest release, and coverage signals.
+- Added Codecov upload for the existing `coverage.xml` output in the primary
+  workflow, authenticated with GitHub OIDC.
+- Documented coverage badge requirements in `docs/CI.md`.
+
+**Validation so far:**
+- `./sm swab -g overconfidence:untested-code.py --no-cache` ✅
+  (`coverage.xml` exists)
+- `./sm swab -g overconfidence:coverage-gaps.py --no-cache` ✅
+- `./sm scour -g myopia:just-this-once.py --no-cache` ✅
+- README/docs link and no-hype scan ✅
+- Workflow/docs diagnostics clean ✅
+- `./sm swab` ✅
+- `./sm scour` ✅ (non-blocking dependency-risk warning remains)
+
+**Next:** Commit and push the branch for the badge follow-up PR.
+
 ## 2026-04-26 Delta: PR 150 README continuity follow-up
 
 Branch: `docs/readme-field-guide`

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,8 @@ Branch: `docs/badges-and-coverage`
 - Documented coverage badge requirements in `docs/CI.md`.
 - Addressed PR #151 feedback by making coverage publication conditional and
   non-blocking while hardening SARIF verdict steps with `always()` guards.
+- Addressed PR #151 OIDC scoping feedback by moving `id-token: write` to the
+  coverage-uploading job.
 
 **Validation so far:**
 - `./sm swab -g overconfidence:untested-code.py --no-cache` ✅
@@ -27,9 +29,14 @@ Branch: `docs/badges-and-coverage`
 - `./sm swab` after feedback fix ✅
 - `./sm scour` after feedback fix ✅ (expected unresolved PR feedback warning
   until threads are resolved; non-blocking dependency-risk warning remains)
+- PR #151 OIDC scoping diagnostics clean ✅
+- `./sm swab` after OIDC scoping fix ✅
+- `./sm scour` after OIDC scoping fix ✅ (expected unresolved PR feedback
+  warning until the thread is resolved; non-blocking dependency-risk warning
+  remains)
 
-**Next:** Commit/push the PR #151 feedback fix, resolve review threads, and
-re-run `sm buff`.
+**Next:** Commit/push the OIDC scoping fix, resolve the final review thread,
+and re-run `sm buff`.
 
 ## 2026-04-26 Delta: PR 150 README continuity follow-up
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -41,6 +41,10 @@ If you want a coverage badge, upload `coverage.xml` to a public coverage
 reporter after `sm swab` or `sm scour` runs. This repo uploads it to Codecov in
 the primary workflow and authenticates the upload with GitHub OIDC.
 
+Keep the upload best-effort. The primary gate should block on slop-mop findings,
+not on a coverage service outage. If `coverage.xml` is not produced, skip the
+upload and let the slop-mop verdict own the check result.
+
 This repo's own workflow is
 [.github/workflows/slopmop-sarif.yml](../.github/workflows/slopmop-sarif.yml).
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -31,6 +31,16 @@ The `fetch-depth: 0` line matters. Some gates compare against git history or
 the PR base branch. A shallow checkout can make those gates fail with missing
 revision errors.
 
+## Coverage badges
+
+Slop-mop's Python test gate writes `coverage.xml` when it runs the pytest path.
+The coverage gates read that same file; they do not publish it anywhere by
+themselves.
+
+If you want a coverage badge, upload `coverage.xml` to a public coverage
+reporter after `sm swab` or `sm scour` runs. This repo uploads it to Codecov in
+the primary workflow and authenticates the upload with GitHub OIDC.
+
 This repo's own workflow is
 [.github/workflows/slopmop-sarif.yml](../.github/workflows/slopmop-sarif.yml).
 


### PR DESCRIPTION
## Summary

- update the README badge set around the Python/PyPI distribution surface
- add Codecov coverage upload for the existing `coverage.xml` output
- document the coverage badge requirement in the CI docs

## Validation

- `./sm swab -g overconfidence:untested-code.py --no-cache`
- `./sm swab -g overconfidence:coverage-gaps.py --no-cache`
- `./sm scour -g myopia:just-this-once.py --no-cache`
- README/docs link and no-hype scan
- workflow/docs diagnostics
- `./sm swab`
- `./sm scour` (known non-blocking dependency-risk warning remains)