### PR TITLE
fix: declare packaging as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 # jinja2_templates gate via a lazy import with a graceful fallback when absent.
 dependencies = [
     "tomli>=1.0.0; python_version < '3.11'",
+    "packaging>=21.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 
 # Core runtime
 tomli>=1.0.0; python_version < '3.11'
+packaging>=21.0
 
 # Static analysis
 vulture>=2.14


### PR DESCRIPTION
fix: declare packaging as a runtime dependency

packaging.version.Version is imported at module level in
slopmop/migrations/__init__.py, and is also used in
slopmop/doctor/sm_env.py and slopmop/cli/upgrade.py.
Without it declared in the wheel's install_requires, a
clean-venv smoke test fails immediately on import with:
  ModuleNotFoundError: No module named 'packaging'

Adds packaging>=21.0 to the core dependencies list.
