### PR TITLE
ci: make release workflow single-click

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ on:
           - minor
           - major
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Prevent concurrent releases, but never cancel an in-progress publish. PyPI
 # forbids re-uploading the same version, so a partial publish caused by
 # cancellation would be permanently broken.
@@ -60,7 +63,7 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       previous_version: ${{ steps.resolve.outputs.previous_version }}
       tag: ${{ steps.resolve.outputs.tag }}
-      commit_sha: ${{ steps.commit.outputs.commit_sha || github.sha }}
+      commit_sha: ${{ steps.resolve.outputs.commit_sha || steps.commit.outputs.commit_sha || github.sha }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -102,6 +105,8 @@ jobs:
           BUMP: ${{ github.event.inputs.bump }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           python <<'PY'
           import os
@@ -124,32 +129,70 @@ jobs:
           current_text = pyproject.read_text()
           current = project_version(current_text)
           event_name = os.environ["GITHUB_EVENT_NAME"]
+          commit_sha = ""
 
           if event_name == "workflow_dispatch":
-              bump = os.environ["BUMP"]
-              major, minor, patch = [int(part) for part in current.split(".")]
-              if bump == "major":
-                  major += 1
-                  minor = 0
-                  patch = 0
-              elif bump == "minor":
-                  minor += 1
-                  patch = 0
+              run_id = os.environ["GITHUB_RUN_ID"]
+              if os.environ.get("GITHUB_RUN_ATTEMPT") != "1":
+                  marker = f"[release-run:{run_id}]"
+                  commit_sha = subprocess.run(
+                      [
+                          "git",
+                          "log",
+                          "origin/main",
+                          "--grep",
+                          marker,
+                          "-n",
+                          "1",
+                          "--format=%H",
+                      ],
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  ).stdout.strip()
+                  if not commit_sha:
+                      raise SystemExit(
+                          f"Could not find original release commit for run {run_id}"
+                      )
+                  current_text = subprocess.run(
+                      ["git", "show", f"{commit_sha}:pyproject.toml"],
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  ).stdout
+                  parent_text = subprocess.run(
+                      ["git", "show", f"{commit_sha}^:pyproject.toml"],
+                      capture_output=True,
+                      text=True,
+                      check=True,
+                  ).stdout
+                  version = project_version(current_text)
+                  previous = project_version(parent_text)
               else:
-                  patch += 1
+                  bump = os.environ["BUMP"]
+                  major, minor, patch = [int(part) for part in current.split(".")]
+                  if bump == "major":
+                      major += 1
+                      minor = 0
+                      patch = 0
+                  elif bump == "minor":
+                      minor += 1
+                      patch = 0
+                  else:
+                      patch += 1
 
-              version = f"{major}.{minor}.{patch}"
-              previous = current
-              updated = re.sub(
-                  r'^version\s*=\s*"[^"]+"',
-                  f'version = "{version}"',
-                  current_text,
-                  count=1,
-                  flags=re.MULTILINE,
-              )
-              if updated == current_text:
-                  raise SystemExit("Could not update version in pyproject.toml")
-              pyproject.write_text(updated)
+                  version = f"{major}.{minor}.{patch}"
+                  previous = current
+                  updated = re.sub(
+                      r'^version\s*=\s*"[^"]+"',
+                      f'version = "{version}"',
+                      current_text,
+                      count=1,
+                      flags=re.MULTILINE,
+                  )
+                  if updated == current_text:
+                      raise SystemExit("Could not update version in pyproject.toml")
+                  pyproject.write_text(updated)
               should_release = "true"
           else:
               version = current
@@ -188,6 +231,7 @@ jobs:
           write_output("version", version)
           write_output("previous_version", previous_for_output)
           write_output("tag", tag)
+          write_output("commit_sha", commit_sha)
 
           summary = os.environ.get("GITHUB_STEP_SUMMARY")
           if summary:
@@ -204,14 +248,15 @@ jobs:
 
       - name: Commit manual version bump
         id: commit
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && steps.resolve.outputs.commit_sha == ''
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
-          git commit -m "chore: bump version to ${VERSION} for PyPI release [skip release]"
+          git commit -m "chore: bump version to ${VERSION} for PyPI release [skip release] [release-run:${GITHUB_RUN_ID}]"
           git push origin HEAD:main
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,12 +346,6 @@ jobs:
           sm init >/dev/null
           sm swab --help >/dev/null
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v5
-        with:
-          name: dist
-          path: dist/
-
   publish-pypi:
     name: Publish to PyPI
     needs:
@@ -363,11 +357,18 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v5
+      - uses: actions/checkout@v5
         with:
-          name: dist
-          path: dist/
+          ref: ${{ needs.release-context.outputs.commit_sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build package for PyPI publish
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -388,11 +389,14 @@ jobs:
         with:
           ref: ${{ needs.release-context.outputs.commit_sha }}
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v5
+      - uses: actions/setup-python@v6
         with:
-          name: dist
-          path: dist/
+          python-version: "3.13"
+
+      - name: Build package for GitHub Release assets
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
 # Prepare and publish PyPI releases.
 #
 # Workflow:
-#   1. Run "Release" manually with a bump type to create the version-bump PR
-#   2. Review and merge that PR
-#   3. This workflow detects the pyproject.toml version bump on main
-#   4. The publish path builds the package, uploads to PyPI, and creates the
-#      tag/release automatically
+#   1. Run "Release" manually from main with a bump type
+#   2. The workflow bumps pyproject.toml, commits the bump to main, validates,
+#      builds, publishes to PyPI, and creates the GitHub release
+#
+# The push trigger remains for release PR/script fallback. Manual release commits
+# include [skip release] so the commit they push does not start a duplicate run.
 #
 # Prerequisites (one-time setup):
 #   - Create a PyPI account at https://pypi.org/account/register/
@@ -15,6 +16,8 @@
 #       Repository: slop-mop
 #       Workflow:   release.yml
 #       Environment: pypi
+#   - Allow this workflow's token to write to main, or allow the Actions bot to
+#     bypass branch protection for the version-bump commit
 #   - (Optional) Do the same on https://test.pypi.org for staging
 
 name: Release
@@ -36,38 +39,49 @@ on:
           - minor
           - major
 
-# Prevent concurrent mainline releases, but never cancel an in-progress publish
-# — PyPI forbids re-uploading the same version, so a partial publish caused by
+# Prevent concurrent releases, but never cancel an in-progress publish. PyPI
+# forbids re-uploading the same version, so a partial publish caused by
 # cancellation would be permanently broken.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
-  prepare-release:
-    name: Prepare Release (${{ github.event.inputs.bump }})
-    if: github.event_name == 'workflow_dispatch'
+  release-context:
+    name: Prepare Release Context
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+    outputs:
+      should_release: ${{ steps.resolve.outputs.should_release }}
+      version: ${{ steps.resolve.outputs.version }}
+      previous_version: ${{ steps.resolve.outputs.previous_version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha || github.sha }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ github.token }}
-          # Repo settings now allow Actions to create release PRs.
-          # Post-merge publishing is handled by this workflow's publish path,
-          # so there is no manual tag-push handoff.
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
-      - name: Validate bump input
+      - name: Validate manual release dispatch
+        if: github.event_name == 'workflow_dispatch'
         env:
           BUMP: ${{ github.event.inputs.bump }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Manual releases must be dispatched from main." >&2
+            exit 1
+          fi
+
           case "$BUMP" in
             patch|minor|major) ;;
             *)
@@ -76,99 +90,135 @@ jobs:
               ;;
           esac
 
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Run release script
+      - name: Resolve release version
+        id: resolve
         env:
-          GH_TOKEN: ${{ github.token }}
           BUMP: ${{ github.event.inputs.bump }}
-        run: ./scripts/release.sh "$BUMP"
-
-  detect-release:
-    name: Detect Release Bump
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.detect.outputs.should_release }}
-      version: ${{ steps.detect.outputs.version }}
-      previous_version: ${{ steps.detect.outputs.previous_version }}
-      tag: ${{ steps.detect.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Detect version bump in pyproject.toml
-        id: detect
-        env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           python <<'PY'
           import os
+          import re
           import subprocess
           import tomllib
           from pathlib import Path
 
-          current = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
 
-          previous = current
-          before_sha = os.environ.get("GITHUB_EVENT_BEFORE", "")
-          null_sha = "0" * 40
-          if before_sha and before_sha != null_sha:
-            try:
-              previous_text = subprocess.run(
-                ["git", "show", f"{before_sha}:pyproject.toml"],
-                capture_output=True,
-                text=True,
-                check=True,
-              ).stdout
-              previous = tomllib.loads(previous_text)["project"]["version"]
-            except (
-              subprocess.CalledProcessError,
-              tomllib.TOMLDecodeError,
-              KeyError,
-            ):
-              previous = ""
-          should_release = "true" if current != previous else "false"
+          def write_output(key: str, value: str) -> None:
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                  fh.write(f"{key}={value}\n")
 
-          tag = f"v{current}"
+
+          def project_version(text: str) -> str:
+              return tomllib.loads(text)["project"]["version"]
+
+
+          pyproject = Path("pyproject.toml")
+          current_text = pyproject.read_text()
+          current = project_version(current_text)
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+
+          if event_name == "workflow_dispatch":
+              bump = os.environ["BUMP"]
+              major, minor, patch = [int(part) for part in current.split(".")]
+              if bump == "major":
+                  major += 1
+                  minor = 0
+                  patch = 0
+              elif bump == "minor":
+                  minor += 1
+                  patch = 0
+              else:
+                  patch += 1
+
+              version = f"{major}.{minor}.{patch}"
+              previous = current
+              updated = re.sub(
+                  r'^version\s*=\s*"[^"]+"',
+                  f'version = "{version}"',
+                  current_text,
+                  count=1,
+                  flags=re.MULTILINE,
+              )
+              if updated == current_text:
+                  raise SystemExit("Could not update version in pyproject.toml")
+              pyproject.write_text(updated)
+              should_release = "true"
+          else:
+              version = current
+              previous = current
+              before_sha = os.environ.get("GITHUB_EVENT_BEFORE", "")
+              null_sha = "0" * 40
+              if before_sha and before_sha != null_sha:
+                  try:
+                      previous_text = subprocess.run(
+                          ["git", "show", f"{before_sha}:pyproject.toml"],
+                          capture_output=True,
+                          text=True,
+                          check=True,
+                      ).stdout
+                      previous = project_version(previous_text)
+                  except (
+                      subprocess.CalledProcessError,
+                      tomllib.TOMLDecodeError,
+                      KeyError,
+                  ):
+                      previous = ""
+              should_release = "true" if version != previous else "false"
+
+          tag = f"v{version}"
+          tag_exists = subprocess.run(
+              ["git", "ls-remote", "--exit-code", "--tags", "origin", tag],
+              stdout=subprocess.DEVNULL,
+              stderr=subprocess.DEVNULL,
+              check=False,
+          ).returncode == 0
+          if should_release == "true" and tag_exists:
+              raise SystemExit(f"Tag {tag} already exists")
+
           previous_for_output = previous or "(missing)"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-              fh.write(f"should_release={should_release}\n")
-              fh.write(f"version={current}\n")
-              fh.write(f"previous_version={previous_for_output}\n")
-              fh.write(f"tag={tag}\n")
+          write_output("should_release", should_release)
+          write_output("version", version)
+          write_output("previous_version", previous_for_output)
+          write_output("tag", tag)
 
           summary = os.environ.get("GITHUB_STEP_SUMMARY")
           if summary:
               with open(summary, "a", encoding="utf-8") as fh:
-                if should_release == "true":
-                  fh.write(
-                    f"Release detected: {previous_for_output} -> {current} ({tag})\n"
-                  )
-                else:
-                  fh.write(
-                    f"No release version bump detected in pyproject.toml ({current}).\n"
-                  )
+                  if should_release == "true":
+                      fh.write(
+                          f"Release selected: {previous_for_output} -> {version} ({tag})\n"
+                      )
+                  else:
+                      fh.write(
+                          f"No release version bump detected in pyproject.toml ({version}).\n"
+                      )
           PY
+
+      - name: Commit manual version bump
+        id: commit
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${VERSION} for PyPI release [skip release]"
+          git push origin HEAD:main
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   quality-gate:
     name: Quality Gate
-    needs: detect-release
-    if: needs.detect-release.outputs.should_release == 'true'
+    needs: release-context
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ needs.release-context.outputs.commit_sha }}
 
       - uses: actions/setup-python@v6
         with:
