### PR TITLE
Fix buff human-feedback and worktree guidance

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -12,8 +12,12 @@ Branch: `fix/buff-human-feedback-guidance`
   `--no-resolve` and a concrete clarification request, rather than using it to
   defer clear fixes.
 - Added a regression assertion for the new final warning text.
+- Found open barnacles #170 and #171 for the same `sm buff watch` wrong-worktree
+  footgun.
+- Added a `sm buff status/watch` warning when the current branch differs from
+  the PR head branch, making wrong-worktree watches obvious before polling.
 
-**Next:** Run local validation, commit, push, and report branch state.
+**Next:** Run local validation, commit, push, open the PR, and buff it clean.
 
 ## 2026-05-04 Delta: PR #169 follow-up parser fixes
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,20 @@
 # Project Status
 
+## 2026-05-04 Delta: Buff human-feedback guidance
+
+Branch: `fix/buff-human-feedback-guidance`
+
+**Work completed:**
+- Created a separate branch from `origin/main` for the buff instruction tweak.
+- Updated PR feedback guidance so unresolved comments may also be explicitly
+  awaiting human feedback when reviewer/human intent is unclear.
+- Tightened `needs_human_feedback` wording so agents leave the thread open with
+  `--no-resolve` and a concrete clarification request, rather than using it to
+  defer clear fixes.
+- Added a regression assertion for the new final warning text.
+
+**Next:** Run local validation, commit, push, and report branch state.
+
 ## 2026-05-04 Delta: PR #169 follow-up parser fixes
 
 Branch: `feat/crowdsource-barnacles`  ·  PR `#169`

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,7 +17,14 @@ Branch: `fix/buff-human-feedback-guidance`
 - Added a `sm buff status/watch` warning when the current branch differs from
   the PR head branch, making wrong-worktree watches obvious before polling.
 
-**Next:** Run local validation, commit, push, open the PR, and buff it clean.
+**Validation:**
+- `./sm swab --static` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+- PR `#173` opened: https://github.com/ScienceIsNeato/slop-mop/pull/173
+- `./sm buff watch 173` ✅ after addressing the Bugbot test-structure comment
+
+**Next:** PR `#173` is clean and ready for review/merge.
 
 ## 2026-05-04 Delta: PR #169 follow-up parser fixes
 

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -693,7 +693,8 @@ class PRCommentsCheck(BaseCheck):
             " — Valid but not this PR. File issue, link it."
         )
         lines.append(
-            "# needs_human_feedback    " " — Need reviewer input. Uses --no-resolve."
+            "# needs_human_feedback    "
+            " — Intent unclear; ask for clarification. Uses --no-resolve."
         )
         lines.append("")
 
@@ -895,7 +896,12 @@ class PRCommentsCheck(BaseCheck):
             " — Valid but not this PR. File issue, link it."
         )
         lines.append(
-            "  needs_human_feedback     " " — Need reviewer input. Uses --no-resolve."
+            "  needs_human_feedback     "
+            " — Intent unclear; ask for clarification. Uses --no-resolve."
+        )
+        lines.append(
+            "    Use this when acting would mean guessing about reviewer or "
+            "human intent; do not use it to defer clear fixes."
         )
         lines.append("")
         lines.append("STEP 3: RESOLVE WITH EVIDENCE")
@@ -926,7 +932,12 @@ class PRCommentsCheck(BaseCheck):
         lines.append("")
         lines.append("━" * 80)
         lines.append(
-            "⚠️  DO NOT push until all comments are resolved or marked WONT_RESOLVE!"
+            "⚠️  DO NOT push until all comments are resolved, marked WONT_RESOLVE, "
+            "or explicitly awaiting human feedback."
+        )
+        lines.append(
+            "    Awaiting human feedback is valid when intent is unclear; leave the "
+            "thread open with --no-resolve and a concrete clarification request."
         )
         lines.append("━" * 80)
 

--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -316,7 +316,9 @@ def _build_draft_entries(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "Investigate this thread, choose a scenario "
             "(fixed_in_code / invalid_with_explanation / "
             "no_longer_applicable / out_of_scope_ticketed / "
-            "needs_human_feedback), and provide evidence."
+            "needs_human_feedback), and provide evidence. "
+            "Use needs_human_feedback when intent is unclear enough that acting "
+            "would mean guessing; leave the thread open with --no-resolve."
             f"{signals_hint}"
         )
 

--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -481,6 +481,78 @@ def _get_repo_slug(project_root: str) -> str:
     return f"{owner}/{repo}"
 
 
