### PR TITLE
feat: file barnacles as structured GitHub issues

### DIFF
--- a/DOCS/GATE_REASONING.md
+++ b/DOCS/GATE_REASONING.md
@@ -84,12 +84,6 @@ This file is generated from built-in gate metadata. Edit the gate reasoning sour
 - Tradeoffs: The strict version can be annoying when you sketch a test first and plan to fill the assertions in a minute later.
 - Override When: Fine to relax briefly in draft-only local work, not in committed code that is pretending to be review-ready.
 
-### `deceptiveness:debugger-artifacts`
-
-- Rationale: Leftover breakpoints are the kind of tiny accident that can wreck a real run in embarrassingly expensive ways.
-- Tradeoffs: The only real cost is a little friction when you are actively debugging and want quick iteration.
-- Override When: Fine in local scratch work; not fine once the change is headed toward a commit or a PR.
-
 ### `deceptiveness:gate-dodging`
 
 - Rationale: If the fix is 'turn the smoke alarm down,' the repo learns the wrong lesson and the next regression walks right in.
@@ -121,6 +115,12 @@ This file is generated from built-in gate metadata. Edit the gate reasoning sour
 - Rationale: Dead code makes the map lie. People read paths that do not matter and miss the ones that do.
 - Tradeoffs: Static dead-code tools can false-positive on dynamic hooks, plugins, and intentionally indirect entrypoints.
 - Override When: Override for known dynamic entrypoints with a concrete explanation, not because the deletion is inconvenient right now.
+
+### `laziness:debugger-artifacts`
+
+- Rationale: Leftover breakpoints are the kind of tiny accident that can wreck a real run in embarrassingly expensive ways.
+- Tradeoffs: The only real cost is a little friction when you are actively debugging and want quick iteration.
+- Override When: Fine in local scratch work; not fine once the change is headed toward a commit or a PR.
 
 ### `laziness:generated-artifacts.dart`
 

--- a/DOCS/WORKFLOW.md
+++ b/DOCS/WORKFLOW.md
@@ -129,7 +129,7 @@ structural changes would undo their fixes.
 | 3 — fix later | `overconfidence:untested-code.dart` | Foundation | 💯 Overconfidence | no |
 | 3 — fix later | `overconfidence:untested-code.js` | Foundation | 💯 Overconfidence | no |
 | 3 — fix later | `overconfidence:untested-code.py` | Foundation | 💯 Overconfidence | no |
-| 4 — fix last | `deceptiveness:debugger-artifacts` | Diagnostic | 🎭 Deceptiveness | no |
+| 4 — fix last | `laziness:debugger-artifacts` | Diagnostic | 🦥 Laziness | no |
 | 4 — fix last | `laziness:generated-artifacts.dart` | Diagnostic | 🦥 Laziness | no |
 | 4 — fix last | `laziness:sloppy-formatting.js` | Foundation | 🦥 Laziness | yes |
 | 4 — fix last | `laziness:sloppy-formatting.py` | Foundation | 🦥 Laziness | yes |

--- a/README.md
+++ b/README.md
@@ -267,11 +267,24 @@ pretend the rail is fine. Fix the gate, tune the config, file the bug. The
 point isn't obedience - it's making the correct path the path of least
 resistance.
 
-For slop-mop tooling friction, start with:
+For slop-mop tooling friction, file a barnacle issue upstream:
 
 ```bash
-sm barnacle --help
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "what should have happened" \
+  --actual "what happened instead" \
+  --repro-step "how to reproduce it" \
+  --tried "what you already tried" \
+  --workflow swab \
+  --blocker-type blocking
 ```
+
+Barnacles are for defects in slop-mop itself: invalid guidance, false gate
+results, broken rails, confusing output, or install/upgrade/refit friction. They
+create structured GitHub issues tagged for maintainer triage. They are not a
+local queue and not a replacement for fixing real target-repo failures.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -278,13 +278,16 @@ sm barnacle file \
   --repro-step "how to reproduce it" \
   --tried "what you already tried" \
   --workflow swab \
-  --blocker-type blocking
+  --blocker-type blocking \
+  --json
 ```
 
 Barnacles are for defects in slop-mop itself: invalid guidance, false gate
 results, broken rails, confusing output, or install/upgrade/refit friction. They
 create structured GitHub issues tagged for maintainer triage. They are not a
 local queue and not a replacement for fixing real target-repo failures.
+The generated Markdown body is also written to `.slopmop/last_barnacle_issue.md`
+so failed filings are retryable without reconstructing context.
 
 ## Contributing
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,7 +44,11 @@ Branch: `feat/crowdsource-barnacles`
 - `./sm scour --output-file .slopmop/last_scour.json` ✅ after debugger-artifacts category move
   (known non-blocking dependency-risk warning remains)
 
-**Next:** Commit, push, and open PR.
+**PR:** https://github.com/ScienceIsNeato/slop-mop/pull/169
+
+**Next:** Monitor PR #169 CI/review through `sm buff`; initial status showed
+Primary Code Scanning Gate, Unit Test Coverage, Docker Integration Tests, and
+Cursor Bugbot in progress.
 
 ## 2026-04-30 Delta: Timing history cache-poison fix
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,34 @@
 # Project Status
 
+## 2026-05-03 Delta: Barnacle issue intake replacement
+
+Branch: `feat/crowdsource-barnacles`
+
+**Work in progress:**
+- Replaced the machine-local barnacle queue with one-way GitHub issue intake.
+- `sm barnacle file` now renders structured Markdown with command, expected vs
+  actual behavior, reproduction steps, things tried, output excerpt, impact, and
+  JSON metadata about the affected repo/commit/platform/agent.
+- Kept `sm barnacle describe` as a deprecated alias for `file` during transition.
+- Removed queue/list/show/resolve tests and the global `SLOPMOP_BARNACLE_DIR`
+  test fixture.
+- Updated upgrade failure auto-reporting to file a barnacle issue URL instead of
+  writing local JSON.
+- Updated README and shared agent templates to describe barnacle issues, not a
+  local cleanup queue.
+- Created the upstream GitHub `barnacle` label for issue triage.
+
+**Validation so far:**
+- `./sm barnacle file ... --dry-run` ✅
+- `./sm swab -g laziness:sloppy-formatting.py --auto-fix --output-file .slopmop/barnacle_format.json` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/barnacle_issue_tests.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅
+- `./sm swab --no-cache --output-file .slopmop/last_swab.json` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Commit and push `feat/crowdsource-barnacles`.
+
 ## 2026-04-30 Delta: Timing history cache-poison fix
 
 Branch: `docs/pypi-readme-1.0-polish`

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,27 @@
 # Project Status
 
+## 2026-05-04 Delta: PR #169 follow-up parser fixes
+
+Branch: `feat/crowdsource-barnacles`  ·  PR `#169`
+
+**Work completed:**
+- Added `doctor` to `sm barnacle file --workflow` choices so agents can file
+  barnacles for doctor-flow friction.
+- Fixed the top-level `./sm --help` verb list so `barnacle` is aligned with the
+  surrounding verbs in the descriptive help block.
+- Added parser regressions covering both the accepted `doctor` workflow value
+  and the help-text alignment.
+- Re-ran local validation; `coverage-gaps.py` passed as part of full `sm swab`,
+  covering the Codecov-style changed-lines concern for this follow-up.
+
+**Validation:**
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/pr169_followup_tests.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Commit, resolve the two open PR threads, verify, and push.
+
 ## 2026-05-04 Delta: Barnacle metadata redaction removed
 
 Branch: `feat/crowdsource-barnacles`  ·  PR `#169`

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,11 @@ Branch: `feat/crowdsource-barnacles`
 - Updated README and shared agent templates to describe barnacle issues, not a
   local cleanup queue.
 - Created the upstream GitHub `barnacle` label for issue triage.
+- Hardened filing to use `gh issue create --body-file`, preserve a retryable
+  `.slopmop/last_barnacle_issue.md` body artifact, mark bodies with
+  `Barnacle: true`, and support `--json` output for agents.
+- Added a Claude `/sm-barnacle` command template and updated installed
+  Claude/Copilot skill text so agents know when to file tool-friction reports.
 
 **Validation so far:**
 - `./sm barnacle file ... --dry-run` ✅
@@ -26,8 +31,13 @@ Branch: `feat/crowdsource-barnacles`
 - `./sm swab --no-cache --output-file .slopmop/last_swab.json` ✅
 - `./sm scour --output-file .slopmop/last_scour.json` ✅
   (known non-blocking dependency-risk warning remains)
+- `./sm barnacle file ... --body-file .tmp/barnacle-check.md --json --dry-run` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/barnacle_issue_tests.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅ after template updates
+- `./sm scour --output-file .slopmop/last_scour.json` ✅ after template updates
+  (known non-blocking dependency-risk warning remains)
 
-**Next:** Commit and push `feat/crowdsource-barnacles`.
+**Next:** Commit, push, and open PR.
 
 ## 2026-04-30 Delta: Timing history cache-poison fix
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,36 @@
 # Project Status
 
+## 2026-05-04 Delta: Barnacle metadata redaction removed
+
+Branch: `feat/crowdsource-barnacles`  ·  PR `#169`
+
+**Work completed:**
+- Removed the barnacle metadata redaction/opt-in path per product direction.
+- Barnacle issue bodies now include repo root, remote URL, branch, commit, cwd,
+  dirty state, platform, and agent metadata by default.
+- Removed `--include-sensitive-metadata` from `sm barnacle file` / `describe`.
+- Updated barnacle tests to expect raw metadata, including remote URL userinfo
+  when present.
+- Re-ran the real demo barnacle after removing redaction:
+  https://github.com/ScienceIsNeato/slop-mop/issues/171
+- Tightened missing-label retry detection so `[barnacle]` title text in an
+  unrelated `gh issue create` error no longer strips the barnacle label.
+
+**Validation:**
+- `./sm swab -g laziness:sloppy-formatting.py --output-file .slopmop/remove_redaction_format.json` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/remove_redaction_tests.json` ✅
+- `./sm barnacle file ... --json` ✅ filed issue #171 with raw metadata
+- `./sm swab --output-file .slopmop/last_swab.json` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+- `./sm swab -g laziness:sloppy-formatting.py --output-file .slopmop/remove_redaction_retry_format.json` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/remove_redaction_retry_tests.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅ after retry-detection fix
+- `./sm scour --output-file .slopmop/last_scour.json` ✅ after retry-detection fix
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Amend commit, resolve the Bugbot thread, and push.
+
 ## 2026-05-04 Delta: PR #169 buff feedback fixes
 
 Branch: `feat/crowdsource-barnacles`  ·  PR `#169`
@@ -10,8 +41,8 @@ Branch: `feat/crowdsource-barnacles`  ·  PR `#169`
   remained.
 - Fixed barnacle issue intake feedback:
   - Case-insensitive `[barnacle]` prefix stripping for issue summaries.
-  - Default-redacted repo/cwd/remote/branch/commit metadata, with explicit
-    `--include-sensitive-metadata` opt-in and remote URL userinfo redaction.
+  - Initially added default-redacted repo/cwd/remote/branch/commit metadata;
+    later removed in favor of always reporting raw metadata by default.
   - `sm barnacle describe` deprecation notice now goes to stderr so `--json`
     stdout stays machine-readable.
   - Reused the already-rendered issue body for dry-run, artifact writes, and

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,35 @@
 # Project Status
 
+## 2026-05-04 Delta: PR #169 buff feedback fixes
+
+Branch: `feat/crowdsource-barnacles`  ·  PR `#169`
+
+**Work completed:**
+- Ran `./sm buff inspect 169 --output-file .slopmop/last_buff_169.json` from
+  the PR worktree; CI triage was clean and 7 unresolved review threads
+  remained.
+- Fixed barnacle issue intake feedback:
+  - Case-insensitive `[barnacle]` prefix stripping for issue summaries.
+  - Default-redacted repo/cwd/remote/branch/commit metadata, with explicit
+    `--include-sensitive-metadata` opt-in and remote URL userinfo redaction.
+  - `sm barnacle describe` deprecation notice now goes to stderr so `--json`
+    stdout stays machine-readable.
+  - Reused the already-rendered issue body for dry-run, artifact writes, and
+    issue creation.
+  - `auto_file_barnacle` now returns only validated HTTP(S) issue URLs.
+  - Tests disable automatic upstream issue filing by default.
+  - Fixed `barnacle` verb indentation in `./sm --help`.
+
+**Validation:**
+- `./sm swab -g laziness:sloppy-formatting.py --output-file .slopmop/pr169_format.json` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/pr169_tests.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Final swab after this status update, commit, resolve addressed PR
+threads with `sm buff resolve`, then verify/push/watch.
+
 ## 2026-05-03 Delta: Barnacle issue intake replacement
 
 Branch: `feat/crowdsource-barnacles`

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,8 @@ Branch: `feat/crowdsource-barnacles`
   `Barnacle: true`, and support `--json` output for agents.
 - Added a Claude `/sm-barnacle` command template and updated installed
   Claude/Copilot skill text so agents know when to file tool-friction reports.
+- Moved `debugger-artifacts` from Deceptiveness to Laziness, including the
+  full gate name, flaw classification, config-path guidance, tests, and docs.
 
 **Validation so far:**
 - `./sm barnacle file ... --dry-run` ✅
@@ -35,6 +37,11 @@ Branch: `feat/crowdsource-barnacles`
 - `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/barnacle_issue_tests.json` ✅
 - `./sm swab --output-file .slopmop/last_swab.json` ✅ after template updates
 - `./sm scour --output-file .slopmop/last_scour.json` ✅ after template updates
+  (known non-blocking dependency-risk warning remains)
+- `./sm swab -g laziness:debugger-artifacts --no-cache --output-file .slopmop/debugger_artifacts_gate.json` ✅
+- `./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/untested_after_debugger_move.json` ✅
+- `./sm swab --output-file .slopmop/last_swab.json` ✅ after debugger-artifacts category move
+- `./sm scour --output-file .slopmop/last_scour.json` ✅ after debugger-artifacts category move
   (known non-blocking dependency-risk warning remains)
 
 **Next:** Commit, push, and open PR.

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -115,11 +115,14 @@ sm barnacle file \
   --tried "what you already tried" \
   --output "short relevant output excerpt" \
   --workflow swab \