@@ -198,12 +248,14 @@ jobs:
   build:
     name: Build Package
     needs:
-      - detect-release
+      - release-context
       - quality-gate
-    if: needs.detect-release.outputs.should_release == 'true'
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release-context.outputs.commit_sha }}
 
       - uses: actions/setup-python@v6
         with:
@@ -215,15 +267,15 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: Verify package version matches detected release version
+      - name: Verify package version matches release version
         run: |
-          EXPECTED_VERSION="${{ needs.detect-release.outputs.version }}"
+          EXPECTED_VERSION="${{ needs.release-context.outputs.version }}"
           TOML_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           if [ "$EXPECTED_VERSION" != "$TOML_VERSION" ]; then
-            echo "❌ Detected release version ($EXPECTED_VERSION) does not match pyproject.toml ($TOML_VERSION)"
+            echo "Detected release version ($EXPECTED_VERSION) does not match pyproject.toml ($TOML_VERSION)"
             exit 1
           fi
-          echo "✅ Version match: $EXPECTED_VERSION"
+          echo "Version match: $EXPECTED_VERSION"
 
       - name: Validate package metadata
         run: python -m twine check dist/*
@@ -252,9 +304,9 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs:
-      - detect-release
+      - release-context
       - build
-    if: needs.detect-release.outputs.should_release == 'true'
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -274,14 +326,16 @@ jobs:
   github-release:
     name: GitHub Release
     needs:
-      - detect-release
+      - release-context
       - publish-pypi
-    if: needs.detect-release.outputs.should_release == 'true'
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release-context.outputs.commit_sha }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v5
@@ -292,14 +346,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.detect-release.outputs.tag }}
+          TAG: ${{ needs.release-context.outputs.tag }}
+          TARGET: ${{ needs.release-context.outputs.commit_sha }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "✅ GitHub Release $TAG already exists"
+            echo "GitHub Release $TAG already exists"
             exit 0
           fi
 
           gh release create "$TAG" dist/* \
-            --target "${GITHUB_SHA}" \
+            --target "$TARGET" \
             --title "$TAG" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
               ;;
           esac
 
+      - name: Sync main before manual version bump
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch origin main
+          git pull --ff-only origin main
+
       - name: Resolve release version
         id: resolve
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ github.token }}
@@ -60,7 +60,7 @@ jobs:
           # Post-merge publishing is handled by this workflow's publish path,
           # so there is no manual tag-push handoff.
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -97,11 +97,11 @@ jobs:
       previous_version: ${{ steps.detect.outputs.previous_version }}
       tag: ${{ steps.detect.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -166,16 +166,16 @@ jobs:
     if: needs.detect-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: pip
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -203,9 +203,9 @@ jobs:
     if: needs.detect-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -244,7 +244,7 @@ jobs:
           sm swab --help >/dev/null
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/
@@ -261,7 +261,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/
@@ -281,10 +281,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,7 @@ jobs:
 
           if event_name == "workflow_dispatch":
               run_id = os.environ["GITHUB_RUN_ID"]
+              reuse_existing_commit = False
               if os.environ.get("GITHUB_RUN_ATTEMPT") != "1":
                   marker = f"[release-run:{run_id}]"
                   commit_sha = subprocess.run(
@@ -140,6 +141,7 @@ jobs:
                           "git",
                           "log",
                           "origin/main",
+                          "--fixed-strings",
                           "--grep",
                           marker,
                           "-n",
@@ -150,10 +152,7 @@ jobs:
                       text=True,
                       check=True,
                   ).stdout.strip()
-                  if not commit_sha:
-                      raise SystemExit(
-                          f"Could not find original release commit for run {run_id}"
-                      )
+              if commit_sha:
                   current_text = subprocess.run(
                       ["git", "show", f"{commit_sha}:pyproject.toml"],
                       capture_output=True,
@@ -168,7 +167,8 @@ jobs:
                   ).stdout
                   version = project_version(current_text)
                   previous = project_version(parent_text)
-              else:
+                  reuse_existing_commit = True
+              if not reuse_existing_commit:
                   bump = os.environ["BUMP"]
                   major, minor, patch = [int(part) for part in current.split(".")]
                   if bump == "major":
@@ -223,7 +223,7 @@ jobs:
               stderr=subprocess.DEVNULL,
               check=False,
           ).returncode == 0
-          if should_release == "true" and tag_exists:
+            if should_release == "true" and tag_exists and not commit_sha:
               raise SystemExit(f"Tag {tag} already exists")
 
           previous_for_output = previous or "(missing)"
@@ -355,6 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -87,7 +87,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # diff-cover and gate-dodging need history to compare
           # against the base branch.  Shallow clone (the default)
@@ -95,13 +95,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -172,7 +172,7 @@ jobs:
           category: slopmop
 
       - name: Upload JSON scan report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: slopmop-results
           path: slopmop-results.json
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload coverage report
         if: always() && hashFiles('coverage.xml') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage.xml
@@ -245,10 +245,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: unit-test-coverage
           if-no-files-found: warn
@@ -311,12 +311,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload test output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: docker-integration-output
           path: docker-test-output.txt

--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -56,6 +56,9 @@
 
 name: slop-mop primary code scanning gate
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -174,12 +174,6 @@ jobs:
           # (category, ruleId, fingerprint).
           category: slopmop
 
-      - name: Upload JSON scan report
-        uses: actions/upload-artifact@v5
-        with:
-          name: slopmop-results
-          path: slopmop-results.json
-
       - name: Verify coverage report exists
         if: always()
         run: |
@@ -188,13 +182,6 @@ jobs:
           else
             echo "coverage.xml was not produced by sm scour; skipping coverage upload."
           fi
-
-      - name: Upload coverage report
-        if: always() && hashFiles('coverage.xml') != ''
-        uses: actions/upload-artifact@v5
-        with:
-          name: coverage-report
-          path: coverage.xml
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
@@ -289,16 +276,6 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload coverage artifacts
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: unit-test-coverage
-          if-no-files-found: warn
-          path: |
-            coverage.xml
-            coverage-report.txt
-
   # -------------------------------------------------------------------
   # Docker integration tests
   #
@@ -338,9 +315,3 @@ jobs:
           python -m pytest tests/integration/test_docker_install.py \
             -v --tb=long -m integration 2>&1 | tee docker-test-output.txt
 
-      - name: Upload test output
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: docker-integration-output
-          path: docker-test-output.txt

--- a/.github/workflows/slopmop.yml
+++ b/.github/workflows/slopmop.yml
@@ -7,6 +7,9 @@
 
 name: slop-mop downstream dogfood sanity
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_run:
     workflows: ["slop-mop primary code scanning gate"]

--- a/.github/workflows/slopmop.yml
+++ b/.github/workflows/slopmop.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -45,19 +45,19 @@ jobs:
 
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/DOCS/RELEASING.md
+++ b/DOCS/RELEASING.md
@@ -5,7 +5,22 @@ mechanics are automated; the judgment call is still human.
 
 ## Release Flow
 
-There are two supported entry points:
+The primary release path is the GitHub Actions dispatcher: Actions →
+**Release** → **Run workflow** from `main` with the desired bump type. That
+single run performs the full release:
+
+1. bump `pyproject.toml`
+2. commit the version bump to `main`
+3. run release quality gates
+4. build and smoke-test the package
+5. publish to PyPI
+6. create the GitHub release
+
+This requires the workflow token to be allowed to write the version-bump commit
+to `main`. If branch protection blocks bot pushes, allow the Actions bot to
+bypass protection for this release workflow.
+
+The local release script remains available as a PR-based fallback:
 
 ```bash
 ./scripts/release.sh patch
@@ -13,20 +28,13 @@ There are two supported entry points:
 ./scripts/release.sh major
 ```
 
-Or the equivalent manual GitHub Actions dispatcher: Actions → **Release** →
-**Run workflow** with the desired bump type.
+The fallback script creates a release branch and PR that bumps `pyproject.toml`.
+When that PR lands on `main`, the **Release** workflow still publishes because
+the `pyproject.toml` version changed on `main`.
 
-Both paths create a release branch and PR that bumps `pyproject.toml`. When that
-PR lands on `main`, the **Release** workflow automatically publishes because the
-`pyproject.toml` version changed on `main`.
+## Fallback PR Checklist
 
-There is no second manual publish step in the normal flow. The manual workflow
-run prepares the release PR; merging that PR is the approval boundary and starts
-the PyPI publish path automatically.
-
-## Pre-Merge Checklist
-
-Before merging a release-bump PR:
+Before merging a release-bump PR created by `scripts/release.sh`:
 
 - `requirements.txt` is in sync with `pyproject.toml`
 - config migrations and `DOCS/MIGRATIONS.md` are updated for any breaking
@@ -38,8 +46,7 @@ Before merging a release-bump PR:
 
 ## Build and Publish Verification
 
-`release.yml` performs these checks before PyPI publication after the release
-PR lands on `main`:
+`release.yml` performs these checks before PyPI publication:
 
 - build `sdist` and wheel
 - verify the detected release version matches `pyproject.toml`

--- a/DOCS/RELEASING.md
+++ b/DOCS/RELEASING.md
@@ -20,6 +20,9 @@ This requires the workflow token to be allowed to write the version-bump commit
 to `main`. If branch protection blocks bot pushes, allow the Actions bot to
 bypass protection for this release workflow.
 
+If a manual release run is rerun, the workflow reuses the version-bump commit
+created by the original run instead of applying the bump again.
+
 The local release script remains available as a PR-based fallback:
 
 ```bash

--- a/STATUS.md
+++ b/STATUS.md
@@ -119,6 +119,9 @@ Branch: `fix/single-click-release`
   release in one run.
 - Preserving the `scripts/release.sh` PR-based fallback through the existing
   push-trigger publish path.
+- Addressing PR review feedback by syncing `main` before manual bump commits,
+  opting workflows into Node 24 JavaScript action execution, and making manual
+  release reruns reuse the original run's version-bump commit.
 
 **Validation:**
 - `bash -n scripts/release.sh` ✅

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,6 @@ Branch: `feat/claude-refit-command`
 **Validation:**
 - `./sm swab --static` ✅
 - `./sm scour --output-file .slopmop/last_scour.json` ✅
-- `./sm scour --output-file .slopmop/last_scour.json` ✅
   (known non-blocking dependency-risk warning remains)
 
 **Next:** Branch is ready for PR creation.

--- a/STATUS.md
+++ b/STATUS.md
@@ -122,6 +122,8 @@ Branch: `fix/single-click-release`
 - Addressing PR review feedback by syncing `main` before manual bump commits,
   opting workflows into Node 24 JavaScript action execution, and making manual
   release reruns reuse the original run's version-bump commit.
+- Removed remaining artifact upload/download actions from the workflow set so
+  Node 24 opt-in does not force unsupported artifact action runtimes.
 
 **Validation:**
 - `bash -n scripts/release.sh` ✅

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,6 +26,7 @@ Branch: `feat/claude-refit-command`
 **Validation:**
 - `./sm swab --static` ✅
 - `./sm scour --output-file .slopmop/last_scour.json` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
   (known non-blocking dependency-risk warning remains)
 
 **Next:** Branch is ready for PR creation.
@@ -89,6 +90,20 @@ Branch: `fix/release-workflow-single-trigger`
 - `bash -n scripts/release.sh` ✅
 - `./sm swab --static` ✅
 - `./sm scour --output-file .slopmop/last_scour.json` ✅
+
+## 2026-05-05 Delta: Node 24 workflow action updates
+
+Branch: `fix/node24-release-actions`
+
+**Work completed:**
+- Updating GitHub-owned workflow actions away from Node 20-backed major
+  versions so Prepare Release and related CI jobs stop emitting Node 20
+  deprecation warnings.
+- Covering `checkout`, `setup-python`, `setup-node`, and artifact upload /
+  download actions across the workflow set.
+
+**Validation:**
+- `./sm swab --static` ✅
 
 ## 2026-05-04 Delta: Remove Claude demo scaffolding scripts
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -72,6 +72,9 @@ Branch: `feat/claude-refit-command`
 **Validation:**
 - `bash -n scripts/release.sh` ✅
 - `./sm swab --static` ✅
+- `actionlint .github/workflows/release.yml` not run locally; `actionlint` is
+  not installed
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
 - `./sm scour -g myopia:dependency-risk.py --no-cache` ✅
 - `./sm scour --output-file .slopmop/last_scour.json` ✅
   (PR feedback warning remains until addressed threads are resolved)
@@ -103,6 +106,23 @@ Branch: `fix/node24-release-actions`
   download actions across the workflow set.
 
 **Validation:**
+- `./sm swab --static` ✅
+
+## 2026-05-06 Delta: Single-click release workflow
+
+Branch: `fix/single-click-release`
+
+**Work in progress:**
+- Combining the Node 24 workflow action updates with a fully automated manual
+  Release workflow.
+- Changing the manual Release dispatch to bump `pyproject.toml`, commit the
+  bump to `main`, validate, build, publish to PyPI, and create the GitHub
+  release in one run.
+- Preserving the `scripts/release.sh` PR-based fallback through the existing
+  push-trigger publish path.
+
+**Validation:**
+- `bash -n scripts/release.sh` ✅
 - `./sm swab --static` ✅
 
 ## 2026-05-04 Delta: Remove Claude demo scaffolding scripts

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,11 +13,11 @@
 #   4. Updates pyproject.toml with the new version
 #   5. Commits, pushes, and opens a PR
 #
-# The PR merge is still manual — you review the changelog, then merge.
-# Once merged, release.yml detects the version bump on main and publishes
-# automatically.
+# The PR merge is still manual. This script is the PR-based fallback for cases
+# where the one-click Release workflow should not push directly to main.
+# Once merged, release.yml detects the version bump on main and publishes.
 #
-# Can also be called from CI via the Release workflow's manual bump input.
+# The primary release path is now the GitHub Actions Release workflow.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- update GitHub-owned workflow actions to Node 24-compatible major versions
- make the manual Release workflow bump, commit, validate, build, publish to PyPI, and create the GitHub release in one run
- keep the pyproject.toml push trigger for the PR-based release script fallback while using [skip release] on workflow-created bump commits to avoid duplicate runs

## Validation

- bash -n scripts/release.sh
- ./sm swab --static
- ./sm scour --output-file .slopmop/last_scour.json
- VS Code diagnostics: clean for release.yml, docs, release.sh, STATUS.md
- actionlint not run locally; actionlint is not installed
