### PR TITLE
feat: Claude plugin refit command + barnacle filing fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "source": "github",
         "repo": "ScienceIsNeato/slop-mop"
       },
-      "description": "Protocols for highly efficient and directed remediation of known quality issues — refit onboarding plus the swab/scour/buff/sail loop as a skill and slash commands.",
+      "description": "Protocols for highly efficient and directed remediation of known issues — refit onboarding, the swab/scour/buff/sail loop, and barnacle friction reporting as a skill and slash commands.",
       "version": "1.0.2",
       "category": "code-quality",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,11 @@
   "plugins": [
     {
       "name": "slopmop",
-      "source": ".",
-      "description": "Protocols for highly efficient and directed remediation of known quality issues — the swab/scour/buff/sail loop as a skill plus slash commands.",
+      "source": {
+        "source": "github",
+        "repo": "ScienceIsNeato/slop-mop"
+      },
+      "description": "Protocols for highly efficient and directed remediation of known quality issues — refit onboarding plus the swab/scour/buff/sail loop as a skill and slash commands.",
       "version": "1.0.2",
       "category": "code-quality",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "version": "1.0.2",
-  "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding plus the swab/scour/buff/sail remediation loop as a Claude skill and slash commands.",
+  "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
   "author": {
     "name": "ScienceIsNeato",
     "url": "https://github.com/ScienceIsNeato"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "version": "1.0.2",
-  "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides the swab/scour/buff/sail remediation loop as a Claude skill plus slash commands.",
+  "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding plus the swab/scour/buff/sail remediation loop as a Claude skill and slash commands.",
   "author": {
     "name": "ScienceIsNeato",
     "url": "https://github.com/ScienceIsNeato"

--- a/DOCS/PENETRATION_EFFORTS.md
+++ b/DOCS/PENETRATION_EFFORTS.md
@@ -101,7 +101,8 @@ slop-mop/
 │   ├── sm-sail.md
 │   ├── sm-swab.md
 │   ├── sm-scour.md
-│   └── sm-buff.md
+│   ├── sm-buff.md
+│   └── sm-barnacle.md
 ├── assets/
 │   └── claude-skill-demo.gif
 └── slopmop/

--- a/DOCS/PENETRATION_EFFORTS.md
+++ b/DOCS/PENETRATION_EFFORTS.md
@@ -97,6 +97,7 @@ slop-mop/
 │   └── slopmop/
 │       └── SKILL.md
 ├── commands/
+│   ├── sm-refit.md
 │   ├── sm-sail.md
 │   ├── sm-swab.md
 │   ├── sm-scour.md

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ It reads the current workflow state and runs the next obvious slop-mop verb.
 ## Use with Claude
 
 Slop-mop ships as a Claude plugin: a skill that auto-triggers on remediation
-prompts, plus five slash commands (`/sm-refit`, `/sm-sail`, `/sm-swab`,
-`/sm-scour`, `/sm-buff`). Install once and `sm` is available in every repo — no
-per-repo `sm agent install` required.
+prompts, plus six slash commands (`/sm-refit`, `/sm-sail`, `/sm-swab`,
+`/sm-scour`, `/sm-buff`, `/sm-barnacle`). Install once and `sm` is available in
+every repo — no per-repo `sm agent install` required.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ScienceIsNeato/slop-mop/main/assets/claude-skill-demo.gif" alt="Demo: sm scour flagging a bogus test, an uncovered function, and a silenced gate in one run" width="780"/>
@@ -116,11 +116,16 @@ In Claude Code or Cowork:
 ```
 
 Then ask Claude things like *"refit this repo"*, *"sail this repo"*, *"swab my
-changes before I commit"*, or *"buff PR 142"*. The skill activates on
-remediation language and runs the right verb.
+changes before I commit"*, *"buff PR 142"*, or *"file a barnacle for this sm
+friction"*. The skill activates on remediation language and runs the right verb.
 
 The CLI itself is still a prerequisite — install it once with
 `pipx install slopmop[all]` and the plugin will call into it.
+
+When `sm` itself gives invalid guidance or blocks valid work, use
+`/sm-barnacle` or `sm barnacle file`. That is the preferred internal friction
+reporting path; do not file ad hoc `gh issue create` reports for slop-mop
+tooling defects.
 
 Distribution notes, promotion TODOs, and adoption-tracking signals live in
 [DOCS/PENETRATION_EFFORTS.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/PENETRATION_EFFORTS.md).

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ It reads the current workflow state and runs the next obvious slop-mop verb.
 ## Use with Claude
 
 Slop-mop ships as a Claude plugin: a skill that auto-triggers on remediation
-prompts, plus four slash commands (`/sm-sail`, `/sm-swab`, `/sm-scour`,
-`/sm-buff`). Install once and `sm` is available in every repo — no per-repo
-`sm agent install` required.
+prompts, plus five slash commands (`/sm-refit`, `/sm-sail`, `/sm-swab`,
+`/sm-scour`, `/sm-buff`). Install once and `sm` is available in every repo — no
+per-repo `sm agent install` required.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ScienceIsNeato/slop-mop/main/assets/claude-skill-demo.gif" alt="Demo: sm scour flagging a bogus test, an uncovered function, and a silenced gate in one run" width="780"/>
@@ -115,9 +115,9 @@ In Claude Code or Cowork:
 /plugin install slopmop
 ```
 
-Then ask Claude things like *"sail this repo"*, *"swab my changes before I
-commit"*, or *"buff PR 142"*. The skill activates on remediation language and
-runs the right verb.
+Then ask Claude things like *"refit this repo"*, *"sail this repo"*, *"swab my
+changes before I commit"*, or *"buff PR 142"*. The skill activates on
+remediation language and runs the right verb.
 
 The CLI itself is still a prerequisite — install it once with
 `pipx install slopmop[all]` and the plugin will call into it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -20,6 +20,8 @@ Branch: `feat/claude-refit-command`
   `sm` installation prerequisite hint.
 - Matched installed Claude `/sm-sail` to the published command's first-time
   `sm refit --start` onboarding hint.
+- Applied the Black formatting change required by PR `#179`'s primary code
+  scanning gate for `slopmop/cli/sail.py`.
 
 **Validation:**
 - `./sm swab --static` ✅

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,25 @@
 # Project Status
 
+## 2026-05-05 Delta: Claude refit slash command
+
+Branch: `feat/claude-refit-command`
+
+**Work completed:**
+- Added `/sm-refit` to the published Claude plugin commands and the installed
+  Claude template commands.
+- Updated Claude skill/plugin descriptions so refit is advertised as the
+  onboarding rail alongside the maintenance loop.
+- Updated README and penetration-efforts docs to list `/sm-refit` with the
+  Claude command set.
+- Added install-template regressions so Claude command coverage includes refit.
+
+**Validation:**
+- `./sm swab --static` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+  (known non-blocking dependency-risk warning remains)
+
+**Next:** Branch is ready for PR creation.
+
 ## 2026-05-04 Delta: Remove Claude demo scaffolding scripts
 
 Branch: `feat/claude-skill-plugin`  ·  PR `#172`

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,12 @@ Branch: `feat/claude-refit-command`
 - Updated README and penetration-efforts docs to list `/sm-refit` with the
   Claude command set.
 - Added install-template regressions so Claude command coverage includes refit.
+- Exposed `/sm-barnacle` in the Claude command surface as the preferred internal
+  slop-mop friction reporting path.
+- Added install-template regressions proving every agent target mentions
+  `sm refit` and `sm barnacle file`.
+- Normalized installed Claude slash commands so every verb includes the same
+  `sm` installation prerequisite hint.
 
 **Validation:**
 - `./sm swab --static` ✅

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,8 @@ Branch: `feat/claude-refit-command`
   `sm refit` and `sm barnacle file`.
 - Normalized installed Claude slash commands so every verb includes the same
   `sm` installation prerequisite hint.
+- Matched installed Claude `/sm-sail` to the published command's first-time
+  `sm refit --start` onboarding hint.
 
 **Validation:**
 - `./sm swab --static` ✅

--- a/commands/sm-barnacle.md
+++ b/commands/sm-barnacle.md
@@ -1,0 +1,30 @@
+# /sm-barnacle — report slop-mop tool friction
+
+Use when `sm` itself gives invalid guidance, blocks valid work, produces
+confusing output, or breaks install/upgrade/refit flow.  Do not use this for
+real target-repo failures; fix those through the normal rail.
+
+```bash
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "what should have happened" \
+  --actual "what happened instead" \
+  --repro-step "how to reproduce it" \
+  --tried "what you already tried" \
+  --workflow swab \
+  --blocker-type blocking \
+  --json
+```
+
+Use `--dry-run` when GitHub auth is unavailable.  The generated issue body is
+written to `.slopmop/last_barnacle_issue.md`; pass `--body-file <path>` when a
+specific retry artifact path matters.
+
+The point is to improve the rail, not hide the defect.  File the barnacle, then
+continue only if the friction is non-blocking.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/commands/sm-buff.md
+++ b/commands/sm-buff.md
@@ -9,3 +9,8 @@ Usage: Run `sm buff <PR_NUMBER>` after CI completes or review feedback lands.
 3. Propose a concrete remediation plan for each actionable item.
 
 This converts raw feedback into your next set of tasks. Never mark a failing check as resolved without actually fixing it.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/commands/sm-refit.md
+++ b/commands/sm-refit.md
@@ -1,0 +1,17 @@
+# /sm-refit
+
+Run slop-mop's one-time onboarding remediation rail for this repository.
+
+1. For an existing repo that has not been remediated, start with `sm refit --start`.
+2. Fix the current gate or blocker it reports.
+3. Run `sm refit --iterate` to resume the stored plan.
+4. Repeat until the plan is complete, then run `sm refit --finish`.
+
+This is step 0 for inherited or already-messy repositories. Let refit own the
+structured remediation plan and commits; use the swab/scour/buff loop after the
+repo has entered maintenance.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/commands/sm-sail.md
+++ b/commands/sm-sail.md
@@ -8,3 +8,10 @@ Auto-advance the slop-mop workflow loop for this repository.
 4. Repeat until the PR lands.
 
 This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
+
+**First time in a repo?** If `sm sail` reports no workflow state, the repo hasn't been onboarded yet. Run `sm refit --start` to begin.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/commands/sm-scour.md
+++ b/commands/sm-scour.md
@@ -7,3 +7,8 @@ Run slop-mop's comprehensive pre-PR sweep for this repository.
 3. Propose concrete fixes for each.
 
 Only open or update a PR when `sm scour` reports a clean run.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/commands/sm-swab.md
+++ b/commands/sm-swab.md
@@ -8,3 +8,8 @@ Run slop-mop's iterative development loop for this repository.
 4. Re-run `sm swab` until clean.
 
 This is your inner development loop. Run it early and often — each pass reduces repo entropy. Never bypass or silence a failing check.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -3,8 +3,8 @@ name: slopmop
 description: >-
   Trigger when you would normally reach for pytest, gh, mypy, black, or other
   raw repo tooling in a slop-mop repository. Redirect to `sm swab`,
-  `sm scour`, `sm buff`, `sm sail`, or `sm doctor` so remediation follows the
-  repository's established rails.
+  `sm scour`, `sm buff`, `sm sail`, `sm refit`, or `sm doctor` so remediation
+  follows the repository's established rails.
 ---
 
 # Slop-mop skill
@@ -51,6 +51,7 @@ Then re-run the command.
 - Never bypass or silence a failing check — that's how repo rot compounds.
 - If a gate seems wrong, tune it or file a bug. Don't disable it as a workaround.
 - Report friction (invalid guidance, broken state, blocked rails) rather than work around it.
+- If you find a bug in the plugin itself (broken commands, bad guidance, etc.), file it at https://github.com/ScienceIsNeato/slop-mop/issues with label `triage:needed` — not against the host repo.
 
 ## Reference
 

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -2,12 +2,15 @@
 name: slopmop
 description: >-
   Trigger when you would normally reach for pytest, gh, mypy, black, or other
-  raw repo tooling in a slop-mop repository. Redirect to `sm swab`,
-  `sm scour`, `sm buff`, `sm sail`, `sm refit`, or `sm doctor` so remediation
-  follows the repository's established rails.
+  raw repo tooling. Redirect to `sm swab`, `sm scour`, `sm buff`, `sm sail`,
+  `sm refit`, or `sm doctor` so remediation follows the established rails.
+  Also trigger when filing issues about slop-mop friction — use
+  `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
 ---
 
 # Slop-mop skill
+
+> **Filing slop-mop friction?** Use `/sm-barnacle` or `sm barnacle file` — **never `gh issue create` directly**. The barnacle CLI auto-applies the correct labels and targets the right repo regardless of where you are.
 
 Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **maintenance** (steady-state development). Refit remediates all existing slop and installs permanent guards; the swab/scour/buff loop then keeps the repo clean as you work.
 
@@ -50,8 +53,7 @@ Then re-run the command.
 
 - Never bypass or silence a failing check — that's how repo rot compounds.
 - If a gate seems wrong, tune it or file a bug. Don't disable it as a workaround.
-- Report friction (invalid guidance, broken state, blocked rails) rather than work around it.
-- If you find a bug in the plugin itself (broken commands, bad guidance, etc.), use `/sm-barnacle` or `sm barnacle file` — never `gh issue create` directly. The barnacle command automatically applies the correct labels and files against the slop-mop repo.
+- Report friction (invalid guidance, broken state, blocked rails) via `/sm-barnacle` rather than working around it.
 
 ## Reference
 

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -51,7 +51,7 @@ Then re-run the command.
 - Never bypass or silence a failing check — that's how repo rot compounds.
 - If a gate seems wrong, tune it or file a bug. Don't disable it as a workaround.
 - Report friction (invalid guidance, broken state, blocked rails) rather than work around it.
-- If you find a bug in the plugin itself (broken commands, bad guidance, etc.), file it at https://github.com/ScienceIsNeato/slop-mop/issues with label `triage:needed` — not against the host repo.
+- If you find a bug in the plugin itself (broken commands, bad guidance, etc.), use `/sm-barnacle` or `sm barnacle file` — never `gh issue create` directly. The barnacle command automatically applies the correct labels and files against the slop-mop repo.
 
 ## Reference
 

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -19,6 +19,7 @@ when your impulse is the left column, run the right column instead.
 | Reading CI logs to find the failing test          | `sm buff inspect <PR#>`                      |
 | `gh api ... resolveReviewThread`                  | `sm buff resolve <PR#> <THREAD_ID> -m "..."` |
 | `gh pr review --approve` after addressing threads | `sm buff verify <PR#>` first                 |
+| `gh issue create` for slop-mop tool friction      | `sm barnacle file`                           |
 | "not sure what to do next"                        | `sm sail`                                    |
 | "why won't sm / this gate run?"                   | `sm doctor`                                  |
 | Stale `.slopmop/sm.lock`, broken state dir        | `sm doctor --fix`                            |
@@ -34,6 +35,8 @@ when your impulse is the left column, run the right column instead.
   remediation plan — it knows which check failed and what you need to
   do next, not just that something is red.
 - **NEVER** open or update a PR without `sm scour` passing first.
+- **NEVER** file slop-mop tool-friction issues with raw `gh issue create`.
+  `sm barnacle file` adds the correct labels, issue shape, and source context.
 - **NEVER** bypass or silence a failing check.  If a gate is wrong,
   fix the gate.  If your env is wrong, `sm doctor` will tell you.
 

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-barnacle.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-barnacle.md
@@ -23,3 +23,8 @@ specific retry artifact path matters.
 
 The point is to improve the rail, not hide the defect.  File the barnacle, then
 continue only if the friction is non-blocking.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-buff.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-buff.md
@@ -16,3 +16,8 @@ remediation plan.
 Never run raw `gh pr checks [--watch]` or read CI logs by hand.  Buff
 knows which check failed *and* what to do about it.  `gh` only knows
 the colour.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-refit.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-refit.md
@@ -1,0 +1,17 @@
+# /sm-refit
+
+Run slop-mop's one-time onboarding remediation rail for this repository.
+
+1. For an existing repo that has not been remediated, start with `sm refit --start`.
+2. Fix the current gate or blocker it reports.
+3. Run `sm refit --iterate` to resume the stored plan.
+4. Repeat until the plan is complete, then run `sm refit --finish`.
+
+This is step 0 for inherited or already-messy repositories. Let refit own the
+structured remediation plan and commits; use the swab/scour/buff loop after the
+repo has entered maintenance.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
@@ -9,6 +9,8 @@ Auto-advance the slop-mop workflow loop for this repository.
 
 This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
 
+**First time in a repo?** If `sm sail` reports no workflow state, the repo hasn't been onboarded yet. Run `sm refit --start` to begin.
+
 **Prerequisite:** `sm` must be installed. If `command not found`, suggest:
 ```bash
 pipx install slopmop[all]

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
@@ -8,3 +8,8 @@ Auto-advance the slop-mop workflow loop for this repository.
 4. Repeat until the PR lands.
 
 This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-scour.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-scour.md
@@ -17,3 +17,8 @@ Workflow:
 3. Only open or update a PR when `sm scour` reports clean.
 
 Do not push while scour is red.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-swab.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-swab.md
@@ -11,3 +11,8 @@ auto-fixes what it can.
    dependency ordering.
 
 Rerun after every meaningful edit.  The cache makes re-runs cheap.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
+++ b/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   repo with a single `sm` CLI.  Never run the underlying tools
   directly — `sm swab` for fast iteration, `sm scour` before a PR,
   `sm buff` after CI or review feedback, `sm doctor` when the
-  environment looks broken, `sm sail` when unsure what to do next.
+  environment looks broken, `sm refit` for onboarding existing repos,
+  `sm sail` when unsure what to do next.
   Use `sm barnacle file` when slop-mop itself causes tool friction
   that needs upstream maintainer triage.
 ---

--- a/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
+++ b/slopmop/agent_install/templates/claude/.claude/skills/slopmop/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   `sm buff` after CI or review feedback, `sm doctor` when the
   environment looks broken, `sm refit` for onboarding existing repos,
   `sm sail` when unsure what to do next.
-  Use `sm barnacle file` when slop-mop itself causes tool friction
-  that needs upstream maintainer triage.
+  Use `sm barnacle file` (never `gh issue create`) when slop-mop
+  itself causes tool friction — the barnacle CLI auto-applies labels
+  and targets the right repo.
 ---
 
 {{CORE}}

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -83,6 +83,22 @@ def _has_unpushed_commits(project_root: Path) -> bool:
     return ahead > 0
 
 
+def _onboard_status(project_root: Path) -> str:
+    """Return the onboarding status of the repo.
+
+    Returns:
+        "onboarded"  — .slopmop/ dir exists; repo is in the workflow loop.
+        "init_done"  — .sb_config.json exists but .slopmop/ does not;
+                       sm init ran but sm refit --start has not.
+        "fresh"      — neither exists; repo has never been touched by slopmop.
+    """
+    if (project_root / ".slopmop").exists():
+        return "onboarded"
+    if (project_root / ".sb_config.json").exists():
+        return "init_done"
+    return "fresh"
+
+
 def _reconcile_runtime_state(
     state: WorkflowState,
     project_root: Path,
@@ -303,6 +319,25 @@ _STATE_HANDLERS = {
 def cmd_sail(args: argparse.Namespace) -> int:
     """Auto-advance the workflow: detect state and do the next thing."""
     project_root = Path(getattr(args, "project_root", "."))
+
+    status = _onboard_status(project_root)
+    if status == "fresh":
+        _print_step(
+            "🆕",
+            "Repo not onboarded",
+            "This repo hasn't been set up with slop-mop yet.\n"
+            "   Run: sm refit --start",
+        )
+        return 1
+    if status == "init_done":
+        _print_step(
+            "🔧",
+            "Onboarding incomplete",
+            "sm init ran but refit hasn't started.\n"
+            "   Run: sm refit --start",
+        )
+        return 1
+
     persisted_state = read_state(project_root) or WorkflowState.IDLE
     state = _reconcile_runtime_state(persisted_state, project_root)
     if state != persisted_state:

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -333,8 +333,7 @@ def cmd_sail(args: argparse.Namespace) -> int:
         _print_step(
             "🔧",
             "Onboarding incomplete",
-            "sm init ran but refit hasn't started.\n"
-            "   Run: sm refit --start",
+            "sm init ran but refit hasn't started.\n" "   Run: sm refit --start",
         )
         return 1
 

--- a/tests/unit/test_agent_install.py
+++ b/tests/unit/test_agent_install.py
@@ -322,7 +322,9 @@ class TestCmdAgent:
         assert (tmp_path / ".claude/commands/sm-swab.md").exists()
         assert (tmp_path / ".claude/commands/sm-scour.md").exists()
         assert (tmp_path / ".claude/commands/sm-buff.md").exists()
+        assert (tmp_path / ".claude/commands/sm-sail.md").exists()
         assert (tmp_path / ".claude/commands/sm-refit.md").exists()
+        assert (tmp_path / ".claude/commands/sm-barnacle.md").exists()
         assert (tmp_path / ".claude/skills/slopmop/SKILL.md").exists()
         assert (tmp_path / "CLAUDE.md").exists()
         assert (tmp_path / ".github/copilot-instructions.md").exists()
@@ -379,6 +381,52 @@ class TestCmdAgent:
         for label, path in targets_with_buff.items():
             text = (tmp_path / path).read_text(encoding="utf-8")
             assert "sm buff" in text, f"{label} ({path}) missing 'sm buff'"
+
+    def test_installed_templates_include_refit_for_every_target(self, tmp_path):
+        """Every agent install target exposes refit as the onboarding rail."""
+        args = _make_args(tmp_path)
+
+        result = cmd_agent(args)
+
+        assert result == 0
+
+        target_docs = {
+            "cursor": ".cursor/rules/slopmop-swab.mdc",
+            "claude": "CLAUDE.md",
+            "copilot": ".github/copilot-instructions.md",
+            "windsurf": ".windsurf/rules/slopmop.md",
+            "cline": ".clinerules/slopmop.md",
+            "roo": ".roo/rules/01-slopmop.md",
+            "aider": "CONVENTIONS.md",
+            "antigravity": ".agents/rules/slopmop.md",
+        }
+        for label, path in target_docs.items():
+            text = (tmp_path / path).read_text(encoding="utf-8")
+            assert "sm refit" in text, f"{label} ({path}) missing 'sm refit'"
+
+    def test_installed_templates_include_barnacle_for_every_target(self, tmp_path):
+        """Every agent install target directs sm friction through barnacles."""
+        args = _make_args(tmp_path)
+
+        result = cmd_agent(args)
+
+        assert result == 0
+
+        target_docs = {
+            "cursor": ".cursor/rules/slopmop-swab.mdc",
+            "claude": "CLAUDE.md",
+            "copilot": ".github/copilot-instructions.md",
+            "windsurf": ".windsurf/rules/slopmop.md",
+            "cline": ".clinerules/slopmop.md",
+            "roo": ".roo/rules/01-slopmop.md",
+            "aider": "CONVENTIONS.md",
+            "antigravity": ".agents/rules/slopmop.md",
+        }
+        for label, path in target_docs.items():
+            text = (tmp_path / path).read_text(encoding="utf-8")
+            assert (
+                "sm barnacle file" in text
+            ), f"{label} ({path}) missing 'sm barnacle file'"
 
     def test_installed_content_has_substitution_framing(self, tmp_path):
         """Installed files redirect tool impulses — the instead-of table."""

--- a/tests/unit/test_agent_install.py
+++ b/tests/unit/test_agent_install.py
@@ -220,9 +220,11 @@ class TestClaudeSkill:
             for a in assets
             if "/commands/" in a.destination_relpath
         }
-        assert len(commands) == 5
+        assert len(commands) == 6
         for path, text in commands.items():
-            if "swab" in path:
+            if "refit" in path:
+                assert "sm refit" in text
+            elif "swab" in path:
                 assert "sm swab" in text
             elif "scour" in path:
                 assert "sm scour" in text
@@ -261,6 +263,7 @@ class TestAgentHelpers:
         """
         templates = _templates_for_target("claude")
         paths = [t.relative_path for t in templates]
+        assert ".claude/commands/sm-refit.md" in paths
         assert ".claude/commands/sm-swab.md" in paths
         assert ".claude/commands/sm-scour.md" in paths
         assert ".claude/commands/sm-buff.md" in paths
@@ -319,6 +322,7 @@ class TestCmdAgent:
         assert (tmp_path / ".claude/commands/sm-swab.md").exists()
         assert (tmp_path / ".claude/commands/sm-scour.md").exists()
         assert (tmp_path / ".claude/commands/sm-buff.md").exists()
+        assert (tmp_path / ".claude/commands/sm-refit.md").exists()
         assert (tmp_path / ".claude/skills/slopmop/SKILL.md").exists()
         assert (tmp_path / "CLAUDE.md").exists()
         assert (tmp_path / ".github/copilot-instructions.md").exists()

--- a/tests/unit/test_agent_install.py
+++ b/tests/unit/test_agent_install.py
@@ -232,6 +232,7 @@ class TestClaudeSkill:
                 assert "sm buff" in text
             elif "sail" in path:
                 assert "sm sail" in text
+                assert "sm refit --start" in text
             elif "barnacle" in path:
                 assert "sm barnacle" in text
 

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from slopmop.cli import sail as sail_mod
 from slopmop.cli.scan_triage import ARTIFACT_NAME, WORKFLOW_NAME
 from slopmop.workflow.state_machine import WorkflowState
@@ -24,6 +26,11 @@ def _base_args(tmp_path: Path) -> argparse.Namespace:
 
 class TestSailDispatch:
     """Each workflow state dispatches to the correct action."""
+
+    @pytest.fixture(autouse=True)
+    def _onboarded(self, monkeypatch):
+        """Treat every repo in this class as already onboarded."""
+        monkeypatch.setattr(sail_mod, "_onboard_status", lambda _: "onboarded")
 
     def test_idle_runs_swab(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)
@@ -172,6 +179,59 @@ class TestSailDispatch:
 
         assert sail_mod.cmd_sail(args) == 0
         mock_swab.assert_called_once()
+
+
+class TestSailOnboarding:
+    """sail detects unonboarded repos and gives the right guidance."""
+
+    def test_fresh_repo_prints_guidance_and_returns_1(self, capsys, tmp_path: Path):
+        args = _base_args(tmp_path)
+        # tmp_path has no .slopmop/ and no .sb_config.json
+
+        result = sail_mod.cmd_sail(args)
+
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "sm refit --start" in out
+
+    def test_init_done_but_no_refit_prints_guidance_and_returns_1(
+        self, capsys, tmp_path: Path
+    ):
+        args = _base_args(tmp_path)
+        (tmp_path / ".sb_config.json").write_text("{}")
+
+        result = sail_mod.cmd_sail(args)
+
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "sm refit --start" in out
+
+    def test_onboarded_repo_proceeds_normally(self, monkeypatch, tmp_path: Path):
+        args = _base_args(tmp_path)
+        (tmp_path / ".slopmop").mkdir()
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.IDLE)
+        mock_swab = Mock(return_value=0)
+        monkeypatch.setattr("slopmop.cli.cmd_swab", mock_swab)
+
+        assert sail_mod.cmd_sail(args) == 0
+        mock_swab.assert_called_once()
+
+    def test_onboard_status_fresh(self, tmp_path: Path):
+        assert sail_mod._onboard_status(tmp_path) == "fresh"
+
+    def test_onboard_status_init_done(self, tmp_path: Path):
+        (tmp_path / ".sb_config.json").write_text("{}")
+        assert sail_mod._onboard_status(tmp_path) == "init_done"
+
+    def test_onboard_status_onboarded(self, tmp_path: Path):
+        (tmp_path / ".slopmop").mkdir()
+        assert sail_mod._onboard_status(tmp_path) == "onboarded"
+
+    def test_slopmop_dir_takes_precedence_over_config(self, tmp_path: Path):
+        """When both .slopmop/ and .sb_config.json exist, repo is onboarded."""
+        (tmp_path / ".slopmop").mkdir()
+        (tmp_path / ".sb_config.json").write_text("{}")
+        assert sail_mod._onboard_status(tmp_path) == "onboarded"
 
 
 class TestSwabArgs:


### PR DESCRIPTION
## Summary

- Add `/sm-refit` to the published plugin commands
- Add `/sm-barnacle` to the published plugin commands (was only in the Claude template install, missing from the distributable plugin)
- Update `SKILL.md` to direct LLMs to use `sm barnacle file` / `/sm-barnacle` instead of `gh issue create` directly — ensures `barnacle` label is always applied automatically via `DEFAULT_LABELS`
- Add prerequisite hints (`pipx install slopmop[all]`) to all slash commands
- Add first-time repo onboarding hint to `/sm-sail` pointing at `sm refit --start`

## Barnacle context

These fixes were discovered by installing the plugin on a fresh repo and observing the LLM bypass `sm barnacle file` in favour of raw `gh issue create`, losing the barnacle label. The barnacle CLI already enforces the label — LLMs just need to be told to use it.

Closes #174
Closes #177

Related (upstream/future): #176, #178

## Test plan

- [ ] Install plugin in a fresh repo: `sm-barnacle` slash command is available
- [ ] LLM prompted to report friction uses `/sm-barnacle`, not `gh issue create`
- [ ] All slash commands surface prerequisite hint when `sm` is not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)