-  --blocker-type blocking
+  --blocker-type blocking \
+  --json
 ```
 
 Use `--dry-run` if GitHub auth is unavailable and you need to capture the
-structured issue body for a human.
+structured issue body for a human. The generated body is written to
+`.slopmop/last_barnacle_issue.md` by default; pass `--body-file <path>` if you
+need a specific retry artifact location.
 
 #### After Filing
 - If the barnacle is non-blocking, continue the target-repo rail.

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -86,43 +86,46 @@ available. Otherwise, run CLI commands from the project root.
 
 ### Live Dogfood Protocol
 
-For live refit efforts in real target repositories, use barnacles to hand off
-tool friction to the slop-mop maintainer and immediately resume remediation.
+For live refit efforts in real target repositories, use barnacles to report
+slop-mop friction upstream instead of treating it as target-repo work.
 
 A **barnacle** is a defect or unexpected behaviour in slop-mop itself,
-discovered while using it in a real repository.  The barnacle queue lives at
-`~/.slopmop/barnacles/` so every agent on the machine shares the same pool.
+discovered while using it in a real repository. Barnacles are one-way GitHub
+issues in the slop-mop repo, tagged for maintainer triage. They are not a
+machine-local queue and they are not claimed or resolved from the target repo.
 
-#### State 1: Target Repository Remediation
+#### When To File
 - Work in the target repository using normal `sm` rails.
-- If friction appears (slowdown, weird behaviour, incorrect result), stop immediately.
-- File a barnacle from the affected repo:
-  ```
-  sm barnacle describe \
-    --command "sm <verb> [flags]" \
-    --expected "expected behaviour" \
-    --actual "what actually happened" \
-    --output "$(tail -20 .slopmop/last_swab.json 2>/dev/null)" \
-    --blocker-type blocking
-  ```
-- Note the barnacle ID and transition to State 2.
+- File a barnacle when slop-mop gives invalid guidance, blocks valid work,
+  produces a false positive/negative, or makes the next step unclear.
+- Do not file a barnacle for real target-repo lint, test, coverage, or review
+  failures. Fix those normally.
 
-#### State 2: Fix Slop-Mop Friction (cleaning agent)
-- Switch to a dedicated fix branch.
-- Implement the smallest targeted fix.
-- Validate with `sm swab`.
-- Commit and resolve:
-  ```
-  sm barnacle resolve <id> --commit $(git rev-parse --short HEAD) \
-    --branch $(git branch --show-current) --notes "brief description"
-  ```
-- Transition to State 3.
+#### How To File
+Run this from the affected repository:
 
-#### State 3: Test Fix Against Real Friction
-- Return to the original target-repo scenario and re-run the pinned command.
-- If the fix works: return to State 1.
-- If it fails: file a new barnacle with additional context and return to State 2.
+```bash
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "expected behaviour" \
+  --actual "what actually happened" \
+  --repro-step "first reproduction step" \
+  --repro-step "second reproduction step" \
+  --tried "what you already tried" \
+  --output "short relevant output excerpt" \
+  --workflow swab \
+  --blocker-type blocking
+```
+
+Use `--dry-run` if GitHub auth is unavailable and you need to capture the
+structured issue body for a human.
+
+#### After Filing
+- If the barnacle is non-blocking, continue the target-repo rail.
+- If it blocks forward progress, stop that rail and report the issue URL.
+- Do not invent a local workaround that hides the slop-mop defect.
 
 #### Core Rule
-- Never push through friction in State 1.  File a barnacle, fix slop-mop, and
-  prove the fix in the real target workflow before resuming.
+- Never push through genuine slop-mop friction. File a barnacle issue with
+  reproduction steps and let the upstream fix improve the tool for everyone.

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-barnacle.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-barnacle.md
@@ -1,0 +1,25 @@
+# /sm-barnacle — report slop-mop tool friction
+
+Use when `sm` itself gives invalid guidance, blocks valid work, produces
+confusing output, or breaks install/upgrade/refit flow.  Do not use this for
+real target-repo failures; fix those through the normal rail.
+
+```bash
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "what should have happened" \
+  --actual "what happened instead" \
+  --repro-step "how to reproduce it" \
+  --tried "what you already tried" \
+  --workflow swab \
+  --blocker-type blocking \
+  --json
+```
+
+Use `--dry-run` when GitHub auth is unavailable.  The generated issue body is
+written to `.slopmop/last_barnacle_issue.md`; pass `--body-file <path>` when a
+specific retry artifact path matters.
+
+The point is to improve the rail, not hide the defect.  File the barnacle, then
+continue only if the friction is non-blocking.

--- a/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
+++ b/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   directly — `sm swab` for fast iteration, `sm scour` before a PR,
   `sm buff` after CI or review feedback, `sm doctor` when the
   environment looks broken, `sm sail` when unsure what to do next.
+  Use `sm barnacle file` when slop-mop itself causes tool friction
+  that needs upstream maintainer triage.
 ---
 
 {{CORE}}

--- a/slopmop/agent_install/templates/copilot/.copilot/skills/slopmop/SKILL.md
+++ b/slopmop/agent_install/templates/copilot/.copilot/skills/slopmop/SKILL.md
@@ -16,6 +16,7 @@ Slop-mop (`sm`) is your procedural backbone for development in this repository. 
 - **During inherited remediation**: Run `sm refit --start`, then `sm refit --iterate` until the plan completes.
 - **Before PR**: Run `sm scour` for a comprehensive sweep.
 - **After CI/review**: Run `sm buff <PR_NUMBER>` to convert feedback into next steps.
+- **When sm itself breaks**: Run `sm barnacle file` from the affected repo to file a structured upstream issue with reproduction steps and context.
 
 ## The loop
 

--- a/slopmop/checks/quality/debugger_artifacts.py
+++ b/slopmop/checks/quality/debugger_artifacts.py
@@ -110,12 +110,12 @@ class DebuggerArtifactsCheck(BaseCheck):
 
     @property
     def category(self) -> GateCategory:
-        return GateCategory.DECEPTIVENESS
+        return GateCategory.LAZINESS
 
     @property
     def flaw(self) -> Flaw:
-        # "Look, I cleaned up before committing!" — no you didn't.
-        return Flaw.DECEPTIVENESS
+        # "I'll clean that up before committing" is exactly how this ships.
+        return Flaw.LAZINESS
 
     @property
     def config_schema(self) -> List[ConfigField]:
@@ -202,7 +202,7 @@ class DebuggerArtifactsCheck(BaseCheck):
                 "Remove the debugging statements above before committing. "
                 "If a directory is a false positive (e.g. a debugger test "
                 "suite), add it to "
-                "deceptiveness.gates.debugger-artifacts.exclude_dirs in "
+                "laziness.gates.debugger-artifacts.exclude_dirs in "
                 ".sb_config.json."
             ),
         )

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -17,6 +17,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlparse, urlunparse
 
 from slopmop.utils import git_current_branch, iso_now
 
@@ -94,27 +95,60 @@ def _git_dirty(project_root: str) -> bool:
     return bool(result.stdout.strip())
 
 
-def _collect_metadata(project_root: str, agent: str) -> Dict[str, Any]:
+def _redact_url(url: str) -> str:
+    """Strip embedded credentials from a git remote URL.
+
+    Only HTTPS/HTTP URLs can carry embedded credentials; SSH ``git@`` URLs
+    do not contain real secrets and are returned unchanged.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme in ("http", "https") and (parsed.username or parsed.password):
+            netloc = parsed.hostname or ""
+            if parsed.port:
+                netloc = f"{netloc}:{parsed.port}"
+            return urlunparse(parsed._replace(netloc=netloc))
+    except Exception:
+        pass
+    return url
+
+
+def _collect_metadata(
+    project_root: str, agent: str, include_sensitive: bool = False
+) -> Dict[str, Any]:
+    """Collect environment metadata for a barnacle issue.
+
+    By default only non-sensitive fields are included.  Pass
+    ``include_sensitive=True`` (via ``--include-sensitive-metadata``) to also
+    include the remote URL (with credentials redacted), the HEAD commit SHA,
+    and the current working directory.
+    """
     root = str(Path(project_root).resolve())
-    return {
+    repo: Dict[str, Any] = {
+        "root": root,
+        "branch": git_current_branch(root),
+        "dirty": _git_dirty(root),
+    }
+    if include_sensitive:
+        repo["remote"] = _redact_url(
+            _run_git(root, "config", "--get", "remote.origin.url")
+        )
+        repo["commit"] = _run_git(root, "rev-parse", "HEAD")
+    metadata: Dict[str, Any] = {
         "schema": SCHEMA_VERSION,
         "filed_at": iso_now(),
         "slopmop_version": _installed_slopmop_version(),
         "python_version": platform.python_version(),
         "platform": platform.platform(),
-        "cwd": os.getcwd(),
-        "repo": {
-            "root": root,
-            "remote": _run_git(root, "config", "--get", "remote.origin.url"),
-            "branch": git_current_branch(root),
-            "commit": _run_git(root, "rev-parse", "HEAD"),
-            "dirty": _git_dirty(root),
-        },
+        "repo": repo,
         "agent": {
             "name": agent,
             "source": os.environ.get("SLOPMOP_AGENT_SOURCE", "unknown"),
         },
     }
+    if include_sensitive:
+        metadata["cwd"] = os.getcwd()
+    return metadata
 
 
 def _fenced_block(language: str, content: str) -> str:
@@ -149,6 +183,7 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
     agent = getattr(args, "agent", None) or _default_agent()
     command = getattr(args, "command", "") or ""
     labels = tuple(getattr(args, "labels", None) or DEFAULT_LABELS)
+    include_sensitive = getattr(args, "include_sensitive_metadata", False)
     return BarnacleIssue(
         title=_issue_title(getattr(args, "title", "") or "", command),
         command=command,
@@ -164,7 +199,7 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
         labels=labels,
         reproduction_steps=getattr(args, "reproduction_steps", None) or [command],
         things_tried=getattr(args, "things_tried", None) or [],
-        metadata=_collect_metadata(project_root, agent),
+        metadata=_collect_metadata(project_root, agent, include_sensitive=include_sensitive),
     )
 
 
@@ -366,6 +401,7 @@ def auto_file_barnacle(
         dry_run=False,
         body_file=None,
         json_output=False,
+        include_sensitive_metadata=False,
     )
     try:
         issue = build_barnacle_issue(args)

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from slopmop.utils import git_current_branch, iso_now
 
@@ -195,6 +195,7 @@ def render_issue_body(issue: BarnacleIssue) -> str:
             _fenced_block("text", issue.output_excerpt),
             "",
             "### Impact",
+            "- Barnacle: true",
             f"- Blocker Type: {issue.blocker_type}",
             f"- Affected Workflow: {issue.workflow}",
             f"- Source Repository: {issue.project_root}{gate_line}",
@@ -206,7 +207,23 @@ def render_issue_body(issue: BarnacleIssue) -> str:
     )
 
 
-def _issue_create_command(issue: BarnacleIssue, labels: Sequence[str]) -> List[str]:
+def _default_body_file(issue: BarnacleIssue) -> Path:
+    return Path(issue.project_root) / ".slopmop" / "last_barnacle_issue.md"
+
+
+def write_issue_body_file(
+    issue: BarnacleIssue, body_file: Optional[str] = None
+) -> Path:
+    """Write the rendered issue body to a retryable Markdown artifact."""
+    path = Path(body_file) if body_file else _default_body_file(issue)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_issue_body(issue), encoding="utf-8")
+    return path
+
+
+def _issue_create_command(
+    issue: BarnacleIssue, labels: Sequence[str], body_file: Path
+) -> List[str]:
     command = [
         "gh",
         "issue",
@@ -215,19 +232,22 @@ def _issue_create_command(issue: BarnacleIssue, labels: Sequence[str]) -> List[s
         issue.repo,
         "--title",
         issue.title,
-        "--body",
-        render_issue_body(issue),
+        "--body-file",
+        str(body_file),
     ]
     for label in labels:
         command.extend(["--label", label])
     return command
 
 
-def create_barnacle_issue(issue: BarnacleIssue) -> subprocess.CompletedProcess[str]:
+def create_barnacle_issue(
+    issue: BarnacleIssue, body_file: Optional[str] = None
+) -> Tuple[subprocess.CompletedProcess[str], Path]:
     """Create the GitHub issue, retrying without the barnacle label if needed."""
+    issue_body_path = write_issue_body_file(issue, body_file)
     try:
         result = subprocess.run(
-            _issue_create_command(issue, issue.labels),
+            _issue_create_command(issue, issue.labels, issue_body_path),
             capture_output=True,
             text=True,
             check=False,
@@ -237,31 +257,52 @@ def create_barnacle_issue(issue: BarnacleIssue) -> subprocess.CompletedProcess[s
 
     missing_label = result.returncode != 0 and "barnacle" in result.stderr.lower()
     if not missing_label or "barnacle" not in issue.labels:
-        return result
+        return result, issue_body_path
 
     fallback_labels = tuple(label for label in issue.labels if label != "barnacle")
-    return subprocess.run(
-        _issue_create_command(issue, fallback_labels),
-        capture_output=True,
-        text=True,
-        check=False,
+    return (
+        subprocess.run(
+            _issue_create_command(issue, fallback_labels, issue_body_path),
+            capture_output=True,
+            text=True,
+            check=False,
+        ),
+        issue_body_path,
     )
+
+
+def _print_json(payload: Dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
 
 
 def cmd_barnacle_file(args: argparse.Namespace) -> int:
     """File a structured barnacle issue upstream."""
     issue = build_barnacle_issue(args)
     body = render_issue_body(issue)
+    body_file = getattr(args, "body_file", None)
     if getattr(args, "dry_run", False):
+        body_path = write_issue_body_file(issue, body_file)
+        if getattr(args, "json_output", False):
+            _print_json(
+                {
+                    "title": issue.title,
+                    "repo": issue.repo,
+                    "labels": list(issue.labels),
+                    "body_file": str(body_path),
+                    "body": body,
+                }
+            )
+            return 0
         print(f"Title: {issue.title}")
         print(f"Repo: {issue.repo}")
         print(f"Labels: {', '.join(issue.labels)}")
+        print(f"Body file: {body_path}")
         print()
         print(body)
         return 0
 
     try:
-        result = create_barnacle_issue(issue)
+        result, body_path = create_barnacle_issue(issue, body_file)
     except RuntimeError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         print("Re-run with --dry-run to capture the issue body.", file=sys.stderr)
@@ -271,12 +312,26 @@ def cmd_barnacle_file(args: argparse.Namespace) -> int:
         print("❌ Failed to file barnacle issue", file=sys.stderr)
         if result.stderr.strip():
             print(result.stderr.strip(), file=sys.stderr)
-        print("Re-run with --dry-run to capture the issue body.", file=sys.stderr)
+        print(f"Issue body preserved at: {body_path}", file=sys.stderr)
         return result.returncode
 
+    url = result.stdout.strip()
+    if getattr(args, "json_output", False):
+        _print_json(
+            {
+                "title": issue.title,
+                "repo": issue.repo,
+                "labels": list(issue.labels),
+                "body_file": str(body_path),
+                "url": url,
+            }
+        )
+        return 0
+
     print("🐚 Barnacle issue filed")
-    if result.stdout.strip():
-        print(result.stdout.strip())
+    if url:
+        print(url)
+    print(f"Body file: {body_path}")
     return 0
 
 
@@ -309,10 +364,12 @@ def auto_file_barnacle(
         repo=DEFAULT_REPO,
         labels=list(DEFAULT_LABELS),
         dry_run=False,
+        body_file=None,
+        json_output=False,
     )
     try:
         issue = build_barnacle_issue(args)
-        result = create_barnacle_issue(issue)
+        result, _body_path = create_barnacle_issue(issue)
     except Exception:
         return None
     if result.returncode != 0:

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -18,7 +18,6 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
-from urllib.parse import urlparse, urlunparse
 
 from slopmop.utils import git_current_branch, iso_now
 
@@ -30,7 +29,14 @@ AUTO_FILE_DISABLED_ENVAR = "SLOPMOP_DISABLE_BARNACLE_AUTO_FILE"
 
 HELP_AGENT = "Agent identifier (default: user@hostname)"
 _BARNACLE_PREFIX_RE = re.compile(r"^\[barnacle\]\s*", re.IGNORECASE)
-_REDACTED = "(redacted; pass --include-sensitive-metadata to include)"
+_MISSING_LABEL_MARKERS = (
+    "not found",
+    "does not exist",
+    "not exist",
+    "could not resolve",
+    "couldn't find",
+    "unable to resolve",
+)
 
 
 @dataclass(frozen=True)
@@ -52,7 +58,6 @@ class BarnacleIssue:
     reproduction_steps: Sequence[str]
     things_tried: Sequence[str]
     metadata: Dict[str, Any]
-    include_sensitive_metadata: bool = False
 
 
 def _default_agent() -> str:
@@ -100,61 +105,18 @@ def _git_dirty(project_root: str) -> bool:
     return bool(result.stdout.strip())
 
 
-def _redact_url(url: str) -> str:
-    """Strip embedded credentials from a git remote URL.
-
-    Only HTTPS/HTTP URLs can carry embedded credentials; SSH ``git@`` URLs
-    do not contain real secrets and are returned unchanged.
-    """
-    try:
-        parsed = urlparse(url)
-        if parsed.scheme in ("http", "https") and (parsed.username or parsed.password):
-            netloc = parsed.hostname or ""
-            if parsed.port:
-                netloc = f"{netloc}:{parsed.port}"
-            return urlunparse(
-                (
-                    parsed.scheme,
-                    netloc,
-                    parsed.path,
-                    parsed.params,
-                    parsed.query,
-                    parsed.fragment,
-                )
-            )
-    except Exception:
-        pass
-    return url
-
-
-def _repo_metadata(root: str, include_sensitive: bool) -> Dict[str, Any]:
-    if not include_sensitive:
-        return {
-            "root": _REDACTED,
-            "remote": _REDACTED,
-            "branch": _REDACTED,
-            "commit": _REDACTED,
-            "dirty": _git_dirty(root),
-        }
+def _repo_metadata(root: str) -> Dict[str, Any]:
     return {
         "root": root,
-        "remote": _redact_url(_run_git(root, "config", "--get", "remote.origin.url")),
+        "remote": _run_git(root, "config", "--get", "remote.origin.url"),
         "branch": git_current_branch(root),
         "commit": _run_git(root, "rev-parse", "HEAD"),
         "dirty": _git_dirty(root),
     }
 
 
-def _collect_metadata(
-    project_root: str, agent: str, include_sensitive: bool = False
-) -> Dict[str, Any]:
-    """Collect environment metadata for a barnacle issue.
-
-    By default only non-sensitive fields are included.  Pass
-    ``include_sensitive=True`` (via ``--include-sensitive-metadata``) to also
-    include the remote URL (with credentials redacted), the HEAD commit SHA,
-    and the current working directory.
-    """
+def _collect_metadata(project_root: str, agent: str) -> Dict[str, Any]:
+    """Collect environment metadata for a barnacle issue."""
     root = str(Path(project_root).resolve())
     metadata: Dict[str, Any] = {
         "schema": SCHEMA_VERSION,
@@ -162,8 +124,8 @@ def _collect_metadata(
         "slopmop_version": _installed_slopmop_version(),
         "python_version": platform.python_version(),
         "platform": platform.platform(),
-        "cwd": os.getcwd() if include_sensitive else _REDACTED,
-        "repo": _repo_metadata(root, include_sensitive),
+        "cwd": os.getcwd(),
+        "repo": _repo_metadata(root),
         "agent": {
             "name": agent,
             "source": os.environ.get("SLOPMOP_AGENT_SOURCE", "unknown"),
@@ -208,7 +170,6 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
     agent = getattr(args, "agent", None) or _default_agent()
     command = getattr(args, "command", "") or ""
     labels = tuple(getattr(args, "labels", None) or DEFAULT_LABELS)
-    include_sensitive = bool(getattr(args, "include_sensitive_metadata", False))
     return BarnacleIssue(
         title=_issue_title(getattr(args, "title", "") or "", command),
         command=command,
@@ -224,15 +185,13 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
         labels=labels,
         reproduction_steps=getattr(args, "reproduction_steps", None) or [command],
         things_tried=getattr(args, "things_tried", None) or [],
-        metadata=_collect_metadata(project_root, agent, include_sensitive),
-        include_sensitive_metadata=include_sensitive,
+        metadata=_collect_metadata(project_root, agent),
     )
 
 
 def render_issue_body(issue: BarnacleIssue) -> str:
     """Render the barnacle issue body as structured Markdown."""
     gate_line = f"\n- Gate: {issue.gate}" if issue.gate else ""
-    source_repo = issue.project_root if issue.include_sensitive_metadata else _REDACTED
     return "\n".join(
         [
             "### Barnacle Summary",
@@ -260,7 +219,7 @@ def render_issue_body(issue: BarnacleIssue) -> str:
             "- Barnacle: true",
             f"- Blocker Type: {issue.blocker_type}",
             f"- Affected Workflow: {issue.workflow}",
-            f"- Source Repository: {source_repo}{gate_line}",
+            f"- Source Repository: {issue.project_root}{gate_line}",
             "",
             "### Environment Metadata",
             _fenced_block("json", json.dumps(issue.metadata, indent=2, sort_keys=True)),
@@ -304,6 +263,13 @@ def _issue_create_command(
     return command
 
 
+def _is_missing_barnacle_label(stderr: str) -> bool:
+    text = stderr.lower()
+    if "label" not in text or "barnacle" not in text:
+        return False
+    return any(marker in text for marker in _MISSING_LABEL_MARKERS)
+
+
 def create_barnacle_issue(
     issue: BarnacleIssue, body_file: Optional[str] = None, body: Optional[str] = None
 ) -> Tuple[subprocess.CompletedProcess[str], Path]:
@@ -319,7 +285,7 @@ def create_barnacle_issue(
     except FileNotFoundError as exc:
         raise RuntimeError("GitHub CLI `gh` is required to file barnacles") from exc
 
-    missing_label = result.returncode != 0 and "barnacle" in result.stderr.lower()
+    missing_label = result.returncode != 0 and _is_missing_barnacle_label(result.stderr)
     if not missing_label or "barnacle" not in issue.labels:
         return result, issue_body_path
 
@@ -432,7 +398,6 @@ def auto_file_barnacle(
         dry_run=False,
         body_file=None,
         json_output=False,
-        include_sensitive_metadata=False,
     )
     try:
         issue = build_barnacle_issue(args)

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -1,162 +1,58 @@
-"""Barnacle queue — describe and resolve tool-friction reports.
+"""Barnacle issue intake for slop-mop tool-friction reports.
 
-A barnacle is a defect or friction point in slop-mop itself, discovered
-by an agent while using the tool in a real repository.  The queue lives
-at ``~/.slopmop/barnacles/`` (overridable via ``SLOPMOP_BARNACLE_DIR``)
-so every agent on the same machine can see and act on the same pool.
-
-Lifecycle
----------
-open  →  resolved
-
-Agents discover friction and run ``sm barnacle describe``.
-Once fixed, they run ``sm barnacle resolve`` with the fix commit.
-
-The barnacle verb mirrors the swab/scour/buff nautical theme: every
-agent is both a detector and a potential cleaner.
+A barnacle is a defect or friction point in slop-mop itself, discovered while
+using the tool in a real repository. Barnacles are one-way upstream reports:
+``sm barnacle file`` creates a structured GitHub issue in the slop-mop repo.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
-import re
+import platform
 import socket
+import subprocess
 import sys
-import time
-from datetime import datetime, timezone
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from slopmop.utils import git_current_branch, iso_now
 
-SCHEMA_VERSION = "slopmop/barnacle/v1"
-
-# Status constants
-STATUS_OPEN = "open"
-STATUS_RESOLVED = "resolved"
-
+SCHEMA_VERSION = "slopmop/barnacle-issue/v1"
+DEFAULT_REPO = "ScienceIsNeato/slop-mop"
+DEFAULT_LABELS = ("barnacle", "bug")
 BLOCKER_BLOCKING = "blocking"
 
-# Environment variable to override queue location (primarily for tests)
-QUEUE_DIR_ENVAR = "SLOPMOP_BARNACLE_DIR"
-
-# Shared error/help strings (re-used across handlers and the argparse spec)
-ERR_MISSING_ID = "❌ barnacle_id required"
-ERR_NOT_FOUND_FMT = "❌ Barnacle not found: {}"
 HELP_AGENT = "Agent identifier (default: user@hostname)"
-HELP_BARNACLE_ID = "Full or prefix barnacle ID"
-
-_STATUS_ICONS = {
-    STATUS_OPEN: "🔴",
-    STATUS_RESOLVED: "✅",
-}
 
 
-# ---------------------------------------------------------------------------
-# Queue directory helpers
-# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class BarnacleIssue:
+    """Structured payload for a barnacle issue."""
 
-
-def _queue_dir() -> Path:
-    override = os.environ.get(QUEUE_DIR_ENVAR)
-    if override:
-        return Path(override)
-    return Path.home() / ".slopmop" / "barnacles"
-
-
-def _short_id() -> str:
-    raw = f"{time.time_ns()}{os.getpid()}".encode()
-    return hashlib.sha256(raw).hexdigest()[:8]
-
-
-def _barnacle_id() -> str:
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    return f"barnacle-{ts}-{_short_id()}"
+    title: str
+    command: str
+    expected: str
+    actual: str
+    output_excerpt: str
+    blocker_type: str
+    workflow: str
+    project_root: str
+    gate: Optional[str]
+    agent: str
+    repo: str
+    labels: Sequence[str]
+    reproduction_steps: Sequence[str]
+    things_tried: Sequence[str]
+    metadata: Dict[str, Any]
 
 
 def _default_agent() -> str:
     user = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
     host = socket.gethostname()
     return f"{user}@{host}"
-
-
-def _barnacle_path(bid: str) -> Path:
-    return _queue_dir() / f"{bid}.json"
-
-
-def _read_barnacle(path: Path) -> Dict[str, Any]:
-    return json.loads(path.read_text())  # type: ignore[no-any-return]
-
-
-def _write_barnacle(data: Dict[str, Any]) -> Path:
-    qdir = _queue_dir()
-    qdir.mkdir(parents=True, exist_ok=True)
-    path = _barnacle_path(data["id"])
-    path.write_text(json.dumps(data, indent=2))
-    return path
-
-
-def _list_barnacles(status_filter: Optional[str] = None) -> List[Dict[str, Any]]:
-    qdir = _queue_dir()
-    if not qdir.exists():
-        return []
-    results: List[Dict[str, Any]] = []
-    for p in sorted(qdir.glob("barnacle-*.json")):
-        try:
-            b = _read_barnacle(p)
-        except (json.JSONDecodeError, OSError):
-            continue
-        if not isinstance(b, dict) or "id" not in b or "status" not in b:
-            continue  # skip corrupted entries
-        if status_filter and status_filter != "all":
-            if b.get("status") != status_filter:
-                continue
-        results.append(b)
-    return results
-
-
-_SAFE_PREFIX_RE = re.compile(r"^[a-zA-Z0-9\-_]+$")
-
-
-def _find_barnacle(bid_prefix: str) -> Optional[Dict[str, Any]]:
-    """Find a barnacle by full or prefix ID.
-
-    Iterates only ``barnacle-*.json`` within the queue dir and matches on
-    ``Path.stem.startswith(bid_prefix)`` after validating the prefix contains
-    only safe characters.  Returns ``None`` if 0 or >1 matches are found.
-    """
-    if not _SAFE_PREFIX_RE.match(bid_prefix):
-        print(
-            f"❌ Invalid barnacle ID prefix (unsafe characters): {bid_prefix!r}",
-            file=sys.stderr,
-        )
-        return None
-    qdir = _queue_dir()
-    if not qdir.exists():
-        print(ERR_NOT_FOUND_FMT.format(bid_prefix), file=sys.stderr)
-        return None
-    matches: List[Dict[str, Any]] = []
-    for p in sorted(qdir.glob("barnacle-*.json")):
-        if not p.stem.startswith(bid_prefix):
-            continue
-        try:
-            matches.append(_read_barnacle(p))
-        except (json.JSONDecodeError, OSError):
-            continue
-    if len(matches) == 0:
-        print(ERR_NOT_FOUND_FMT.format(bid_prefix), file=sys.stderr)
-        return None
-    if len(matches) > 1:
-        print(
-            f"❌ Ambiguous prefix '{bid_prefix}' matches {len(matches)} barnacles;"
-            " use a longer prefix.",
-            file=sys.stderr,
-        )
-        return None
-    return matches[0]
 
 
 def _installed_slopmop_version() -> str:
@@ -168,9 +64,220 @@ def _installed_slopmop_version() -> str:
         return "unknown"
 
 
-# ---------------------------------------------------------------------------
-# Public auto-file helper (called by other sm commands)
-# ---------------------------------------------------------------------------
+def _run_git(project_root: str, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _git_dirty(project_root: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        return False
+    return bool(result.stdout.strip())
+
+
+def _collect_metadata(project_root: str, agent: str) -> Dict[str, Any]:
+    root = str(Path(project_root).resolve())
+    return {
+        "schema": SCHEMA_VERSION,
+        "filed_at": iso_now(),
+        "slopmop_version": _installed_slopmop_version(),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "cwd": os.getcwd(),
+        "repo": {
+            "root": root,
+            "remote": _run_git(root, "config", "--get", "remote.origin.url"),
+            "branch": git_current_branch(root),
+            "commit": _run_git(root, "rev-parse", "HEAD"),
+            "dirty": _git_dirty(root),
+        },
+        "agent": {
+            "name": agent,
+            "source": os.environ.get("SLOPMOP_AGENT_SOURCE", "unknown"),
+        },
+    }
+
+
+def _fenced_block(language: str, content: str) -> str:
+    body = content.strip() or "(none provided)"
+    return f"```{language}\n{body}\n```"
+
+
+def _bullets(values: Sequence[str]) -> str:
+    cleaned = [value.strip() for value in values if value and value.strip()]
+    if not cleaned:
+        return "- (none provided)"
+    return "\n".join(f"- {value}" for value in cleaned)
+
+
+def _numbered(values: Sequence[str]) -> str:
+    cleaned = [value.strip() for value in values if value and value.strip()]
+    if not cleaned:
+        return "1. (none provided)"
+    return "\n".join(f"{idx}. {value}" for idx, value in enumerate(cleaned, 1))
+
+
+def _issue_title(raw_title: str, command: str) -> str:
+    title = raw_title.strip() or f"slop-mop friction while running {command}"
+    if title.lower().startswith("[barnacle]"):
+        return title
+    return f"[barnacle] {title}"
+
+
+def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
+    """Build a normalized barnacle issue from parsed CLI arguments."""
+    project_root = str(Path(getattr(args, "project_root", ".")).resolve())
+    agent = getattr(args, "agent", None) or _default_agent()
+    command = getattr(args, "command", "") or ""
+    labels = tuple(getattr(args, "labels", None) or DEFAULT_LABELS)
+    return BarnacleIssue(
+        title=_issue_title(getattr(args, "title", "") or "", command),
+        command=command,
+        expected=getattr(args, "expected", "") or "",
+        actual=getattr(args, "actual", "") or "",
+        output_excerpt=getattr(args, "output_excerpt", "") or "",
+        blocker_type=getattr(args, "blocker_type", BLOCKER_BLOCKING),
+        workflow=getattr(args, "workflow", "unknown") or "unknown",
+        project_root=project_root,
+        gate=getattr(args, "gate", None),
+        agent=agent,
+        repo=getattr(args, "repo", DEFAULT_REPO) or DEFAULT_REPO,
+        labels=labels,
+        reproduction_steps=getattr(args, "reproduction_steps", None) or [command],
+        things_tried=getattr(args, "things_tried", None) or [],
+        metadata=_collect_metadata(project_root, agent),
+    )
+
+
+def render_issue_body(issue: BarnacleIssue) -> str:
+    """Render the barnacle issue body as structured Markdown."""
+    gate_line = f"\n- Gate: {issue.gate}" if issue.gate else ""
+    return "\n".join(
+        [
+            "### Barnacle Summary",
+            issue.title.removeprefix("[barnacle] "),
+            "",
+            "### Current Behavior",
+            issue.actual or "(none provided)",
+            "",
+            "### Expected Behavior",
+            issue.expected or "(none provided)",
+            "",
+            "### Command",
+            _fenced_block("bash", issue.command),
+            "",
+            "### Reproduction Steps",
+            _numbered(issue.reproduction_steps),
+            "",
+            "### Things Tried",
+            _bullets(issue.things_tried),
+            "",
+            "### Output Excerpt",
+            _fenced_block("text", issue.output_excerpt),
+            "",
+            "### Impact",
+            f"- Blocker Type: {issue.blocker_type}",
+            f"- Affected Workflow: {issue.workflow}",
+            f"- Source Repository: {issue.project_root}{gate_line}",
+            "",
+            "### Environment Metadata",
+            _fenced_block("json", json.dumps(issue.metadata, indent=2, sort_keys=True)),
+            "",
+        ]
+    )
+
+
+def _issue_create_command(issue: BarnacleIssue, labels: Sequence[str]) -> List[str]:
+    command = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        issue.repo,
+        "--title",
+        issue.title,
+        "--body",
+        render_issue_body(issue),
+    ]
+    for label in labels:
+        command.extend(["--label", label])
+    return command
+
+
+def create_barnacle_issue(issue: BarnacleIssue) -> subprocess.CompletedProcess[str]:
+    """Create the GitHub issue, retrying without the barnacle label if needed."""
+    try:
+        result = subprocess.run(
+            _issue_create_command(issue, issue.labels),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("GitHub CLI `gh` is required to file barnacles") from exc
+
+    missing_label = result.returncode != 0 and "barnacle" in result.stderr.lower()
+    if not missing_label or "barnacle" not in issue.labels:
+        return result
+
+    fallback_labels = tuple(label for label in issue.labels if label != "barnacle")
+    return subprocess.run(
+        _issue_create_command(issue, fallback_labels),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def cmd_barnacle_file(args: argparse.Namespace) -> int:
+    """File a structured barnacle issue upstream."""
+    issue = build_barnacle_issue(args)
+    body = render_issue_body(issue)
+    if getattr(args, "dry_run", False):
+        print(f"Title: {issue.title}")
+        print(f"Repo: {issue.repo}")
+        print(f"Labels: {', '.join(issue.labels)}")
+        print()
+        print(body)
+        return 0
+
+    try:
+        result = create_barnacle_issue(issue)
+    except RuntimeError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        print("Re-run with --dry-run to capture the issue body.", file=sys.stderr)
+        return 1
+
+    if result.returncode != 0:
+        print("❌ Failed to file barnacle issue", file=sys.stderr)
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        print("Re-run with --dry-run to capture the issue body.", file=sys.stderr)
+        return result.returncode
+
+    print("🐚 Barnacle issue filed")
+    if result.stdout.strip():
+        print(result.stdout.strip())
+    return 0
 
 
 def auto_file_barnacle(
@@ -183,221 +290,42 @@ def auto_file_barnacle(
     blocker_type: str = BLOCKER_BLOCKING,
     project_root: Optional[str] = None,
     reproduction_steps: Optional[List[str]] = None,
+    workflow: str = "unknown",
 ) -> Optional[str]:
-    """Auto-file a barnacle from within a slop-mop command.
-
-    Called by commands that can self-detect tool defects (e.g. ``sm upgrade``
-    when post-install validation fails unexpectedly).
-
-    Returns the barnacle ID on success, None if filing fails (never raises).
-    """
+    """Best-effort compatibility wrapper that files a barnacle issue."""
+    args = argparse.Namespace(
+        title="automated slop-mop friction report",
+        command=command,
+        gate=gate,
+        expected=expected,
+        actual=actual,
+        output_excerpt=output_excerpt,
+        blocker_type=blocker_type,
+        project_root=project_root or ".",
+        reproduction_steps=reproduction_steps or [command],
+        things_tried=[],
+        workflow=workflow,
+        agent=None,
+        repo=DEFAULT_REPO,
+        labels=list(DEFAULT_LABELS),
+        dry_run=False,
+    )
     try:
-        _queue_dir().mkdir(parents=True, exist_ok=True)
-        branch = git_current_branch(project_root) if project_root else "unknown"
-        bid = _barnacle_id()
-        data: Dict[str, Any] = {
-            "schema": SCHEMA_VERSION,
-            "id": bid,
-            "filed_at": iso_now(),
-            "status": STATUS_OPEN,
-            "filed_by": {
-                "agent": _default_agent(),
-                "repo": project_root or "unknown",
-                "branch": branch,
-                "slopmop_version": _installed_slopmop_version(),
-            },
-            "command": command,
-            "gate": gate,
-            "blocker_type": blocker_type,
-            "expected": expected,
-            "actual": actual,
-            "output_excerpt": output_excerpt,
-            "reproduction_steps": reproduction_steps or [command],
-            "auto_filed": True,
-            "resolution": None,
-        }
-        _write_barnacle(data)
-        return bid
+        issue = build_barnacle_issue(args)
+        result = create_barnacle_issue(issue)
     except Exception:
         return None
-
-
-# ---------------------------------------------------------------------------
-# Subcommand handlers
-# ---------------------------------------------------------------------------
-
-
-def cmd_barnacle_describe(args: argparse.Namespace) -> int:
-    """Describe a new barnacle."""
-    project_root = str(Path(getattr(args, "project_root", ".")).resolve())
-    bid = _barnacle_id()
-    data: Dict[str, Any] = {
-        "schema": SCHEMA_VERSION,
-        "id": bid,
-        "filed_at": iso_now(),
-        "status": STATUS_OPEN,
-        "filed_by": {
-            "agent": getattr(args, "agent", None) or _default_agent(),
-            "repo": project_root,
-            "branch": git_current_branch(project_root),
-            "slopmop_version": _installed_slopmop_version(),
-        },
-        "command": getattr(args, "command", "") or "",
-        "gate": getattr(args, "gate", None),
-        "blocker_type": getattr(args, "blocker_type", BLOCKER_BLOCKING),
-        "expected": getattr(args, "expected", "") or "",
-        "actual": getattr(args, "actual", "") or "",
-        "output_excerpt": getattr(args, "output_excerpt", "") or "",
-        "reproduction_steps": getattr(args, "reproduction_steps", None)
-        or [getattr(args, "command", "") or ""],
-        "auto_filed": False,
-        "resolution": None,
-    }
-    path = _write_barnacle(data)
-    print(f"🐚 Barnacle described: {bid}")
-    print(f"   {path}")
-    print(f"   Blocker: {data['blocker_type']}")
-    print()
-    print(f"Resolve it with:")
-    print(f"  sm barnacle resolve {bid} --commit <SHA> --branch <branch>")
-    return 0
-
-
-def cmd_barnacle_list(args: argparse.Namespace) -> int:
-    """List barnacles in the queue."""
-    status_filter = getattr(args, "status", STATUS_OPEN)
-    barnacles = _list_barnacles(status_filter)
-    if not barnacles:
-        label = "no" if status_filter == "all" else f"no {status_filter}"
-        print(f"🐚 {label.capitalize()} barnacles  ({_queue_dir()})")
-        return 0
-
-    print(f"🐚 Barnacles  ({_queue_dir()})")
-    for b in barnacles:
-        status = b.get("status", "?")
-        icon = _STATUS_ICONS.get(status, "❓")
-        blocker = "  [BLOCKING]" if b.get("blocker_type") == BLOCKER_BLOCKING else ""
-        filed_by = b.get("filed_by", {})
-        repo = Path(filed_by.get("repo", "?")).name
-        date = b.get("filed_at", "?")[:10]
-        print(f"  {icon} {b['id']}{blocker}")
-        print(f"     {b.get('command', '?')} · {repo} · {date}")
-    return 0
-
-
-def _print_barnacle(b: Dict[str, Any]) -> None:
-    status = b.get("status", "?")
-    icon = _STATUS_ICONS.get(status, "❓")
-    filed_by = b.get("filed_by", {})
-    print(f"🐚 {b['id']}")
-    print(f"   Status:  {icon} {status}")
-    print(f"   Filed:   {b.get('filed_at', '?')}")
-    print(f"   By:      {filed_by.get('agent', '?')}")
-    print(f"   Repo:    {filed_by.get('repo', '?')}  ({filed_by.get('branch', '?')})")
-    print(f"   Version: {filed_by.get('slopmop_version', '?')}")
-    print(f"   Blocker: {b.get('blocker_type', '?')}")
-    print(f"   Command: {b.get('command', '?')}")
-    if b.get("gate"):
-        print(f"   Gate:    {b['gate']}")
-    print()
-    print(f"Expected:")
-    print(f"  {b.get('expected', '(none)')}")
-    print()
-    print(f"Actual:")
-    print(f"  {b.get('actual', '(none)')}")
-    if b.get("output_excerpt"):
-        print()
-        print("Output excerpt:")
-        for line in b["output_excerpt"].strip().splitlines()[:20]:
-            print(f"  {line}")
-    if b.get("reproduction_steps"):
-        print()
-        print("Reproduction steps:")
-        for i, step in enumerate(b["reproduction_steps"], 1):
-            print(f"  {i}. {step}")
-    if b.get("resolution"):
-        res = b["resolution"]
-        print()
-        print(f"Resolved by: {res.get('agent', '?')}  at {res.get('resolved_at', '?')}")
-        if res.get("fix_commit"):
-            print(f"  Commit: {res['fix_commit']}")
-        if res.get("fix_branch"):
-            print(f"  Branch: {res['fix_branch']}")
-        if res.get("notes"):
-            print(f"  Notes:  {res['notes']}")
-
-
-def cmd_barnacle_show(args: argparse.Namespace) -> int:
-    """Show full details for one barnacle."""
-    bid = getattr(args, "barnacle_id", None)
-    if not bid:
-        print(ERR_MISSING_ID, file=sys.stderr)
-        return 1
-    b = _find_barnacle(bid)
-    if not b:
-        return 1
-    if getattr(args, "json_output", False):
-        print(json.dumps(b, indent=2))
-        return 0
-    _print_barnacle(b)
-    return 0
-
-
-def cmd_barnacle_resolve(args: argparse.Namespace) -> int:
-    """Resolve a barnacle with fix details."""
-    bid = getattr(args, "barnacle_id", None)
-    if not bid:
-        print(ERR_MISSING_ID, file=sys.stderr)
-        return 1
-    b = _find_barnacle(bid)
-    if not b:
-        return 1
-    if b.get("status") == STATUS_RESOLVED:
-        print("⚠️  Already resolved")
-        return 0
-
-    agent = getattr(args, "agent", None) or _default_agent()
-    resolution: Dict[str, Any] = {
-        "agent": agent,
-        "resolved_at": iso_now(),
-        "fix_commit": getattr(args, "commit", None),
-        "fix_branch": getattr(args, "branch", None),
-        "notes": getattr(args, "notes", None),
-    }
-    b["status"] = STATUS_RESOLVED
-    b["resolution"] = resolution
-    _write_barnacle(b)
-
-    print(f"✅ Resolved {b['id']}")
-    if resolution.get("fix_commit"):
-        print(f"   Commit: {resolution['fix_commit']}")
-    if resolution.get("fix_branch"):
-        print(f"   Branch: {resolution['fix_branch']}")
-    if resolution.get("notes"):
-        print(f"   Notes:  {resolution['notes']}")
-    print()
-    repo = b.get("filed_by", {}).get("repo", "?")
-    print(f"Original reporter can verify in:")
-    print(f"  {repo}")
-    return 0
-
-
-# ---------------------------------------------------------------------------
-# Top-level dispatcher
-# ---------------------------------------------------------------------------
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or issue.title
 
 
 def cmd_barnacle(args: argparse.Namespace) -> int:
     """Dispatch barnacle subcommands."""
     action = getattr(args, "barnacle_action", None)
-    dispatch = {
-        "describe": cmd_barnacle_describe,
-        "list": cmd_barnacle_list,
-        "show": cmd_barnacle_show,
-        "resolve": cmd_barnacle_resolve,
-    }
-    handler = dispatch.get(action or "")
-    if not handler:
-        print("Usage: sm barnacle <describe|list|show|resolve>")
-        return 2
-    return handler(args)
+    if action in {"file", "describe"}:
+        if action == "describe":
+            print("sm barnacle describe is deprecated; use sm barnacle file.")
+        return cmd_barnacle_file(args)
+    print("Usage: sm barnacle file --command <cmd> --expected <text> --actual <text>")
+    return 2

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import socket
 import subprocess
 import sys
@@ -25,8 +26,11 @@ SCHEMA_VERSION = "slopmop/barnacle-issue/v1"
 DEFAULT_REPO = "ScienceIsNeato/slop-mop"
 DEFAULT_LABELS = ("barnacle", "bug")
 BLOCKER_BLOCKING = "blocking"
+AUTO_FILE_DISABLED_ENVAR = "SLOPMOP_DISABLE_BARNACLE_AUTO_FILE"
 
 HELP_AGENT = "Agent identifier (default: user@hostname)"
+_BARNACLE_PREFIX_RE = re.compile(r"^\[barnacle\]\s*", re.IGNORECASE)
+_REDACTED = "(redacted; pass --include-sensitive-metadata to include)"
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,7 @@ class BarnacleIssue:
     reproduction_steps: Sequence[str]
     things_tried: Sequence[str]
     metadata: Dict[str, Any]
+    include_sensitive_metadata: bool = False
 
 
 def _default_agent() -> str:
@@ -108,11 +113,36 @@ def _redact_url(url: str) -> str:
             if parsed.port:
                 netloc = f"{netloc}:{parsed.port}"
             return urlunparse(
-                (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+                (
+                    parsed.scheme,
+                    netloc,
+                    parsed.path,
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment,
+                )
             )
     except Exception:
         pass
     return url
+
+
+def _repo_metadata(root: str, include_sensitive: bool) -> Dict[str, Any]:
+    if not include_sensitive:
+        return {
+            "root": _REDACTED,
+            "remote": _REDACTED,
+            "branch": _REDACTED,
+            "commit": _REDACTED,
+            "dirty": _git_dirty(root),
+        }
+    return {
+        "root": root,
+        "remote": _redact_url(_run_git(root, "config", "--get", "remote.origin.url")),
+        "branch": git_current_branch(root),
+        "commit": _run_git(root, "rev-parse", "HEAD"),
+        "dirty": _git_dirty(root),
+    }
 
 
 def _collect_metadata(
@@ -126,30 +156,19 @@ def _collect_metadata(
     and the current working directory.
     """
     root = str(Path(project_root).resolve())
-    repo: Dict[str, Any] = {
-        "root": root,
-        "branch": git_current_branch(root),
-        "dirty": _git_dirty(root),
-    }
-    if include_sensitive:
-        repo["remote"] = _redact_url(
-            _run_git(root, "config", "--get", "remote.origin.url")
-        )
-        repo["commit"] = _run_git(root, "rev-parse", "HEAD")
     metadata: Dict[str, Any] = {
         "schema": SCHEMA_VERSION,
         "filed_at": iso_now(),
         "slopmop_version": _installed_slopmop_version(),
         "python_version": platform.python_version(),
         "platform": platform.platform(),
-        "repo": repo,
+        "cwd": os.getcwd() if include_sensitive else _REDACTED,
+        "repo": _repo_metadata(root, include_sensitive),
         "agent": {
             "name": agent,
             "source": os.environ.get("SLOPMOP_AGENT_SOURCE", "unknown"),
         },
     }
-    if include_sensitive:
-        metadata["cwd"] = os.getcwd()
     return metadata
 
 
@@ -174,9 +193,13 @@ def _numbered(values: Sequence[str]) -> str:
 
 def _issue_title(raw_title: str, command: str) -> str:
     title = raw_title.strip() or f"slop-mop friction while running {command}"
-    if title.lower().startswith("[barnacle]"):
+    if _BARNACLE_PREFIX_RE.match(title):
         return title
     return f"[barnacle] {title}"
+
+
+def _issue_summary(title: str) -> str:
+    return _BARNACLE_PREFIX_RE.sub("", title).strip() or title
 
 
 def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
@@ -185,7 +208,7 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
     agent = getattr(args, "agent", None) or _default_agent()
     command = getattr(args, "command", "") or ""
     labels = tuple(getattr(args, "labels", None) or DEFAULT_LABELS)
-    include_sensitive = getattr(args, "include_sensitive_metadata", False)
+    include_sensitive = bool(getattr(args, "include_sensitive_metadata", False))
     return BarnacleIssue(
         title=_issue_title(getattr(args, "title", "") or "", command),
         command=command,
@@ -201,17 +224,19 @@ def build_barnacle_issue(args: argparse.Namespace) -> BarnacleIssue:
         labels=labels,
         reproduction_steps=getattr(args, "reproduction_steps", None) or [command],
         things_tried=getattr(args, "things_tried", None) or [],
-        metadata=_collect_metadata(project_root, agent, include_sensitive=include_sensitive),
+        metadata=_collect_metadata(project_root, agent, include_sensitive),
+        include_sensitive_metadata=include_sensitive,
     )
 
 
 def render_issue_body(issue: BarnacleIssue) -> str:
     """Render the barnacle issue body as structured Markdown."""
     gate_line = f"\n- Gate: {issue.gate}" if issue.gate else ""
+    source_repo = issue.project_root if issue.include_sensitive_metadata else _REDACTED
     return "\n".join(
         [
             "### Barnacle Summary",
-            issue.title.removeprefix("[barnacle] "),
+            _issue_summary(issue.title),
             "",
             "### Current Behavior",
             issue.actual or "(none provided)",
@@ -235,7 +260,7 @@ def render_issue_body(issue: BarnacleIssue) -> str:
             "- Barnacle: true",
             f"- Blocker Type: {issue.blocker_type}",
             f"- Affected Workflow: {issue.workflow}",
-            f"- Source Repository: {issue.project_root}{gate_line}",
+            f"- Source Repository: {source_repo}{gate_line}",
             "",
             "### Environment Metadata",
             _fenced_block("json", json.dumps(issue.metadata, indent=2, sort_keys=True)),
@@ -249,12 +274,14 @@ def _default_body_file(issue: BarnacleIssue) -> Path:
 
 
 def write_issue_body_file(
-    issue: BarnacleIssue, body_file: Optional[str] = None
+    issue: BarnacleIssue, body_file: Optional[str] = None, body: Optional[str] = None
 ) -> Path:
     """Write the rendered issue body to a retryable Markdown artifact."""
     path = Path(body_file) if body_file else _default_body_file(issue)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(render_issue_body(issue), encoding="utf-8")
+    path.write_text(
+        body if body is not None else render_issue_body(issue), encoding="utf-8"
+    )
     return path
 
 
@@ -278,10 +305,10 @@ def _issue_create_command(
 
 
 def create_barnacle_issue(
-    issue: BarnacleIssue, body_file: Optional[str] = None
+    issue: BarnacleIssue, body_file: Optional[str] = None, body: Optional[str] = None
 ) -> Tuple[subprocess.CompletedProcess[str], Path]:
     """Create the GitHub issue, retrying without the barnacle label if needed."""
-    issue_body_path = write_issue_body_file(issue, body_file)
+    issue_body_path = write_issue_body_file(issue, body_file, body)
     try:
         result = subprocess.run(
             _issue_create_command(issue, issue.labels, issue_body_path),
@@ -318,7 +345,7 @@ def cmd_barnacle_file(args: argparse.Namespace) -> int:
     body = render_issue_body(issue)
     body_file = getattr(args, "body_file", None)
     if getattr(args, "dry_run", False):
-        body_path = write_issue_body_file(issue, body_file)
+        body_path = write_issue_body_file(issue, body_file, body)
         if getattr(args, "json_output", False):
             _print_json(
                 {
@@ -339,7 +366,7 @@ def cmd_barnacle_file(args: argparse.Namespace) -> int:
         return 0
 
     try:
-        result, body_path = create_barnacle_issue(issue, body_file)
+        result, body_path = create_barnacle_issue(issue, body_file, body)
     except RuntimeError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         print("Re-run with --dry-run to capture the issue body.", file=sys.stderr)
@@ -385,6 +412,8 @@ def auto_file_barnacle(
     workflow: str = "unknown",
 ) -> Optional[str]:
     """Best-effort compatibility wrapper that files a barnacle issue."""
+    if os.environ.get(AUTO_FILE_DISABLED_ENVAR):
+        return None
     args = argparse.Namespace(
         title="automated slop-mop friction report",
         command=command,
@@ -412,7 +441,10 @@ def auto_file_barnacle(
         return None
     if result.returncode != 0:
         return None
-    return result.stdout.strip() or issue.title
+    url = result.stdout.strip()
+    if url.startswith(("http://", "https://")):
+        return url
+    return None
 
 
 def cmd_barnacle(args: argparse.Namespace) -> int:
@@ -420,7 +452,10 @@ def cmd_barnacle(args: argparse.Namespace) -> int:
     action = getattr(args, "barnacle_action", None)
     if action in {"file", "describe"}:
         if action == "describe":
-            print("sm barnacle describe is deprecated; use sm barnacle file.")
+            print(
+                "sm barnacle describe is deprecated; use sm barnacle file.",
+                file=sys.stderr,
+            )
         return cmd_barnacle_file(args)
     print("Usage: sm barnacle file --command <cmd> --expected <text> --actual <text>")
     return 2

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -107,7 +107,9 @@ def _redact_url(url: str) -> str:
             netloc = parsed.hostname or ""
             if parsed.port:
                 netloc = f"{netloc}:{parsed.port}"
-            return urlunparse(parsed._replace(netloc=netloc))
+            return urlunparse(
+                (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+            )
     except Exception:
         pass
     return url

--- a/slopmop/cli/upgrade.py
+++ b/slopmop/cli/upgrade.py
@@ -450,25 +450,26 @@ def cmd_upgrade(args: argparse.Namespace) -> int:
         if details:
             print(details, file=sys.stderr)
 
-        # Auto-file a barnacle so cleaning agents can pick it up.
+        # Auto-file a barnacle issue upstream for slop-mop maintainers.
         try:
             from slopmop.cli.barnacle import auto_file_barnacle  # noqa: PLC0415
 
-            bid = auto_file_barnacle(
+            issue_url = auto_file_barnacle(
                 command=f"sm upgrade  (→ {installed_version})",
                 expected="Post-upgrade validation (sm swab) passes clean",
                 actual=f"sm {VALIDATION_VERB} exited {validation.returncode}",
                 output_excerpt=details[:2000] if details else "",
                 blocker_type="blocking",
                 project_root=str(project_root),
+                workflow="upgrade",
                 reproduction_steps=[
                     f"sm upgrade --to-version {installed_version}",
                     f"sm {VALIDATION_VERB}",
                 ],
             )
-            if bid:
+            if issue_url:
                 print(
-                    f"🐚 Barnacle auto-filed: {bid}\n" f"  (sm barnacle show {bid})",
+                    "🐚 Barnacle issue auto-filed:\n" f"  {issue_url}",
                     file=sys.stderr,
                 )
         except Exception:

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -881,8 +881,9 @@ def _add_barnacle_parser(
             dest="include_sensitive_metadata",
             action="store_true",
             help=(
-                "Include remote URL, commit SHA, and working directory in the "
-                "metadata block. Credentials are always redacted from remote URLs."
+                "Include repo path, remote URL, branch, commit SHA, and working "
+                "directory in the metadata block. Credentials are always "
+                "redacted from remote URLs."
             ),
         )
 

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -876,6 +876,15 @@ def _add_barnacle_parser(
             action="store_true",
             help="Emit machine-readable filing details",
         )
+        parser.add_argument(
+            "--include-sensitive-metadata",
+            dest="include_sensitive_metadata",
+            action="store_true",
+            help=(
+                "Include remote URL, commit SHA, and working directory in the "
+                "metadata block. Credentials are always redacted from remote URLs."
+            ),
+        )
 
     file_p = barnacle_sub.add_parser("file", help="File a barnacle GitHub issue")
     add_file_args(file_p)

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -782,75 +782,99 @@ def _add_barnacle_parser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
     """Add the barnacle subcommand parser."""
-    from slopmop.cli.barnacle import HELP_AGENT, HELP_BARNACLE_ID  # noqa: PLC0415
+    from slopmop.cli.barnacle import DEFAULT_REPO, HELP_AGENT  # noqa: PLC0415
 
     barnacle_parser = subparsers.add_parser(
         "barnacle",
-        help="Describe and resolve tool-friction reports",
+        help="File upstream tool-friction issues",
         description=(
-            "Barnacle queue for slop-mop tool-friction reports.  "
-            "Every agent is both a barnacle detector and a potential cleaner.\n\n"
-            "Queue location: ~/.slopmop/barnacles/  "
-            "(override: SLOPMOP_BARNACLE_DIR)\n\n"
-            "Lifecycle: open → resolved"
+            "File a structured GitHub issue when slop-mop itself blocks or "
+            "misguides work in a real repository. Barnacles are one-way "
+            "upstream reports, not a local queue."
         ),
     )
     barnacle_sub = barnacle_parser.add_subparsers(
         dest="barnacle_action", help="Action to perform"
     )
 
-    # ── describe ──────────────────────────────────────────────────────
+    def add_file_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--title", help="Short issue title")
+        parser.add_argument(
+            "--command", required=True, help="Command that triggered the friction"
+        )
+        parser.add_argument("--gate", help="Gate name if the friction is gate-specific")
+        parser.add_argument(
+            "--expected", required=True, help="What should have happened"
+        )
+        parser.add_argument("--actual", required=True, help="What actually happened")
+        parser.add_argument(
+            "--output", dest="output_excerpt", help="Relevant terminal output excerpt"
+        )
+        parser.add_argument(
+            "--repro-step",
+            dest="reproduction_steps",
+            action="append",
+            help="Reproduction step; repeat for multiple steps",
+        )
+        parser.add_argument(
+            "--tried",
+            dest="things_tried",
+            action="append",
+            help="Thing already tried; repeat for multiple attempts",
+        )
+        parser.add_argument(
+            "--workflow",
+            choices=[
+                "swab",
+                "scour",
+                "buff",
+                "sail",
+                "refit",
+                "upgrade",
+                "install",
+                "agent-skill",
+                "unknown",
+            ],
+            default="unknown",
+            help="Affected slop-mop workflow",
+        )
+        parser.add_argument(
+            "--blocker-type",
+            dest="blocker_type",
+            choices=["blocking", "non-blocking"],
+            default="blocking",
+            help="Whether this barnacle blocks forward progress (default: blocking)",
+        )
+        parser.add_argument("--agent", help=HELP_AGENT)
+        parser.add_argument(
+            "--project-root", default=".", help="Root of the affected repository"
+        )
+        parser.add_argument(
+            "--repo",
+            default=DEFAULT_REPO,
+            help=f"GitHub repo to file against (default: {DEFAULT_REPO})",
+        )
+        parser.add_argument(
+            "--label",
+            dest="labels",
+            action="append",
+            help="Issue label; defaults to barnacle + bug when omitted",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print the issue title/body without creating a GitHub issue",
+        )
+
+    file_p = barnacle_sub.add_parser("file", help="File a barnacle GitHub issue")
+    add_file_args(file_p)
+
     describe_p = barnacle_sub.add_parser(
-        "describe", help="Describe a new barnacle report"
+        "describe",
+        help="Deprecated alias for file",
+        description="Deprecated alias for file",
     )
-    describe_p.add_argument(
-        "--command", required=True, help="Command that triggered the friction"
-    )
-    describe_p.add_argument("--gate", help="Gate name if the friction is gate-specific")
-    describe_p.add_argument(
-        "--expected", required=True, help="What should have happened"
-    )
-    describe_p.add_argument("--actual", required=True, help="What actually happened")
-    describe_p.add_argument(
-        "--output", dest="output_excerpt", help="Relevant terminal output excerpt"
-    )
-    describe_p.add_argument(
-        "--blocker-type",
-        dest="blocker_type",
-        choices=["blocking", "non-blocking"],
-        default="blocking",
-        help="Whether this barnacle blocks forward progress (default: blocking)",
-    )
-    describe_p.add_argument("--agent", help=HELP_AGENT)
-    describe_p.add_argument(
-        "--project-root", default=".", help="Root of the affected repository"
-    )
-
-    # ── list ──────────────────────────────────────────────────────────
-    list_p = barnacle_sub.add_parser("list", help="List barnacles in the queue")
-    list_p.add_argument(
-        "--status",
-        choices=["open", "resolved", "all"],
-        default="open",
-        help="Filter by status (default: open)",
-    )
-
-    # ── show ──────────────────────────────────────────────────────────
-    show_p = barnacle_sub.add_parser("show", help="Show full details for one barnacle")
-    show_p.add_argument("barnacle_id", help=HELP_BARNACLE_ID)
-    show_p.add_argument(
-        "--json", dest="json_output", action="store_true", help="Output as JSON"
-    )
-
-    # ── resolve ───────────────────────────────────────────────────────
-    resolve_p = barnacle_sub.add_parser(
-        "resolve", help="Resolve a barnacle with fix details"
-    )
-    resolve_p.add_argument("barnacle_id", help=HELP_BARNACLE_ID)
-    resolve_p.add_argument("--commit", help="Fix commit SHA")
-    resolve_p.add_argument("--branch", help="Fix branch name")
-    resolve_p.add_argument("--notes", help="Any additional notes for the reporter")
-    resolve_p.add_argument("--agent", help=HELP_AGENT)
+    add_file_args(describe_p)
 
 
 def _add_audit_parser(
@@ -946,7 +970,7 @@ Verbs:
   upgrade     Upgrade slop-mop and validate the result
   buff        Post-PR CI triage and next-step guidance
   refit       Structured remediation planning and continuation
-  barnacle    File, claim, and resolve tool-friction reports
+    barnacle    File upstream tool-friction issues
   agent       Install agent integration templates
   config      View or update quality gate configuration
   help        Show detailed help for quality gates
@@ -963,6 +987,7 @@ Examples:
   sm upgrade --check                    Preview an upgrade without mutating
   sm buff                               Post-PR CI triage
   sm refit --start                      Generate a remediation plan
+    sm barnacle file --dry-run            Preview a tool-friction issue
   sm swab -g python,quality             Run specific gate groups
   sm scour --verbose                    Thorough with details
   sm config --show                      Show current configuration
@@ -995,7 +1020,6 @@ Examples:
         action="version",
         version=f"%(prog)s {__version__}",
     )
-
     return parser
 
 

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -998,7 +998,7 @@ Examples:
   sm upgrade --check                    Preview an upgrade without mutating
   sm buff                               Post-PR CI triage
   sm refit --start                      Generate a remediation plan
-    sm barnacle file --dry-run            Preview a tool-friction issue
+  sm barnacle file --dry-run            Preview a tool-friction issue
   sm swab -g python,quality             Run specific gate groups
   sm scour --verbose                    Thorough with details
   sm config --show                      Show current configuration

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -876,16 +876,6 @@ def _add_barnacle_parser(
             action="store_true",
             help="Emit machine-readable filing details",
         )
-        parser.add_argument(
-            "--include-sensitive-metadata",
-            dest="include_sensitive_metadata",
-            action="store_true",
-            help=(
-                "Include repo path, remote URL, branch, commit SHA, and working "
-                "directory in the metadata block. Credentials are always "
-                "redacted from remote URLs."
-            ),
-        )
 
     file_p = barnacle_sub.add_parser("file", help="File a barnacle GitHub issue")
     add_file_args(file_p)

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -865,6 +865,17 @@ def _add_barnacle_parser(
             action="store_true",
             help="Print the issue title/body without creating a GitHub issue",
         )
+        parser.add_argument(
+            "--body-file",
+            dest="body_file",
+            help="Path for the generated Markdown body artifact",
+        )
+        parser.add_argument(
+            "--json",
+            dest="json_output",
+            action="store_true",
+            help="Emit machine-readable filing details",
+        )
 
     file_p = barnacle_sub.add_parser("file", help="File a barnacle GitHub issue")
     add_file_args(file_p)

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -34,7 +34,6 @@ import json
 import logging
 import os
 import sys
-import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -830,6 +829,7 @@ def _add_barnacle_parser(
                 "buff",
                 "sail",
                 "refit",
+                "doctor",
                 "upgrade",
                 "install",
                 "agent-skill",
@@ -966,45 +966,48 @@ def _add_audit_parser(
 
 def create_parser() -> argparse.ArgumentParser:
     """Create the argument parser for sm CLI."""
+    description = "\n".join(
+        [
+            "🪣 sm - Slop-Mop Quality Gate Framework",
+            "",
+            "A language-agnostic, bolt-on code validation tool designed to catch AI-generated",
+            "slop before it lands in your codebase. Provides fast, actionable feedback for",
+            "both human developers and AI coding assistants.",
+            "",
+            "Verbs:",
+            "  swab        Quick validation — runs on every commit",
+            "  scour       Thorough validation — PR readiness (superset of swab)",
+            "  upgrade     Upgrade slop-mop and validate the result",
+            "  buff        Post-PR CI triage and next-step guidance",
+            "  refit       Structured remediation planning and continuation",
+            "  barnacle    File upstream tool-friction issues",
+            "  agent       Install agent integration templates",
+            "  config      View or update quality gate configuration",
+            "  help        Show detailed help for quality gates",
+            "",
+            "Quick Start:",
+            "  1. Add slop-mop as a git submodule",
+            "  2. Run: ./slop-mop/scripts/setup.sh (creates venv, installs tools, adds ./sm)",
+            "  3. Run: sm init (auto-detect project, write config)",
+            "  4. Run: sm swab (run quick quality gates)",
+            "",
+            "Examples:",
+            "  sm swab                               Quick validation (every commit)",
+            "  sm scour                              Thorough validation (PR readiness)",
+            "  sm upgrade --check                    Preview an upgrade without mutating",
+            "  sm buff                               Post-PR CI triage",
+            "  sm refit --start                      Generate a remediation plan",
+            "  sm barnacle file --dry-run            Preview a tool-friction issue",
+            "  sm swab -g python,quality             Run specific gate groups",
+            "  sm scour --verbose                    Thorough with details",
+            "  sm config --show                      Show current configuration",
+            "  sm config --enable python-security    Enable a quality gate",
+            "  sm help python-lint-format            Show help for specific gate",
+        ]
+    )
     parser = argparse.ArgumentParser(
         prog="./sm",
-        description=(textwrap.dedent("""
-🪣 sm - Slop-Mop Quality Gate Framework
-
-A language-agnostic, bolt-on code validation tool designed to catch AI-generated
-slop before it lands in your codebase. Provides fast, actionable feedback for
-both human developers and AI coding assistants.
-
-Verbs:
-  swab        Quick validation — runs on every commit
-  scour       Thorough validation — PR readiness (superset of swab)
-  upgrade     Upgrade slop-mop and validate the result
-  buff        Post-PR CI triage and next-step guidance
-  refit       Structured remediation planning and continuation
-    barnacle    File upstream tool-friction issues
-  agent       Install agent integration templates
-  config      View or update quality gate configuration
-  help        Show detailed help for quality gates
-
-Quick Start:
-  1. Add slop-mop as a git submodule
-  2. Run: ./slop-mop/scripts/setup.sh (creates venv, installs tools, adds ./sm)
-  3. Run: sm init (auto-detect project, write config)
-  4. Run: sm swab (run quick quality gates)
-
-Examples:
-  sm swab                               Quick validation (every commit)
-  sm scour                              Thorough validation (PR readiness)
-  sm upgrade --check                    Preview an upgrade without mutating
-  sm buff                               Post-PR CI triage
-  sm refit --start                      Generate a remediation plan
-  sm barnacle file --dry-run            Preview a tool-friction issue
-  sm swab -g python,quality             Run specific gate groups
-  sm scour --verbose                    Thorough with details
-  sm config --show                      Show current configuration
-  sm config --enable python-security    Enable a quality gate
-  sm help python-lint-format            Show help for specific gate
-""")),
+        description=description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from slopmop.cli.barnacle import AUTO_FILE_DISABLED_ENVAR
 from slopmop.core.result import CheckResult, CheckStatus
+
+
+@pytest.fixture(autouse=True)
+def _disable_barnacle_auto_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent tests from creating real upstream GitHub barnacle issues."""
+
+    monkeypatch.setenv(AUTO_FILE_DISABLED_ENVAR, "1")
 
 
 class _FakeLock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,26 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from slopmop.cli.barnacle import QUEUE_DIR_ENVAR
 from slopmop.core.result import CheckResult, CheckStatus
-
-
-@pytest.fixture(autouse=True)
-def _isolate_barnacle_queue(
-    tmp_path_factory: pytest.TempPathFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Always point ``SLOPMOP_BARNACLE_DIR`` at a per-test tmp path.
-
-    Without this, any test that ends up calling ``auto_file_barnacle`` (e.g.
-    via ``cmd_upgrade`` covering the validation-failure path) leaks barnacles
-    into the developer's real ``~/.slopmop/barnacles/`` queue. Tests that
-    intentionally exercise the default queue location must explicitly call
-    ``monkeypatch.delenv(QUEUE_DIR_ENVAR, raising=False)``.
-    """
-
-    isolated = tmp_path_factory.mktemp("slopmop-barnacles")
-    monkeypatch.setenv(QUEUE_DIR_ENVAR, str(isolated))
 
 
 class _FakeLock:

--- a/tests/unit/test_agent_install.py
+++ b/tests/unit/test_agent_install.py
@@ -220,7 +220,7 @@ class TestClaudeSkill:
             for a in assets
             if "/commands/" in a.destination_relpath
         }
-        assert len(commands) == 4
+        assert len(commands) == 5
         for path, text in commands.items():
             if "swab" in path:
                 assert "sm swab" in text
@@ -230,6 +230,8 @@ class TestClaudeSkill:
                 assert "sm buff" in text
             elif "sail" in path:
                 assert "sm sail" in text
+            elif "barnacle" in path:
+                assert "sm barnacle" in text
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +264,7 @@ class TestAgentHelpers:
         assert ".claude/commands/sm-swab.md" in paths
         assert ".claude/commands/sm-scour.md" in paths
         assert ".claude/commands/sm-buff.md" in paths
+        assert ".claude/commands/sm-barnacle.md" in paths
         assert ".claude/skills/slopmop/SKILL.md" in paths
         assert "CLAUDE.md" in paths
 

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -15,6 +15,7 @@ from slopmop.cli.barnacle import (
     cmd_barnacle_file,
     create_barnacle_issue,
     render_issue_body,
+    write_issue_body_file,
 )
 
 
@@ -72,6 +73,8 @@ def _args(**kwargs) -> argparse.Namespace:
         repo=DEFAULT_REPO,
         labels=list(DEFAULT_LABELS),
         dry_run=False,
+        body_file=None,
+        json_output=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -106,6 +109,7 @@ class TestRenderIssueBody:
         assert "### Expected Behavior" in body
         assert "### Reproduction Steps" in body
         assert "### Environment Metadata" in body
+        assert "- Barnacle: true" in body
         assert "myopia:test.py" in body
         assert SCHEMA_VERSION in body
 
@@ -116,26 +120,42 @@ class TestRenderIssueBody:
         assert "- (none provided)" in body
 
 
+class TestBodyFile:
+    def test_writes_retryable_issue_body(self, tmp_path):
+        body_path = write_issue_body_file(
+            _issue(project_root=str(tmp_path)), str(tmp_path / "barnacle.md")
+        )
+
+        assert body_path == tmp_path / "barnacle.md"
+        assert "### Barnacle Summary" in body_path.read_text()
+
+
 class TestCreateBarnacleIssue:
-    def test_invokes_gh_issue_create_with_labels(self):
+    def test_invokes_gh_issue_create_with_body_file_and_labels(self, tmp_path):
         completed = subprocess.CompletedProcess(
             args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
         with patch(
             "slopmop.cli.barnacle.subprocess.run", return_value=completed
         ) as run:
-            result = create_barnacle_issue(_issue())
+            result, body_path = create_barnacle_issue(
+                _issue(project_root=str(tmp_path)), str(tmp_path / "issue.md")
+            )
 
         assert result.returncode == 0
+        assert body_path == tmp_path / "issue.md"
+        assert body_path.exists()
         command = run.call_args.args[0]
         assert command[:3] == ["gh", "issue", "create"]
         assert "--repo" in command
         assert DEFAULT_REPO in command
+        assert "--body-file" in command
+        assert str(body_path) in command
         assert command.count("--label") == 2
         assert "barnacle" in command
         assert "bug" in command
 
-    def test_retries_without_barnacle_label_when_missing(self):
+    def test_retries_without_barnacle_label_when_missing(self, tmp_path):
         missing = subprocess.CompletedProcess(
             args=["gh"], returncode=1, stdout="", stderr="label barnacle not found"
         )
@@ -145,19 +165,21 @@ class TestCreateBarnacleIssue:
         with patch(
             "slopmop.cli.barnacle.subprocess.run", side_effect=[missing, success]
         ) as run:
-            result = create_barnacle_issue(_issue())
+            result, _body_path = create_barnacle_issue(
+                _issue(project_root=str(tmp_path))
+            )
 
         assert result.returncode == 0
         fallback_command = run.call_args_list[1].args[0]
         assert "barnacle" not in fallback_command
         assert "bug" in fallback_command
 
-    def test_missing_gh_raises_runtime_error(self):
+    def test_missing_gh_raises_runtime_error(self, tmp_path):
         with patch(
             "slopmop.cli.barnacle.subprocess.run", side_effect=FileNotFoundError
         ):
             try:
-                create_barnacle_issue(_issue())
+                create_barnacle_issue(_issue(project_root=str(tmp_path)))
             except RuntimeError as exc:
                 assert "GitHub CLI" in str(exc)
             else:
@@ -165,24 +187,40 @@ class TestCreateBarnacleIssue:
 
 
 class TestCmdBarnacleFile:
-    def test_dry_run_prints_body_without_creating_issue(self, capsys):
+    def test_dry_run_prints_body_without_creating_issue(self, capsys, tmp_path):
         with (
             patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
             patch("slopmop.cli.barnacle.create_barnacle_issue") as create,
         ):
-            rc = cmd_barnacle_file(_args(dry_run=True))
+            rc = cmd_barnacle_file(
+                _args(dry_run=True, project_root=str(tmp_path), body_file=None)
+            )
 
         assert rc == 0
-        assert "Title: [barnacle]" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "Title: [barnacle]" in out
+        assert "Body file:" in out
         create.assert_not_called()
 
-    def test_success_prints_issue_url(self, capsys):
+    def test_dry_run_json_prints_machine_readable_payload(self, capsys, tmp_path):
+        with patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()):
+            rc = cmd_barnacle_file(
+                _args(dry_run=True, json_output=True, project_root=str(tmp_path))
+            )
+
+        assert rc == 0
+        assert '"body_file"' in capsys.readouterr().out
+
+    def test_success_prints_issue_url(self, capsys, tmp_path):
         result = subprocess.CompletedProcess(
             args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
         with (
             patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
-            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+            patch(
+                "slopmop.cli.barnacle.create_barnacle_issue",
+                return_value=(result, tmp_path / "issue.md"),
+            ),
         ):
             rc = cmd_barnacle_file(_args())
 
@@ -190,31 +228,55 @@ class TestCmdBarnacleFile:
         out = capsys.readouterr().out
         assert "Barnacle issue filed" in out
         assert "https://example.test/1" in out
+        assert "Body file:" in out
 
-    def test_failure_reports_retryable_dry_run(self, capsys):
+    def test_success_json_prints_url_payload(self, capsys, tmp_path):
+        result = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
+        )
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch(
+                "slopmop.cli.barnacle.create_barnacle_issue",
+                return_value=(result, tmp_path / "issue.md"),
+            ),
+        ):
+            rc = cmd_barnacle_file(_args(json_output=True))
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert '"url": "https://example.test/1"' in out
+
+    def test_failure_reports_retryable_body_file(self, capsys, tmp_path):
         result = subprocess.CompletedProcess(
             args=["gh"], returncode=1, stdout="", stderr="auth failed"
         )
         with (
             patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
-            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+            patch(
+                "slopmop.cli.barnacle.create_barnacle_issue",
+                return_value=(result, tmp_path / "issue.md"),
+            ),
         ):
             rc = cmd_barnacle_file(_args())
 
         assert rc == 1
         err = capsys.readouterr().err
         assert "Failed to file" in err
-        assert "--dry-run" in err
+        assert "Issue body preserved" in err
 
 
 class TestAutoFileBarnacle:
-    def test_best_effort_returns_issue_url(self):
+    def test_best_effort_returns_issue_url(self, tmp_path):
         result = subprocess.CompletedProcess(
             args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
         with (
             patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
-            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+            patch(
+                "slopmop.cli.barnacle.create_barnacle_issue",
+                return_value=(result, tmp_path / "issue.md"),
+            ),
         ):
             url = auto_file_barnacle(
                 command="sm upgrade",

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -1,300 +1,234 @@
-"""Tests for the barnacle queue CLI."""
+"""Tests for the barnacle GitHub issue intake CLI."""
 
 import argparse
-import json
-import re
+import subprocess
 from unittest.mock import patch
 
 from slopmop.cli.barnacle import (
-    QUEUE_DIR_ENVAR,
+    DEFAULT_LABELS,
+    DEFAULT_REPO,
     SCHEMA_VERSION,
-    STATUS_OPEN,
-    STATUS_RESOLVED,
-    _barnacle_id,
-    _find_barnacle,
-    _list_barnacles,
-    _queue_dir,
+    BarnacleIssue,
     auto_file_barnacle,
+    build_barnacle_issue,
     cmd_barnacle,
-    cmd_barnacle_describe,
-    cmd_barnacle_list,
-    cmd_barnacle_resolve,
-    cmd_barnacle_show,
+    cmd_barnacle_file,
+    create_barnacle_issue,
+    render_issue_body,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+
+def _metadata() -> dict[str, object]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "repo": {
+            "root": "/repo",
+            "remote": "git@example.com:owner/repo.git",
+            "branch": "main",
+            "commit": "abc123",
+            "dirty": False,
+        },
+        "agent": {"name": "test-agent", "source": "unit-test"},
+    }
+
+
+def _issue(**kwargs) -> BarnacleIssue:
+    defaults = dict(
+        title="[barnacle] swab output was misleading",
+        command="sm swab",
+        expected="clear guidance",
+        actual="confusing guidance",
+        output_excerpt="bad output",
+        blocker_type="blocking",
+        workflow="swab",
+        project_root="/repo",
+        gate="myopia:test.py",
+        agent="test-agent",
+        repo=DEFAULT_REPO,
+        labels=DEFAULT_LABELS,
+        reproduction_steps=["sm swab"],
+        things_tried=["sm swab --no-cache"],
+        metadata=_metadata(),
+    )
+    defaults.update(kwargs)
+    return BarnacleIssue(**defaults)
 
 
 def _args(**kwargs) -> argparse.Namespace:
-    """Build a minimal Namespace; barnacle handlers only read named attrs."""
     defaults = dict(
-        barnacle_action=None,
-        barnacle_id=None,
+        barnacle_action="file",
+        title="swab output was misleading",
         command="sm swab",
-        gate=None,
-        expected="swab passes",
-        actual="swab failed",
-        output_excerpt="",
+        gate="myopia:test.py",
+        expected="clear guidance",
+        actual="confusing guidance",
+        output_excerpt="bad output",
         blocker_type="blocking",
-        agent=None,
         project_root=".",
-        auto_filed=False,
-        status="open",
-        json_output=False,
-        commit=None,
-        branch=None,
-        notes=None,
-        reproduction_steps=[],
+        reproduction_steps=["sm swab"],
+        things_tried=["sm swab --no-cache"],
+        workflow="swab",
+        agent="test-agent",
+        repo=DEFAULT_REPO,
+        labels=list(DEFAULT_LABELS),
+        dry_run=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
 
 
-# ---------------------------------------------------------------------------
-# Unit: barnacle_id format
-# ---------------------------------------------------------------------------
+class TestBuildBarnacleIssue:
+    def test_prefixes_title_and_collects_metadata(self):
+        with patch(
+            "slopmop.cli.barnacle._collect_metadata", return_value=_metadata()
+        ) as collect:
+            issue = build_barnacle_issue(_args(project_root="/repo"))
+
+        assert issue.title == "[barnacle] swab output was misleading"
+        assert issue.repo == DEFAULT_REPO
+        assert issue.labels == DEFAULT_LABELS
+        assert issue.reproduction_steps == ["sm swab"]
+        collect.assert_called_once_with("/repo", "test-agent")
+
+    def test_keeps_existing_barnacle_prefix(self):
+        with patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()):
+            issue = build_barnacle_issue(_args(title="[barnacle] already tagged"))
+
+        assert issue.title == "[barnacle] already tagged"
 
 
-class TestBarnacleId:
-    def test_format(self):
-        bid = _barnacle_id()
-        assert bid.startswith("barnacle-")
-        # barnacle-YYYYMMDD-HHMMSS-<8hex>
-        assert re.match(r"^barnacle-\d{8}-\d{6}-[0-9a-f]{8}$", bid), bid
+class TestRenderIssueBody:
+    def test_renders_structured_markdown(self):
+        body = render_issue_body(_issue())
 
-    def test_unique(self):
-        ids = {_barnacle_id() for _ in range(20)}
-        assert len(ids) == 20
+        assert "### Barnacle Summary" in body
+        assert "### Current Behavior" in body
+        assert "### Expected Behavior" in body
+        assert "### Reproduction Steps" in body
+        assert "### Environment Metadata" in body
+        assert "myopia:test.py" in body
+        assert SCHEMA_VERSION in body
 
+    def test_defaults_empty_lists_to_placeholders(self):
+        body = render_issue_body(_issue(reproduction_steps=[], things_tried=[]))
 
-# ---------------------------------------------------------------------------
-# Unit: queue_dir override via env var
-# ---------------------------------------------------------------------------
-
-
-class TestQueueDir:
-    def test_default_is_home_slopmop(self, monkeypatch):
-        # The autouse isolation fixture sets SLOPMOP_BARNACLE_DIR for safety;
-        # this test verifies the genuine default, so drop the override first.
-        monkeypatch.delenv(QUEUE_DIR_ENVAR, raising=False)
-        qdir = _queue_dir()
-        assert qdir.parts[-2:] == (".slopmop", "barnacles")
-
-    def test_override_via_env(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "queue"))
-        assert _queue_dir() == tmp_path / "queue"
+        assert "1. (none provided)" in body
+        assert "- (none provided)" in body
 
 
-# ---------------------------------------------------------------------------
-# cmd_barnacle_describe
-# ---------------------------------------------------------------------------
-
-
-class TestCmdBarnacleDescribe:
-    def test_creates_json_file(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        rc = cmd_barnacle_describe(
-            _args(command="sm scour", expected="ok", actual="fail")
+class TestCreateBarnacleIssue:
+    def test_invokes_gh_issue_create_with_labels(self):
+        completed = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
-        assert rc == 0
-        files = list(tmp_path.glob("barnacle-*.json"))
-        assert len(files) == 1
-        data = json.loads(files[0].read_text())
-        assert data["schema"] == SCHEMA_VERSION
-        assert data["status"] == STATUS_OPEN
-        assert data["command"] == "sm scour"
+        with patch(
+            "slopmop.cli.barnacle.subprocess.run", return_value=completed
+        ) as run:
+            result = create_barnacle_issue(_issue())
 
-    def test_output_contains_id(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        out = capsys.readouterr().out
-        assert "barnacle-" in out
+        assert result.returncode == 0
+        command = run.call_args.args[0]
+        assert command[:3] == ["gh", "issue", "create"]
+        assert "--repo" in command
+        assert DEFAULT_REPO in command
+        assert command.count("--label") == 2
+        assert "barnacle" in command
+        assert "bug" in command
 
-    def test_auto_filed_flag(self, tmp_path, monkeypatch):
-        """CLI-described barnacles are never auto_filed (only auto_file_barnacle() sets True)."""
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args(auto_filed=True))
-        data = json.loads(next(tmp_path.glob("barnacle-*.json")).read_text())
-        assert data["auto_filed"] is False
-
-
-# ---------------------------------------------------------------------------
-# cmd_barnacle_list
-# ---------------------------------------------------------------------------
-
-
-class TestCmdBarnacleList:
-    def test_empty_queue_no_dir(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "nonexistent"))
-        rc = cmd_barnacle_list(_args())
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert "barnacle" in out.lower()
-
-    def test_files_show_in_list(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        cmd_barnacle_describe(_args(command="sm refit"))
-        rc = cmd_barnacle_list(_args(status="open"))
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert "barnacle-" in out
-
-    def test_all_status_filter(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        rc = cmd_barnacle_list(_args(status="all"))
-        assert rc == 0
-
-
-# ---------------------------------------------------------------------------
-# _list_barnacles / _find_barnacle
-# ---------------------------------------------------------------------------
-
-
-class TestListAndFind:
-    def test_list_empty_when_dir_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "nope"))
-        assert _list_barnacles() == []
-
-    def test_list_filters_by_status(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        assert len(_list_barnacles("open")) == 1
-        assert len(_list_barnacles("resolved")) == 0
-
-    def test_find_by_prefix(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        files = list(tmp_path.glob("barnacle-*.json"))
-        bid = files[0].stem
-        # Find by first 20 characters
-        found = _find_barnacle(bid[:20])
-        assert found is not None
-        assert found["id"] == bid
-
-    def test_find_missing_returns_none(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "empty"))
-        assert _find_barnacle("barnacle-99999999") is None
-
-
-# ---------------------------------------------------------------------------
-# open → resolved lifecycle
-# ---------------------------------------------------------------------------
-
-
-class TestLifecycle:
-    def test_full_lifecycle(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-
-        # DESCRIBE
-        cmd_barnacle_describe(_args(command="sm upgrade"))
-        files = list(tmp_path.glob("barnacle-*.json"))
-        assert len(files) == 1
-        bid = files[0].stem
-
-        # RESOLVE
-        rc = cmd_barnacle_resolve(
-            _args(
-                barnacle_id=bid,
-                commit="abc1234",
-                branch="fix/test",
-                notes="fixed it",
-                agent="test-agent",
-            )
+    def test_retries_without_barnacle_label_when_missing(self):
+        missing = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="label barnacle not found"
         )
-        assert rc == 0
-        data = json.loads(files[0].read_text())
-        assert data["status"] == STATUS_RESOLVED
-        assert data["resolution"]["fix_commit"] == "abc1234"
-
-    def test_resolve_already_resolved_is_noop(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        bid = next(tmp_path.glob("barnacle-*.json")).stem
-        cmd_barnacle_resolve(_args(barnacle_id=bid))
-        rc = cmd_barnacle_resolve(_args(barnacle_id=bid))
-        assert rc == 0  # second resolve is a no-op, not an error
-
-
-# ---------------------------------------------------------------------------
-# cmd_barnacle_show
-# ---------------------------------------------------------------------------
-
-
-class TestCmdBarnacleShow:
-    def test_show_renders_fields(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(
-            _args(command="sm buff", expected="buff ok", actual="buff fail")
+        success = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
-        bid = next(tmp_path.glob("barnacle-*.json")).stem
-        rc = cmd_barnacle_show(_args(barnacle_id=bid))
+        with patch(
+            "slopmop.cli.barnacle.subprocess.run", side_effect=[missing, success]
+        ) as run:
+            result = create_barnacle_issue(_issue())
+
+        assert result.returncode == 0
+        fallback_command = run.call_args_list[1].args[0]
+        assert "barnacle" not in fallback_command
+        assert "bug" in fallback_command
+
+    def test_missing_gh_raises_runtime_error(self):
+        with patch(
+            "slopmop.cli.barnacle.subprocess.run", side_effect=FileNotFoundError
+        ):
+            try:
+                create_barnacle_issue(_issue())
+            except RuntimeError as exc:
+                assert "GitHub CLI" in str(exc)
+            else:
+                raise AssertionError("expected RuntimeError")
+
+
+class TestCmdBarnacleFile:
+    def test_dry_run_prints_body_without_creating_issue(self, capsys):
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch("slopmop.cli.barnacle.create_barnacle_issue") as create,
+        ):
+            rc = cmd_barnacle_file(_args(dry_run=True))
+
+        assert rc == 0
+        assert "Title: [barnacle]" in capsys.readouterr().out
+        create.assert_not_called()
+
+    def test_success_prints_issue_url(self, capsys):
+        result = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
+        )
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+        ):
+            rc = cmd_barnacle_file(_args())
+
         assert rc == 0
         out = capsys.readouterr().out
-        assert "sm buff" in out
-        assert "buff ok" in out
+        assert "Barnacle issue filed" in out
+        assert "https://example.test/1" in out
 
-    def test_show_json_flag(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        cmd_barnacle_describe(_args())
-        capsys.readouterr()  # clear file command output
-        bid = next(tmp_path.glob("barnacle-*.json")).stem
-        rc = cmd_barnacle_show(_args(barnacle_id=bid, json_output=True))
-        assert rc == 0
-        out = capsys.readouterr().out
-        parsed = json.loads(out)
-        assert parsed["id"] == bid
+    def test_failure_reports_retryable_dry_run(self, capsys):
+        result = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="auth failed"
+        )
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+        ):
+            rc = cmd_barnacle_file(_args())
 
-    def test_show_missing_id_fails(self, tmp_path, monkeypatch, capsys):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "empty"))
-        rc = cmd_barnacle_show(_args(barnacle_id="barnacle-nonexistent"))
-        assert rc != 0
-
-    def test_show_none_id_fails(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        rc = cmd_barnacle_show(_args(barnacle_id=None))
-        assert rc != 0
-
-
-# ---------------------------------------------------------------------------
-# auto_file_barnacle
-# ---------------------------------------------------------------------------
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Failed to file" in err
+        assert "--dry-run" in err
 
 
 class TestAutoFileBarnacle:
-    def test_creates_file_returns_id(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        bid = auto_file_barnacle(
-            command="sm upgrade",
-            expected="swab passes",
-            actual="swab failed",
-            output_excerpt="gate failed",
-            blocker_type="blocking",
-            project_root=str(tmp_path),
+    def test_best_effort_returns_issue_url(self):
+        result = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
-        assert bid is not None
-        assert bid.startswith("barnacle-")
-        assert (tmp_path / f"{bid}.json").exists()
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch("slopmop.cli.barnacle.create_barnacle_issue", return_value=result),
+        ):
+            url = auto_file_barnacle(
+                command="sm upgrade",
+                expected="swab passes",
+                actual="swab failed",
+                output_excerpt="failure",
+                workflow="upgrade",
+            )
 
-    def test_auto_filed_flag_in_data(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        bid = auto_file_barnacle(
-            command="sm upgrade",
-            expected="ok",
-            actual="fail",
-            output_excerpt="",
-        )
-        data = json.loads((tmp_path / f"{bid}.json").read_text())
-        assert data["auto_filed"] is True
+        assert url == "https://example.test/1"
 
-    def test_never_raises_on_failure(self, tmp_path, monkeypatch):
-        # Make the queue dir unwritable by monkeypatching _write_barnacle
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
+    def test_never_raises_on_failure(self):
         with patch(
-            "slopmop.cli.barnacle._write_barnacle", side_effect=OSError("no disk")
+            "slopmop.cli.barnacle.create_barnacle_issue", side_effect=OSError("boom")
         ):
             result = auto_file_barnacle(
                 command="sm upgrade",
@@ -302,12 +236,8 @@ class TestAutoFileBarnacle:
                 actual="fail",
                 output_excerpt="",
             )
+
         assert result is None
-
-
-# ---------------------------------------------------------------------------
-# cmd_barnacle dispatcher
-# ---------------------------------------------------------------------------
 
 
 class TestCmdBarnacleDispatcher:
@@ -315,12 +245,18 @@ class TestCmdBarnacleDispatcher:
         rc = cmd_barnacle(_args(barnacle_action=None))
         assert rc == 2
 
-    def test_describe_action_dispatches(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path))
-        rc = cmd_barnacle(_args(barnacle_action="describe"))
-        assert rc == 0
+    def test_file_action_dispatches(self):
+        with patch(
+            "slopmop.cli.barnacle.cmd_barnacle_file", return_value=0
+        ) as file_cmd:
+            rc = cmd_barnacle(_args(barnacle_action="file"))
 
-    def test_list_action_dispatches(self, tmp_path, monkeypatch):
-        monkeypatch.setenv(QUEUE_DIR_ENVAR, str(tmp_path / "empty"))
-        rc = cmd_barnacle(_args(barnacle_action="list"))
         assert rc == 0
+        file_cmd.assert_called_once()
+
+    def test_describe_alias_dispatches_with_deprecation_notice(self, capsys):
+        with patch("slopmop.cli.barnacle.cmd_barnacle_file", return_value=0):
+            rc = cmd_barnacle(_args(barnacle_action="describe"))
+
+        assert rc == 0
+        assert "deprecated" in capsys.readouterr().out

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -5,6 +5,7 @@ import subprocess
 from unittest.mock import patch
 
 from slopmop.cli.barnacle import (
+    AUTO_FILE_DISABLED_ENVAR,
     DEFAULT_LABELS,
     DEFAULT_REPO,
     SCHEMA_VERSION,
@@ -50,6 +51,7 @@ def _issue(**kwargs) -> BarnacleIssue:
         reproduction_steps=["sm swab"],
         things_tried=["sm swab --no-cache"],
         metadata=_metadata(),
+        include_sensitive_metadata=False,
     )
     defaults.update(kwargs)
     return BarnacleIssue(**defaults)
@@ -116,9 +118,11 @@ class TestCollectMetadata:
             meta = _collect_metadata(str(tmp_path), "agent")
 
         repo = meta["repo"]
-        assert "remote" not in repo
-        assert "commit" not in repo
-        assert "cwd" not in meta
+        assert repo["root"].startswith("(redacted")
+        assert repo["remote"].startswith("(redacted")
+        assert repo["branch"].startswith("(redacted")
+        assert repo["commit"].startswith("(redacted")
+        assert meta["cwd"].startswith("(redacted")
 
     def test_include_sensitive_adds_remote_commit_cwd(self, tmp_path):
         with (
@@ -165,13 +169,24 @@ class TestBuildBarnacleIssue:
         assert issue.repo == DEFAULT_REPO
         assert issue.labels == DEFAULT_LABELS
         assert issue.reproduction_steps == ["sm swab"]
-        collect.assert_called_once_with("/repo", "test-agent", include_sensitive=False)
+        collect.assert_called_once_with("/repo", "test-agent", False)
 
-    def test_keeps_existing_barnacle_prefix(self):
+    def test_keeps_existing_barnacle_prefix_case_insensitively(self):
         with patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()):
-            issue = build_barnacle_issue(_args(title="[barnacle] already tagged"))
+            issue = build_barnacle_issue(_args(title="[BARNACLE] already tagged"))
 
-        assert issue.title == "[barnacle] already tagged"
+        assert issue.title == "[BARNACLE] already tagged"
+
+    def test_sensitive_metadata_requires_explicit_opt_in(self):
+        with patch(
+            "slopmop.cli.barnacle._collect_metadata", return_value=_metadata()
+        ) as collect:
+            issue = build_barnacle_issue(
+                _args(project_root="/repo", include_sensitive_metadata=True)
+            )
+
+        assert issue.include_sensitive_metadata is True
+        collect.assert_called_once_with("/repo", "test-agent", True)
 
 
 class TestRenderIssueBody:
@@ -186,6 +201,13 @@ class TestRenderIssueBody:
         assert "- Barnacle: true" in body
         assert "myopia:test.py" in body
         assert SCHEMA_VERSION in body
+        assert "Source Repository: (redacted" in body
+
+    def test_strips_barnacle_summary_case_insensitively(self):
+        body = render_issue_body(_issue(title="[BARNACLE] noisy prefix"))
+
+        assert "### Barnacle Summary\nnoisy prefix" in body
+        assert "[BARNACLE] noisy prefix" not in body
 
     def test_defaults_empty_lists_to_placeholders(self):
         body = render_issue_body(_issue(reproduction_steps=[], things_tried=[]))
@@ -341,7 +363,8 @@ class TestCmdBarnacleFile:
 
 
 class TestAutoFileBarnacle:
-    def test_best_effort_returns_issue_url(self, tmp_path):
+    def test_best_effort_returns_issue_url(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(AUTO_FILE_DISABLED_ENVAR, raising=False)
         result = subprocess.CompletedProcess(
             args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
@@ -362,7 +385,30 @@ class TestAutoFileBarnacle:
 
         assert url == "https://example.test/1"
 
-    def test_never_raises_on_failure(self):
+    def test_returns_none_when_issue_create_prints_no_url(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(AUTO_FILE_DISABLED_ENVAR, raising=False)
+        result = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="", stderr=""
+        )
+        with (
+            patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()),
+            patch(
+                "slopmop.cli.barnacle.create_barnacle_issue",
+                return_value=(result, tmp_path / "issue.md"),
+            ),
+        ):
+            url = auto_file_barnacle(
+                command="sm upgrade",
+                expected="swab passes",
+                actual="swab failed",
+                output_excerpt="failure",
+                workflow="upgrade",
+            )
+
+        assert url is None
+
+    def test_never_raises_on_failure(self, monkeypatch):
+        monkeypatch.delenv(AUTO_FILE_DISABLED_ENVAR, raising=False)
         with patch(
             "slopmop.cli.barnacle.create_barnacle_issue", side_effect=OSError("boom")
         ):
@@ -372,6 +418,16 @@ class TestAutoFileBarnacle:
                 actual="fail",
                 output_excerpt="",
             )
+
+        assert result is None
+
+    def test_auto_file_disabled_by_env(self):
+        result = auto_file_barnacle(
+            command="sm upgrade",
+            expected="ok",
+            actual="fail",
+            output_excerpt="",
+        )
 
         assert result is None
 
@@ -395,4 +451,6 @@ class TestCmdBarnacleDispatcher:
             rc = cmd_barnacle(_args(barnacle_action="describe"))
 
         assert rc == 0
-        assert "deprecated" in capsys.readouterr().out
+        captured = capsys.readouterr()
+        assert "deprecated" in captured.err
+        assert captured.out == ""

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -124,11 +124,10 @@ class TestCollectMetadata:
         with (
             patch(
                 "slopmop.cli.barnacle._run_git",
-                side_effect=lambda _root, *args: (
-                    "https://github.com/owner/repo.git"
-                    if "remote.origin.url" in args
-                    else "abc123"
-                ),
+                side_effect=[
+                    "https://github.com/owner/repo.git",  # remote.origin.url
+                    "abc123",  # rev-parse HEAD
+                ],
             ),
             patch("slopmop.cli.barnacle._git_dirty", return_value=False),
             patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -11,7 +11,6 @@ from slopmop.cli.barnacle import (
     SCHEMA_VERSION,
     BarnacleIssue,
     _collect_metadata,
-    _redact_url,
     auto_file_barnacle,
     build_barnacle_issue,
     cmd_barnacle,
@@ -25,9 +24,12 @@ from slopmop.cli.barnacle import (
 def _metadata() -> dict[str, object]:
     return {
         "schema": SCHEMA_VERSION,
+        "cwd": "/worktree",
         "repo": {
             "root": "/repo",
+            "remote": "git@example.com:owner/repo.git",
             "branch": "main",
+            "commit": "abc123",
             "dirty": False,
         },
         "agent": {"name": "test-agent", "source": "unit-test"},
@@ -51,7 +53,6 @@ def _issue(**kwargs) -> BarnacleIssue:
         reproduction_steps=["sm swab"],
         things_tried=["sm swab --no-cache"],
         metadata=_metadata(),
-        include_sensitive_metadata=False,
     )
     defaults.update(kwargs)
     return BarnacleIssue(**defaults)
@@ -77,85 +78,34 @@ def _args(**kwargs) -> argparse.Namespace:
         dry_run=False,
         body_file=None,
         json_output=False,
-        include_sensitive_metadata=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
 
 
-class TestRedactUrl:
-    def test_strips_user_and_password_from_https(self):
-        url = "https://oauth2:TOKEN@github.com/owner/repo.git"
-        assert _redact_url(url) == "https://github.com/owner/repo.git"
-
-    def test_strips_token_only_from_https(self):
-        url = "https://TOKEN@github.com/owner/repo.git"
-        assert _redact_url(url) == "https://github.com/owner/repo.git"
-
-    def test_preserves_https_without_credentials(self):
-        url = "https://github.com/owner/repo.git"
-        assert _redact_url(url) == url
-
-    def test_preserves_ssh_url_unchanged(self):
-        url = "git@github.com:owner/repo.git"
-        assert _redact_url(url) == url
-
-    def test_preserves_unknown_on_error(self):
-        assert _redact_url("unknown") == "unknown"
-
-    def test_preserves_port_when_present(self):
-        url = "https://user:pass@github.example.com:8443/owner/repo.git"
-        assert _redact_url(url) == "https://github.example.com:8443/owner/repo.git"
-
-
 class TestCollectMetadata:
-    def test_default_omits_sensitive_fields(self, tmp_path):
-        with (
-            patch("slopmop.cli.barnacle._run_git", return_value="unknown"),
-            patch("slopmop.cli.barnacle._git_dirty", return_value=False),
-            patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
-        ):
-            meta = _collect_metadata(str(tmp_path), "agent")
-
-        repo = meta["repo"]
-        assert repo["root"].startswith("(redacted")
-        assert repo["remote"].startswith("(redacted")
-        assert repo["branch"].startswith("(redacted")
-        assert repo["commit"].startswith("(redacted")
-        assert meta["cwd"].startswith("(redacted")
-
-    def test_include_sensitive_adds_remote_commit_cwd(self, tmp_path):
+    def test_includes_repository_metadata_by_default(self, tmp_path):
         with (
             patch(
                 "slopmop.cli.barnacle._run_git",
                 side_effect=[
-                    "https://github.com/owner/repo.git",  # remote.origin.url
-                    "abc123",  # rev-parse HEAD
+                    "https://user:TOKEN@github.com/owner/repo.git",
+                    "abc123",
                 ],
             ),
             patch("slopmop.cli.barnacle._git_dirty", return_value=False),
             patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
+            patch("slopmop.cli.barnacle.os.getcwd", return_value="/worktree"),
         ):
-            meta = _collect_metadata(str(tmp_path), "agent", include_sensitive=True)
+            meta = _collect_metadata(str(tmp_path), "agent")
 
-        assert "remote" in meta["repo"]
-        assert "commit" in meta["repo"]
-        assert "cwd" in meta
-
-    def test_include_sensitive_redacts_remote_credentials(self, tmp_path):
-        with (
-            patch(
-                "slopmop.cli.barnacle._run_git",
-                return_value="https://user:TOKEN@github.com/owner/repo.git",
-            ),
-            patch("slopmop.cli.barnacle._git_dirty", return_value=False),
-            patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
-        ):
-            meta = _collect_metadata(str(tmp_path), "agent", include_sensitive=True)
-
-        assert "TOKEN" not in meta["repo"]["remote"]
-        assert "user" not in meta["repo"]["remote"]
-        assert meta["repo"]["remote"] == "https://github.com/owner/repo.git"
+        repo = meta["repo"]
+        assert repo["root"] == str(tmp_path.resolve())
+        assert repo["remote"] == "https://user:TOKEN@github.com/owner/repo.git"
+        assert repo["branch"] == "main"
+        assert repo["commit"] == "abc123"
+        assert repo["dirty"] is False
+        assert meta["cwd"] == "/worktree"
 
 
 class TestBuildBarnacleIssue:
@@ -169,24 +119,13 @@ class TestBuildBarnacleIssue:
         assert issue.repo == DEFAULT_REPO
         assert issue.labels == DEFAULT_LABELS
         assert issue.reproduction_steps == ["sm swab"]
-        collect.assert_called_once_with("/repo", "test-agent", False)
+        collect.assert_called_once_with("/repo", "test-agent")
 
     def test_keeps_existing_barnacle_prefix_case_insensitively(self):
         with patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()):
             issue = build_barnacle_issue(_args(title="[BARNACLE] already tagged"))
 
         assert issue.title == "[BARNACLE] already tagged"
-
-    def test_sensitive_metadata_requires_explicit_opt_in(self):
-        with patch(
-            "slopmop.cli.barnacle._collect_metadata", return_value=_metadata()
-        ) as collect:
-            issue = build_barnacle_issue(
-                _args(project_root="/repo", include_sensitive_metadata=True)
-            )
-
-        assert issue.include_sensitive_metadata is True
-        collect.assert_called_once_with("/repo", "test-agent", True)
 
 
 class TestRenderIssueBody:
@@ -201,7 +140,7 @@ class TestRenderIssueBody:
         assert "- Barnacle: true" in body
         assert "myopia:test.py" in body
         assert SCHEMA_VERSION in body
-        assert "Source Repository: (redacted" in body
+        assert "Source Repository: /repo" in body
 
     def test_strips_barnacle_summary_case_insensitively(self):
         body = render_issue_body(_issue(title="[BARNACLE] noisy prefix"))
@@ -269,6 +208,21 @@ class TestCreateBarnacleIssue:
         fallback_command = run.call_args_list[1].args[0]
         assert "barnacle" not in fallback_command
         assert "bug" in fallback_command
+
+    def test_does_not_retry_for_non_label_error_mentioning_barnacle(self, tmp_path):
+        failed = subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=1,
+            stdout="",
+            stderr="failed creating issue titled [barnacle] network error",
+        )
+        with patch("slopmop.cli.barnacle.subprocess.run", return_value=failed) as run:
+            result, _body_path = create_barnacle_issue(
+                _issue(project_root=str(tmp_path))
+            )
+
+        assert result.returncode == 1
+        assert run.call_count == 1
 
     def test_missing_gh_raises_runtime_error(self, tmp_path):
         with patch(

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -9,6 +9,8 @@ from slopmop.cli.barnacle import (
     DEFAULT_REPO,
     SCHEMA_VERSION,
     BarnacleIssue,
+    _collect_metadata,
+    _redact_url,
     auto_file_barnacle,
     build_barnacle_issue,
     cmd_barnacle,
@@ -24,9 +26,7 @@ def _metadata() -> dict[str, object]:
         "schema": SCHEMA_VERSION,
         "repo": {
             "root": "/repo",
-            "remote": "git@example.com:owner/repo.git",
             "branch": "main",
-            "commit": "abc123",
             "dirty": False,
         },
         "agent": {"name": "test-agent", "source": "unit-test"},
@@ -75,9 +75,84 @@ def _args(**kwargs) -> argparse.Namespace:
         dry_run=False,
         body_file=None,
         json_output=False,
+        include_sensitive_metadata=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
+
+
+class TestRedactUrl:
+    def test_strips_user_and_password_from_https(self):
+        url = "https://oauth2:TOKEN@github.com/owner/repo.git"
+        assert _redact_url(url) == "https://github.com/owner/repo.git"
+
+    def test_strips_token_only_from_https(self):
+        url = "https://TOKEN@github.com/owner/repo.git"
+        assert _redact_url(url) == "https://github.com/owner/repo.git"
+
+    def test_preserves_https_without_credentials(self):
+        url = "https://github.com/owner/repo.git"
+        assert _redact_url(url) == url
+
+    def test_preserves_ssh_url_unchanged(self):
+        url = "git@github.com:owner/repo.git"
+        assert _redact_url(url) == url
+
+    def test_preserves_unknown_on_error(self):
+        assert _redact_url("unknown") == "unknown"
+
+    def test_preserves_port_when_present(self):
+        url = "https://user:pass@github.example.com:8443/owner/repo.git"
+        assert _redact_url(url) == "https://github.example.com:8443/owner/repo.git"
+
+
+class TestCollectMetadata:
+    def test_default_omits_sensitive_fields(self, tmp_path):
+        with (
+            patch("slopmop.cli.barnacle._run_git", return_value="unknown"),
+            patch("slopmop.cli.barnacle._git_dirty", return_value=False),
+            patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
+        ):
+            meta = _collect_metadata(str(tmp_path), "agent")
+
+        repo = meta["repo"]
+        assert "remote" not in repo
+        assert "commit" not in repo
+        assert "cwd" not in meta
+
+    def test_include_sensitive_adds_remote_commit_cwd(self, tmp_path):
+        with (
+            patch(
+                "slopmop.cli.barnacle._run_git",
+                side_effect=lambda _root, *args: (
+                    "https://github.com/owner/repo.git"
+                    if "remote.origin.url" in args
+                    else "abc123"
+                ),
+            ),
+            patch("slopmop.cli.barnacle._git_dirty", return_value=False),
+            patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
+        ):
+            meta = _collect_metadata(str(tmp_path), "agent", include_sensitive=True)
+
+        assert "remote" in meta["repo"]
+        assert "commit" in meta["repo"]
+        assert "cwd" in meta
+
+    def test_include_sensitive_redacts_remote_credentials(self, tmp_path):
+        with (
+            patch(
+                "slopmop.cli.barnacle._run_git",
+                return_value="https://user:TOKEN@github.com/owner/repo.git",
+            ),
+            patch("slopmop.cli.barnacle._git_dirty", return_value=False),
+            patch("slopmop.cli.barnacle.git_current_branch", return_value="main"),
+        ):
+            meta = _collect_metadata(str(tmp_path), "agent", include_sensitive=True)
+
+        assert "TOKEN" not in meta["repo"]["remote"]
+        assert "user" not in meta["repo"]["remote"]
+        assert meta["repo"]["remote"] == "https://github.com/owner/repo.git"
 
 
 class TestBuildBarnacleIssue:
@@ -91,7 +166,7 @@ class TestBuildBarnacleIssue:
         assert issue.repo == DEFAULT_REPO
         assert issue.labels == DEFAULT_LABELS
         assert issue.reproduction_steps == ["sm swab"]
-        collect.assert_called_once_with("/repo", "test-agent")
+        collect.assert_called_once_with("/repo", "test-agent", include_sensitive=False)
 
     def test_keeps_existing_barnacle_prefix(self):
         with patch("slopmop.cli.barnacle._collect_metadata", return_value=_metadata()):

--- a/tests/unit/test_debugger_artifacts.py
+++ b/tests/unit/test_debugger_artifacts.py
@@ -1,5 +1,6 @@
 """Tests for the cross-language debugger-artifacts gate."""
 
+from slopmop.checks.base import Flaw
 from slopmop.checks.quality.debugger_artifacts import DebuggerArtifactsCheck
 from slopmop.core.result import CheckStatus
 
@@ -181,4 +182,5 @@ class TestReporting:
 
     def test_full_name(self):
         check = DebuggerArtifactsCheck({})
-        assert check.full_name == "deceptiveness:debugger-artifacts"
+        assert check.full_name == "laziness:debugger-artifacts"
+        assert check.flaw == Flaw.LAZINESS

--- a/tests/unit/test_sm_cli_parser.py
+++ b/tests/unit/test_sm_cli_parser.py
@@ -371,3 +371,32 @@ class TestCreateParser:
         assert args.fix is True
         assert args.yes is True
         assert args.checks == ["state.lock"]
+
+    def test_barnacle_file_accepts_doctor_workflow(self):
+        parser = create_parser()
+
+        args = parser.parse_args(
+            [
+                "barnacle",
+                "file",
+                "--command",
+                "sm doctor --fix",
+                "--expected",
+                "doctor should list health checks",
+                "--actual",
+                "doctor exited before running",
+                "--workflow",
+                "doctor",
+            ]
+        )
+
+        assert args.verb == "barnacle"
+        assert args.workflow == "doctor"
+
+    def test_help_text_keeps_barnacle_aligned_with_other_verbs(self):
+        parser = create_parser()
+
+        help_text = parser.format_help()
+
+        assert "\n  buff        Post-PR CI triage and next-step guidance\n" in help_text
+        assert "\n  barnacle    File upstream tool-friction issues\n" in help_text


### PR DESCRIPTION
## Summary

- replace the local barnacle queue with one-way structured GitHub issue filing
- add retryable issue body artifacts, JSON output, and explicit barnacle issue markers
- update README and installed agent templates, including a Claude /sm-barnacle command
- move debugger-artifacts from Deceptiveness to Laziness

## Validation

- ./sm barnacle file ... --body-file .tmp/barnacle-check.md --json --dry-run
- ./sm swab -g laziness:debugger-artifacts --no-cache --output-file .slopmop/debugger_artifacts_gate.json
- ./sm swab -g overconfidence:untested-code.py --no-cache --output-file .slopmop/untested_after_debugger_move.json
- ./sm swab --output-file .slopmop/last_swab.json
- ./sm scour --output-file .slopmop/last_scour.json

Known warning: myopia:dependency-risk.py reports the existing non-blocking dependency risk with no patched version available.
