### PR TITLE
chore: bump version to 0.15.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.15.0"
+version = "0.15.1"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
## Release v0.15.1

**Bump type:** `patch` (0.15.0 -> 0.15.1)

### Changes since v0.15.0

- PR #152: consolidate documentation under `DOCS/`
- PR #151: scope Codecov OIDC, make coverage upload non-blocking, and add badges
- PR #150: rewrite README as a field guide
- PR #149: fix Python detection, excludes, gate applicability, and timing samples

### Validation

- `sm swab --no-cache`
- `sm scour --no-cache`

Both passed from a clean release worktree using a local `.venv` installed from this branch.

### Post-merge

After this PR merges, `release.yml` should detect the version bump on `main`, build the package, publish to PyPI, create tag `v0.15.1`, and create the GitHub Release.