### PR TITLE
chore: cut 1.0.0 release branch

### DIFF
--- a/DOCS/COMPATIBILITY.md
+++ b/DOCS/COMPATIBILITY.md
@@ -1,10 +1,8 @@
 # Compatibility and Support
 
-slop-mop is still pre-1.0. The project is trying to be disciplined about
-compatibility, but it is not claiming a frozen surface yet.
-
-This document is the public contract for what users should expect from releases
-before 1.0.0.
+Starting with 1.0.0, slop-mop treats its documented CLI, config, and release
+surfaces as stable. The project can still evolve, but user-visible breakage
+needs a migration path or a clearly documented major release boundary.
 
 ## Support Scope
 
@@ -13,13 +11,13 @@ The actively supported surfaces are:
 - the latest published PyPI release
 - `main`, when validating an upcoming release or an unreleased fix
 
-Pre-1.0 releases do not have long-term support branches. Fixes land in `main`
-first. Older releases may be closed as unsupported instead of backported.
+The latest minor release receives active fixes. Fixes land in `main` first;
+older release lines may be closed as unsupported instead of backported unless a
+security or severe data-loss issue warrants a targeted patch.
 
-## Versioning Expectations Before 1.0
+## Versioning Expectations
 
-slop-mop uses semantic-looking versions, but pre-1.0 rules are intentionally
-stricter than "anything goes" and looser than a true 1.x contract.
+slop-mop follows semantic versioning for the documented public surface.
 
 ### Patch releases
 
@@ -31,19 +29,19 @@ Patch releases should avoid intentional breakage in:
 - release/install behavior from supported package entry points
 
 Bug fixes, dependency bumps, and additive flags are fine. Intentional breakage
-in a patch release needs a very strong reason and should be called out
-explicitly in release notes.
+in a patch release needs a very strong reason, a migration or compatibility
+shim when practical, and explicit release notes.
 
 ### Minor releases
 
-Minor releases may still evolve:
+Minor releases may add or deprecate:
 
 - gate names
 - config structure
 - machine-readable output formats
 - agent-install templates and workflow scaffolding
 
-When that happens:
+When a minor release changes behavior:
 
 - ship an automated `sm upgrade` migration when the change is automatable
 - update [DOCS/MIGRATIONS.md](MIGRATIONS.md) when migration authoring rules
@@ -53,11 +51,13 @@ When that happens:
 
 ## Config and Output Compatibility
 
-Before 1.0.0:
+For 1.x releases:
 
-- committed config templates may change between minor releases
+- committed config templates may gain new optional settings between minor
+  releases
 - existing user configs should keep working via migration whenever practical
-- JSON and SARIF output should be treated as evolving integration surfaces
+- JSON, SARIF, and porcelain output should avoid incompatible changes inside a
+  minor release line
 
 If a change intentionally breaks an integration surface, the release notes
 should say so plainly rather than hiding it inside a generic changelog entry.
@@ -85,20 +85,10 @@ otherwise.
 
 ## Deprecation Policy
 
-Pre-1.0 does not guarantee a long deprecation window, but the project should
-still avoid surprise removals.
+The project should avoid surprise removals.
 
 The expectation is:
 
 - additive changes can land immediately
 - renames/removals should come with a migration when possible
 - release notes should call out behavior changes that require user action
-
-## 1.0 Trigger
-
-When slop-mop reaches 1.0.0, this document should be tightened into a stable
-1.x compatibility contract with:
-
-- explicit backward-compatibility promises
-- a documented support window
-- a clearer policy for deprecations and removals

--- a/DOCS/RELEASING.md
+++ b/DOCS/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing Slop-Mop
 
-slop-mop is still pre-1.0, so releases should optimize for **verification**
-over speed. The mechanics are automated; the judgment call is still human.
+slop-mop releases should optimize for **verification** over speed. The
+mechanics are automated; the judgment call is still human.
 
 ## Release Flow
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is opinionated. Sometimes loudly. That is on purpose.
 
 ## Project Status
 
-slop-mop is still pre-1.0. The current public policy surface for release and
+slop-mop has reached 1.0.0. The current public policy surface for release and
 stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,26 @@
 # Project Status
 
+## 2026-04-29 Delta: 1.0.0 release branch
+
+Branch: `release/v1.0.0`
+
+**Work in progress:**
+- Synced local `main` to `origin/main` after PR #157 merged.
+- Stashed the stale local `backlog_cleaning` work as
+  `pre-1.0-main-sync-stale-wip` before switching branches.
+- Started the 1.0.0 release branch from current `main`.
+- Bumped package metadata to `1.0.0` and updated release-facing docs from
+  pre-1.0 language to the stable 1.x contract.
+
+**Validation so far:**
+- Stale release-text scan is clean for release-facing files; remaining `0.15.x`
+  hits are migration history and upgrade fixtures.
+- `./sm swab --no-cache --output-file .slopmop/last_swab.json` ✅
+- `./sm scour --no-cache --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Commit and push the release branch without creating a PR automatically.
+
 ## 2026-04-29 Delta: PR #157 buff — Bugbot stale-gate category fix
 
 - **Commit:** `5ea9031` — `_CONFIG_CATEGORY_KEYS` had `quality` but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "0.15.1"
+version = "1.0.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["quality-gate", "linting", "testing", "ci-cd", "code-quality", "ai", "llm", "vibe-coding"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: Other/Proprietary License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
- Bump package version to 1.0.0.
- Mark the package classifier as Production/Stable.
- Update release-facing docs for the 1.x compatibility contract.

Validation:
- ./sm swab --no-cache --output-file .slopmop/last_swab.json
- ./sm scour --no-cache --output-file .slopmop/last_scour.json