+def _get_current_branch(project_root: Path) -> str | None:
+    """Return the current git branch name, if it can be resolved."""
+
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+            cwd=project_root,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def _get_pr_head_branch(project_root: Path, pr_number: int) -> str | None:
+    """Return the PR head branch name, if GitHub can provide it."""
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "headRefName",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+            cwd=project_root,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    branch = str(data.get("headRefName") or "").strip()
+    return branch or None
+
+
+def _warn_if_pr_worktree_mismatch(project_root: Path, pr_number: int) -> None:
+    """Warn when buff is watching a PR from a different branch/worktree."""
+
+    current_branch = _get_current_branch(project_root)
+    pr_head_branch = _get_pr_head_branch(project_root, pr_number)
+    if not current_branch or not pr_head_branch or current_branch == pr_head_branch:
+        return
+
+    print("⚠️  PR/worktree mismatch detected")
+    print(f"   Current branch: {current_branch}")
+    print(f"   PR #{pr_number} head branch: {pr_head_branch}")
+    print(f"   Project root: {project_root}")
+    print(
+        "   If this is intentional, continue. Otherwise run buff from the "
+        "PR worktree or switch to the PR branch before watching."
+    )
+    print()
+
+
 def _post_pr_comment(
     project_root: str, owner: str, repo: str, pr_number: int, message: str
 ) -> None:
@@ -598,6 +670,7 @@ def _cmd_buff_status(
 
     print_project_header(str(project_root))
     print(f"🔀 PR: #{resolved_pr}")
+    _warn_if_pr_worktree_mismatch(project_root, resolved_pr)
     if watch:
         flags = f"polling every {interval}s"
         if fail_fast:

--- a/tests/unit/test_buff_inspect_and_status.py
+++ b/tests/unit/test_buff_inspect_and_status.py
@@ -268,6 +268,42 @@ class TestBuffInspectCommand:
 
 
 class TestBuffStatusCommand:
+    def test_get_current_branch_returns_branch(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout="feature/demo\n")),
+        )
+
+        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) == "feature/demo"
+
+    def test_get_current_branch_returns_none_on_command_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=1, stdout="")),
+        )
+
+        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) is None
+
+    def test_get_pr_head_branch_returns_branch(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout='{"headRefName":"feat-x"}')),
+        )
+
+        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) == "feat-x"
+
+    def test_get_pr_head_branch_returns_none_on_invalid_json(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout="not-json")),
+        )
+
+        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) is None
+
     def test_cmd_buff_status_fires_buff_hook_on_clean_terminal_state(
         self, monkeypatch, capsys
     ):
@@ -451,6 +487,62 @@ class TestBuffStatusCommand:
         out = capsys.readouterr().out
         assert "CI checks are clean, but unresolved PR review threads remain." in out
         assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_status_warns_on_pr_worktree_mismatch(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
+        monkeypatch.setattr(buff_mod, "_get_current_branch", Mock(return_value="main"))
+        monkeypatch.setattr(
+            buff_mod, "_get_pr_head_branch", Mock(return_value="feature/pr-85")
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+        monkeypatch.setattr(buff_mod, "_fire_buff_hook", Mock())
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "PR/worktree mismatch detected" in out
+        assert "Current branch: main" in out
+        assert "PR #85 head branch: feature/pr-85" in out
+        assert "run buff from the PR worktree" in out
 
     def test_cmd_buff_watch_waits_once_for_post_ci_feedback_settle(
         self, monkeypatch, capsys

--- a/tests/unit/test_pr_checks.py
+++ b/tests/unit/test_pr_checks.py
@@ -304,6 +304,8 @@ class TestPRCommentsCheck:
         assert "PRRT_456" in guidance
         assert "CHOOSE A SCENARIO" in guidance
         assert "fixed_in_code" in guidance
+        assert "explicitly awaiting human feedback" in guidance
+        assert "leave the thread open with --no-resolve" in guidance
 
     def test_get_unresolved_threads_parses_response(self, tmp_path):
         """Test _get_unresolved_threads correctly parses GraphQL response."""

--- a/tests/unit/test_pr_checks.py
+++ b/tests/unit/test_pr_checks.py
@@ -281,6 +281,8 @@ class TestPRCommentsCheck:
         assert result.status == CheckStatus.WARNED
         assert "1 unresolved" in result.output
         assert result.status_detail == "1 unresolved"
+
+    def test_format_guidance_includes_ai_agent_instructions(self):
         """Test format_guidance includes AI agent instructions."""
         threads = [
             {


### PR DESCRIPTION
## Summary

- Clarifies buff PR feedback guidance so awaiting human feedback is a valid state when intent is unclear.
- Adds a loud buff status/watch warning when the current branch does not match the PR head branch, making wrong-worktree watches obvious before polling.
- Adds regressions for the new guidance and mismatch warning.

## Validation

- ./sm swab --static
- ./sm scour --output-file .slopmop/last_scour.json

Closes #170
Closes #171
