### PR TITLE
feat: add GitHub Actions hygiene gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
               stderr=subprocess.DEVNULL,
               check=False,
           ).returncode == 0
-            if should_release == "true" and tag_exists and not commit_sha:
+          if should_release == "true" and tag_exists and not commit_sha:
               raise SystemExit(f"Tag {tag} already exists")
 
           previous_for_output = previous or "(missing)"

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,18 @@
 
 Branch: `feat/github-actions-hygiene-gate`
 
+**Follow-up after PR CI:**
+- Clarified the CI scour failure summary so scour-only gate labels include the
+  actionable error/status detail instead of only the gate name.
+- Added regression coverage for the scour summary display and expanded GitHub
+  Actions hygiene tests across no-op workflows, permission inheritance,
+  OIDC publish variants, actionlint output parsing, heredoc extraction, and
+  workflow file discovery.
+
+**Follow-up validation:**
+- `./sm swab -g overconfidence:untested-code.py --static` ✅
+- `./sm scour -g myopia:just-this-once.py --static --no-cache` ✅
+
 **Work completed:**
 - Added `myopia:github-actions-hygiene`, a composite GitHub Actions gate that
   runs on `swab` and `scour`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,28 @@
 # Project Status
 
+## 2026-05-06 Delta: GitHub Actions hygiene gate design
+
+Branch: `feat/github-actions-hygiene-gate`
+
+**Work completed:**
+- Added `myopia:github-actions-hygiene`, a composite GitHub Actions gate that
+  runs on `swab` and `scour`.
+- The gate scans `.github/workflows/*.yml` and `.github/workflows/*.yaml`,
+  parses workflow YAML, optionally consumes `actionlint` when installed, and
+  pre-parses embedded Python heredocs.
+- Added high-confidence hard failures for restrictive checkout permissions,
+  OIDC publish jobs missing `id-token: write`, and known deprecated GitHub-owned
+  action majors.
+- Fixed the release workflow indentation defect that the new gate caught.
+- Added unit coverage for YAML parse failures, embedded Python parse failures,
+  checkout permission policy, OIDC publish policy, deprecated actions, and the
+  no-explicit-permissions default case.
+
+**Validation:**
+- `./sm swab -g myopia:github-actions-hygiene --static` ✅
+- `./sm swab --static` ✅
+- `./sm scour --output-file .slopmop/last_scour.json` ✅
+
 ## 2026-05-05 Delta: Claude refit slash command
 
 Branch: `feat/claude-refit-command`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "tomli>=1.0.0; python_version < '3.11'",
     "packaging>=21.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -55,6 +56,7 @@ lint = [
 typing = [
     "mypy>=1.17.0",
     "pyright>=1.1.0",
+    "types-PyYAML>=6.0.12",
 ]
 # Static analysis (dead code, complexity)
 analysis = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@
 # Core runtime
 tomli>=1.0.0; python_version < '3.11'
 packaging>=21.0
+PyYAML>=6.0
 
 # Static analysis
 vulture>=2.14
@@ -25,6 +26,7 @@ ruff>=0.1.0
 # Type checking
 mypy>=1.17.0
 pyright>=1.1.0
+types-PyYAML>=6.0.12
 
 # Security scanning
 bandit>=1.7.0

--- a/scripts/summarize_scour_failure.py
+++ b/scripts/summarize_scour_failure.py
@@ -164,12 +164,35 @@ def _classify_failed_gates(
         classification_line = "SWAB-overlap failures"
         print("::notice::Classification: CI failed on gates that are also in SWAB.")
 
-    if swab_failed:
-        print(f"::error::SWAB-overlap failed gates: {', '.join(swab_failed)}")
-    if scour_only_failed:
-        print(f"::error::SCOUR-only failed gates: {', '.join(scour_only_failed)}")
+    swab_labels = _gate_failure_labels(actionable, swab_failed)
+    scour_only_labels = _gate_failure_labels(actionable, scour_only_failed)
 
-    return classification_line, swab_failed, scour_only_failed
+    if swab_failed:
+        print(f"::error::SWAB-overlap failed gates: {', '.join(swab_labels)}")
+    if scour_only_failed:
+        print(f"::error::SCOUR-only failed gates: {', '.join(scour_only_labels)}")
+
+    return classification_line, swab_labels, scour_only_labels
+
+
+def _gate_failure_labels(
+    actionable: list[dict[str, Any]],
+    gate_names: list[str],
+) -> list[str]:
+    """Return gate labels with the first actionable error attached."""
+    labels: list[str] = []
+    for gate_name in gate_names:
+        matching = next(
+            (row for row in actionable if str(row.get("name", "")) == gate_name),
+            None,
+        )
+        detail = ""
+        if matching is not None:
+            error = str(matching.get("error") or "").strip()
+            status_detail = str(matching.get("status_detail") or "").strip()
+            detail = error or status_detail
+        labels.append(f"{gate_name} — {detail}" if detail else gate_name)
+    return labels
 
 
 def _print_actionable_details(actionable: list[dict[str, Any]]) -> list[str]:

--- a/slopmop/checks/__init__.py
+++ b/slopmop/checks/__init__.py
@@ -98,9 +98,11 @@ def _register_crosscutting_checks(registry: CheckRegistry) -> None:
         StringDuplicationCheck,
     )
     from slopmop.checks.security import SecurityCheck, SecurityLocalCheck
+    from slopmop.checks.workflow import GitHubActionsHygieneCheck
 
     registry.register(SecurityCheck)
     registry.register(SecurityLocalCheck)
+    registry.register(GitHubActionsHygieneCheck)
     registry.register(AmbiguityMinesCheck)
     registry.register(BogusTestsCheck)
     registry.register(ComplexityCheck)

--- a/slopmop/checks/metadata.py
+++ b/slopmop/checks/metadata.py
@@ -438,6 +438,29 @@ def _myopia_scope_reasoning_entries() -> tuple[tuple[type[BaseCheck], Reasoning]
     )
 
 
+def _github_actions_hygiene_reasoning_entry() -> tuple[type[BaseCheck], Reasoning]:
+    from slopmop.checks.workflow import GitHubActionsHygieneCheck
+
+    return (
+        GitHubActionsHygieneCheck,
+        _reasoning(
+            rationale=(
+                "GitHub workflows are executable infrastructure; YAML can look fine "
+                "while embedded scripts, action runtimes, or token permissions fail "
+                "only after CI has already started."
+            ),
+            tradeoffs=(
+                "Workflow policy checks can be noisy if they guess from weak signals, "
+                "so this gate only hard-fails high-confidence patterns."
+            ),
+            override_when=(
+                "Suppress only for workflow directories whose execution context is "
+                "intentionally managed outside GitHub Actions defaults."
+            ),
+        ),
+    )
+
+
 @lru_cache(maxsize=1)
 def _myopia_risk_reasoning_entries() -> tuple[tuple[type[BaseCheck], Reasoning], ...]:
     from slopmop.checks.general.interactive_assumptions import (
@@ -447,6 +470,7 @@ def _myopia_risk_reasoning_entries() -> tuple[tuple[type[BaseCheck], Reasoning],
     from slopmop.checks.security import SecurityCheck
 
     return (
+        _github_actions_hygiene_reasoning_entry(),
         (
             InteractiveAssumptionsCheck,
             _reasoning(

--- a/slopmop/checks/workflow/__init__.py
+++ b/slopmop/checks/workflow/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow infrastructure checks."""
+
+from slopmop.checks.workflow.github_actions import GitHubActionsHygieneCheck
+
+__all__ = ["GitHubActionsHygieneCheck"]

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -1,0 +1,517 @@
+"""GitHub Actions workflow hygiene checks."""
+
+from __future__ import annotations
+
+import ast
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import ClassVar, Iterable, Iterator, List, Optional, cast
+
+from slopmop.checks.base import (
+    BaseCheck,
+    CheckRole,
+    ConfigField,
+    Flaw,
+    GateCategory,
+    GateLevel,
+    RemediationChurn,
+    ToolContext,
+)
+from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
+
+_WORKFLOW_EXTENSIONS = frozenset({".yml", ".yaml"})
+_PYTHON_HEREDOC_RE = re.compile(
+    r"\b(?:python|python3(?:\.\d+)?)\b.*<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?"
+)
+_ACTIONLINT_RE = re.compile(r"^(.*?):(\d+):(\d+):\s*(.*?)(?:\s+\[(.+)\])?$")
+_DEPRECATED_ACTION_MIN_MAJOR = {
+    "actions/checkout": (5, "actions/checkout@v5"),
+    "actions/setup-python": (6, "actions/setup-python@v6"),
+    "actions/setup-node": (6, "actions/setup-node@v6"),
+}
+_OIDC_ACTIONS = {
+    "pypa/gh-action-pypi-publish",
+}
+_CODECOV_ACTION = "codecov/codecov-action"
+WorkflowMap = dict[str, object]
+Permissions = dict[str, object] | str | None
+
+
+def _rel(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _workflow_files(root: Path, workflow_dirs: Iterable[str]) -> List[Path]:
+    files: List[Path] = []
+    for directory in workflow_dirs:
+        workflow_dir = root / directory
+        if not workflow_dir.exists():
+            continue
+        for path in sorted(workflow_dir.iterdir()):
+            if path.is_file() and path.suffix.lower() in _WORKFLOW_EXTENSIONS:
+                files.append(path)
+    return files
+
+
+def _load_workflow(path: Path) -> tuple[Optional[WorkflowMap], Optional[Finding]]:
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return None, Finding(
+            message="PyYAML is required to parse GitHub Actions workflow files",
+            level=FindingLevel.WARNING,
+            file=path.as_posix(),
+            fix_strategy="Install slopmop with its runtime dependencies, including PyYAML.",
+        )
+
+    try:
+        loaded = cast(object, yaml.safe_load(path.read_text(encoding="utf-8")))
+        if loaded is None:
+            return {}, None
+        if not isinstance(loaded, dict):
+            return {}, None
+        return cast(WorkflowMap, loaded), None
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        line = getattr(mark, "line", None)
+        column = getattr(mark, "column", None)
+        return None, Finding(
+            message=f"Workflow YAML does not parse: {exc}",
+            level=FindingLevel.ERROR,
+            file=path.as_posix(),
+            line=line + 1 if isinstance(line, int) else None,
+            column=column + 1 if isinstance(column, int) else None,
+            rule_id="workflow-yaml-parse",
+            fix_strategy="Fix the YAML syntax before relying on this workflow in CI.",
+        )
+
+
+def _iter_jobs(workflow: WorkflowMap) -> Iterator[tuple[str, WorkflowMap]]:
+    jobs_obj = workflow.get("jobs")
+    if not isinstance(jobs_obj, dict):
+        return
+    jobs = cast(dict[object, object], jobs_obj)
+    for job_name_obj, job_obj in jobs.items():
+        if isinstance(job_name_obj, str) and isinstance(job_obj, dict):
+            yield job_name_obj, cast(WorkflowMap, job_obj)
+
+
+def _iter_steps(job: WorkflowMap) -> Iterator[WorkflowMap]:
+    steps_obj = job.get("steps")
+    if not isinstance(steps_obj, list):
+        return
+    steps = cast(list[object], steps_obj)
+    for step_obj in steps:
+        if isinstance(step_obj, dict):
+            yield cast(WorkflowMap, step_obj)
+
+
+def _line_for_text(lines: list[str], needle: str) -> Optional[int]:
+    for index, line in enumerate(lines, 1):
+        if needle in line:
+            return index
+    return None
+
+
+def _line_for_uses(lines: list[str], uses_value: str) -> Optional[int]:
+    for index, line in enumerate(lines, 1):
+        if "uses:" in line and uses_value in line:
+            return index
+    return None
+
+
+def _permissions_allow(
+    permissions: Permissions,
+    permission: str,
+    required: str,
+) -> bool:
+    if permissions == "write-all":
+        return True
+    if permissions == "read-all":
+        return required == "read"
+    if not isinstance(permissions, dict):
+        return False
+
+    value = permissions.get(permission)
+    if required == "read":
+        return value in {"read", "write"}
+    return value == "write"
+
+
+def _effective_permissions(workflow: WorkflowMap, job: WorkflowMap) -> Permissions:
+    if "permissions" in job:
+        return _as_permissions(job.get("permissions"))
+    if "permissions" in workflow:
+        return _as_permissions(workflow.get("permissions"))
+    return None
+
+
+def _as_permissions(value: object) -> Permissions:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return cast(dict[str, object], value)
+    return None
+
+
+def _action_ref(uses_value: str) -> tuple[str, str]:
+    if "@" not in uses_value:
+        return uses_value.lower(), ""
+    name, version = uses_value.rsplit("@", 1)
+    return name.lower(), version
+
+
+def _major(version: str) -> Optional[int]:
+    match = re.match(r"v(\d+)(?:\b|\.)", version)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _uses_checkout(step: WorkflowMap) -> bool:
+    uses = step.get("uses")
+    if not isinstance(uses, str):
+        return False
+    action, _version = _action_ref(uses)
+    return action == "actions/checkout"
+
+
+def _uses_oidc_publish(step: WorkflowMap) -> bool:
+    uses = step.get("uses")
+    if isinstance(uses, str):
+        action, _version = _action_ref(uses)
+        if action in _OIDC_ACTIONS:
+            return True
+        if action == _CODECOV_ACTION:
+            with_block = step.get("with")
+            return (
+                isinstance(with_block, dict)
+                and str(cast(dict[str, object], with_block).get("use_oidc", "")).lower()
+                == "true"
+            )
+
+    run = step.get("run")
+    if not isinstance(run, str):
+        return False
+    lower_run = run.lower()
+    return "npm publish" in lower_run and "--provenance" in lower_run
+
+
+def _extract_python_heredocs(run_block: str) -> Iterable[tuple[int, str]]:
+    lines = run_block.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _PYTHON_HEREDOC_RE.search(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        delimiter = match.group(1)
+        code_start = index + 1
+        code_lines: list[str] = []
+        index += 1
+        while index < len(lines) and lines[index].strip() != delimiter:
+            code_lines.append(lines[index])
+            index += 1
+        yield code_start + 1, "\n".join(code_lines)
+        index += 1
+
+
+class GitHubActionsHygieneCheck(BaseCheck):
+    """Preflight GitHub Actions workflows before they fail at runtime."""
+
+    tool_context: ClassVar[ToolContext] = ToolContext.PURE
+    role = CheckRole.DIAGNOSTIC
+    level = GateLevel.SWAB
+    remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_UNLIKELY
+
+    @property
+    def name(self) -> str:
+        return "github-actions-hygiene"
+
+    @property
+    def display_name(self) -> str:
+        return "⚙️ GitHub Actions Hygiene"
+
+    @property
+    def gate_description(self) -> str:
+        return "Pre-parses GitHub Actions workflows and catches CI runtime traps"
+
+    @property
+    def category(self) -> GateCategory:
+        return GateCategory.MYOPIA
+
+    @property
+    def flaw(self) -> Flaw:
+        return Flaw.MYOPIA
+
+    @property
+    def config_schema(self) -> List[ConfigField]:
+        return [
+            ConfigField(
+                name="workflow_dirs",
+                field_type="string[]",
+                default=[".github/workflows"],
+                description="Directories containing GitHub Actions workflow YAML files",
+            ),
+            ConfigField(
+                name="run_actionlint",
+                field_type="boolean",
+                default=True,
+                description="Run actionlint when the executable is available on PATH",
+            ),
+        ]
+
+    def is_applicable(self, project_root: str) -> bool:
+        root = Path(project_root)
+        workflow_dirs = self.config.get("workflow_dirs") or [".github/workflows"]
+        return bool(_workflow_files(root, workflow_dirs))
+
+    def skip_reason(self, project_root: str) -> str:
+        return "No GitHub Actions workflow files found"
+
+    def run(self, project_root: str) -> CheckResult:
+        start = time.perf_counter()
+        root = Path(project_root)
+        workflow_dirs = self.config.get("workflow_dirs") or [".github/workflows"]
+        workflows = _workflow_files(root, workflow_dirs)
+        findings: list[Finding] = []
+        actionlint_available = False
+
+        for path in workflows:
+            rel_path = _rel(path, root)
+            text = path.read_text(encoding="utf-8")
+            lines = text.splitlines()
+            workflow, parse_finding = _load_workflow(path)
+            if parse_finding:
+                findings.append(self._with_repo_relative_file(parse_finding, root))
+                continue
+            if workflow is None:
+                continue
+
+            findings.extend(self._workflow_findings(workflow, rel_path, lines))
+            findings.extend(self._actionlint_findings(path, root))
+            actionlint_available = (
+                actionlint_available or shutil.which("actionlint") is not None
+            )
+
+        elapsed = time.perf_counter() - start
+        if not findings:
+            note = (
+                "actionlint checked"
+                if actionlint_available
+                else "actionlint not installed"
+            )
+            return self._create_result(
+                status=CheckStatus.PASSED,
+                duration=elapsed,
+                output=f"GitHub Actions hygiene passed ({len(workflows)} workflow files, {note})",
+            )
+
+        return self._create_result(
+            status=CheckStatus.FAILED,
+            duration=elapsed,
+            output="\n".join(str(finding) for finding in findings[:30]),
+            error=f"Found {len(findings)} GitHub Actions hygiene issue(s)",
+            fix_suggestion=(
+                "Fix the workflow findings above, then verify with: "
+                + self.verify_command
+            ),
+            findings=findings,
+        )
+
+    def _workflow_findings(
+        self,
+        workflow: WorkflowMap,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        for job_name, job in _iter_jobs(workflow):
+            permissions = _effective_permissions(workflow, job)
+            for step in _iter_steps(job):
+                uses = step.get("uses")
+                if isinstance(uses, str):
+                    findings.extend(
+                        self._deprecated_action_findings(uses, rel_path, lines)
+                    )
+                if _uses_checkout(step):
+                    findings.extend(
+                        self._checkout_permission_findings(
+                            permissions, job_name, rel_path, lines
+                        )
+                    )
+                if _uses_oidc_publish(step):
+                    findings.extend(
+                        self._id_token_findings(permissions, job_name, rel_path, lines)
+                    )
+                run = step.get("run")
+                if isinstance(run, str):
+                    findings.extend(self._python_heredoc_findings(run, rel_path, lines))
+        return findings
+
+    def _deprecated_action_findings(
+        self,
+        uses_value: str,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        action, version = _action_ref(uses_value)
+        policy = _DEPRECATED_ACTION_MIN_MAJOR.get(action)
+        major = _major(version)
+        if not policy or major is None or major >= policy[0]:
+            return []
+        replacement = policy[1]
+        return [
+            Finding(
+                message=f"Deprecated GitHub Action runtime: {uses_value}",
+                level=FindingLevel.ERROR,
+                file=rel_path,
+                line=_line_for_uses(lines, uses_value),
+                rule_id="deprecated-action-version",
+                fix_strategy=f"Upgrade to {replacement} or a newer supported major.",
+            )
+        ]
+
+    def _checkout_permission_findings(
+        self,
+        permissions: Permissions,
+        job_name: str,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        if permissions is None or _permissions_allow(permissions, "contents", "read"):
+            return []
+        return [
+            Finding(
+                message=(
+                    f"Job '{job_name}' uses actions/checkout but effective permissions "
+                    "do not grant contents: read"
+                ),
+                level=FindingLevel.ERROR,
+                file=rel_path,
+                line=_line_for_text(lines, "permissions:"),
+                rule_id="checkout-missing-contents-read",
+                fix_strategy="Add contents: read to the workflow or job permissions block.",
+            )
+        ]
+
+    def _id_token_findings(
+        self,
+        permissions: Permissions,
+        job_name: str,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        if _permissions_allow(permissions, "id-token", "write"):
+            return []
+        return [
+            Finding(
+                message=(
+                    f"Job '{job_name}' uses an OIDC publish pattern but effective "
+                    "permissions do not grant id-token: write"
+                ),
+                level=FindingLevel.ERROR,
+                file=rel_path,
+                line=_line_for_text(lines, "permissions:"),
+                rule_id="oidc-publish-missing-id-token-write",
+                fix_strategy="Add id-token: write to the publishing job permissions block.",
+            )
+        ]
+
+    def _python_heredoc_findings(
+        self,
+        run_block: str,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        run_start = self._run_start_line(run_block, lines)
+        for offset, code in _extract_python_heredocs(run_block):
+            try:
+                ast.parse(code)
+            except SyntaxError as exc:
+                finding_line = run_start + offset + (exc.lineno or 1) - 2
+                findings.append(
+                    Finding(
+                        message=f"Embedded Python heredoc does not parse: {exc.msg}",
+                        level=FindingLevel.ERROR,
+                        file=rel_path,
+                        line=finding_line if run_start else None,
+                        column=exc.offset,
+                        rule_id="embedded-python-parse",
+                        fix_strategy="Fix the embedded Python syntax before the workflow runs.",
+                    )
+                )
+        return findings
+
+    def _actionlint_findings(self, path: Path, root: Path) -> list[Finding]:
+        if not self.config.get("run_actionlint", True) or not shutil.which(
+            "actionlint"
+        ):
+            return []
+        result = self._runner.run(["actionlint", str(path)], cwd=str(root), timeout=30)
+        if result.returncode == 0:
+            return []
+        findings: list[Finding] = []
+        for line in result.output.splitlines():
+            match = _ACTIONLINT_RE.match(line)
+            if not match:
+                continue
+            file_path, lineno, column, message, rule = match.groups()
+            findings.append(
+                Finding(
+                    message=message,
+                    level=FindingLevel.ERROR,
+                    file=(
+                        Path(file_path).relative_to(root).as_posix()
+                        if Path(file_path).is_absolute()
+                        else file_path
+                    ),
+                    line=int(lineno),
+                    column=int(column),
+                    rule_id=f"actionlint:{rule or 'workflow'}",
+                    fix_strategy="Fix the actionlint workflow diagnostic.",
+                )
+            )
+        if findings:
+            return findings
+        return [
+            Finding(
+                message=result.output.strip() or "actionlint failed",
+                level=FindingLevel.ERROR,
+                file=_rel(path, root),
+                rule_id="actionlint",
+                fix_strategy="Run actionlint locally and fix the reported workflow issue.",
+            )
+        ]
+
+    @staticmethod
+    def _run_start_line(run_block: str, lines: list[str]) -> int:
+        first = next((line for line in run_block.splitlines() if line.strip()), "")
+        if not first:
+            return 0
+        return _line_for_text(lines, first.strip()) or 0
+
+    @staticmethod
+    def _with_repo_relative_file(finding: Finding, root: Path) -> Finding:
+        if not finding.file:
+            return finding
+        file_path = Path(finding.file)
+        try:
+            rel_file = file_path.relative_to(root).as_posix()
+        except ValueError:
+            rel_file = file_path.as_posix()
+        return Finding(
+            message=finding.message,
+            level=finding.level,
+            file=rel_file,
+            line=finding.line,
+            column=finding.column,
+            end_line=finding.end_line,
+            end_column=finding.end_column,
+            rule_id=finding.rule_id,
+            fix_strategy=finding.fix_strategy,
+        )

--- a/slopmop/subprocess/validator.py
+++ b/slopmop/subprocess/validator.py
@@ -95,6 +95,7 @@ class CommandValidator:
             "pyright",
             "ruff",
             "find-duplicate-strings",
+            "actionlint",
             # JavaScript/Node ecosystem
             "node",
             "npm",

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -1,0 +1,166 @@
+"""Tests for the GitHub Actions hygiene gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from slopmop.checks.workflow import GitHubActionsHygieneCheck
+from slopmop.core.registry import get_registry
+from slopmop.core.result import CheckStatus
+
+
+def _write_workflow(root: Path, body: str, name: str = "ci.yml") -> Path:
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    path = workflow_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _check() -> GitHubActionsHygieneCheck:
+    return GitHubActionsHygieneCheck({"run_actionlint": False})
+
+
+class TestGitHubActionsHygieneCheck:
+    def test_name_and_registration(self):
+        check = _check()
+
+        assert check.full_name == "myopia:github-actions-hygiene"
+        assert check.full_name in get_registry().list_checks()
+
+    def test_not_applicable_without_workflows(self, tmp_path):
+        assert _check().is_applicable(str(tmp_path)) is False
+
+    def test_valid_modern_workflow_passes(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+      - run: python --version
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_broken_workflow_yaml_fails_before_runtime(self, tmp_path):
+        _write_workflow(tmp_path, "name: [\njobs:\n  test: {}\n")
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "workflow-yaml-parse"
+
+    def test_embedded_python_heredoc_syntax_error_fails(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: Release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          python <<'PY'
+          if True:
+          print('not indented')
+          PY
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert {finding.rule_id for finding in result.findings} == {
+            "embedded-python-parse"
+        }
+
+    def test_restrictive_permissions_require_contents_for_checkout(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "checkout-missing-contents-read"
+
+    def test_checkout_without_explicit_permissions_does_not_guess(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_oidc_publish_pattern_requires_id_token_write(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: Release
+on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "oidc-publish-missing-id-token-write"
+
+    def test_deprecated_github_action_major_fails(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "deprecated-action-version"
+        assert "actions/checkout@v5" in result.findings[0].fix_strategy

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from slopmop.checks.workflow import GitHubActionsHygieneCheck
+from slopmop.checks.workflow.github_actions import (
+    _action_ref,
+    _extract_python_heredocs,
+    _major,
+    _workflow_files,
+)
 from slopmop.core.registry import get_registry
-from slopmop.core.result import CheckStatus
+from slopmop.core.result import CheckStatus, Finding
 
 
 def _write_workflow(root: Path, body: str, name: str = "ci.yml") -> Path:
     workflow_dir = root / ".github" / "workflows"
-    workflow_dir.mkdir(parents=True)
+    workflow_dir.mkdir(parents=True, exist_ok=True)
     path = workflow_dir / name
     path.write_text(body, encoding="utf-8")
     return path
@@ -164,3 +171,230 @@ jobs:
         assert result.status == CheckStatus.FAILED
         assert result.findings[0].rule_id == "deprecated-action-version"
         assert "actions/checkout@v5" in result.findings[0].fix_strategy
+
+    def test_empty_and_non_mapping_workflows_are_safe_noops(self, tmp_path):
+        _write_workflow(tmp_path, "", "empty.yml")
+        _write_workflow(tmp_path, "- not\n- a\n- mapping\n", "list.yaml")
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_ignores_workflows_without_job_and_step_mappings(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: Odd but valid
+on: push
+jobs:
+  123:
+    runs-on: ubuntu-latest
+  empty:
+    steps: nope
+  mixed:
+    steps:
+      - plain string
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_write_all_and_read_all_permissions_allow_checkout(self, tmp_path):
+        for permission_value in ("write-all", "read-all"):
+            workflow_dir = tmp_path / permission_value
+            _write_workflow(
+                workflow_dir,
+                f"""
+name: CI
+on: push
+permissions: {permission_value}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+""",
+            )
+
+            result = _check().run(str(workflow_dir))
+
+            assert result.status == CheckStatus.PASSED
+
+    def test_job_permissions_override_workflow_permissions(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+permissions: {}
+jobs:
+  test:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_code_publish_patterns_require_id_token_write(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: Publish
+on: push
+permissions:
+  contents: read
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm publish --provenance
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert [finding.rule_id for finding in result.findings] == [
+            "oidc-publish-missing-id-token-write",
+            "oidc-publish-missing-id-token-write",
+        ]
+
+    def test_oidc_publish_passes_with_job_level_id_token(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: Release
+on: workflow_dispatch
+permissions: {}
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+
+    def test_action_references_without_version_are_not_deprecated(self, tmp_path):
+        _write_workflow(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout
+      - uses: docker://alpine:latest
+""",
+        )
+
+        result = _check().run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+        assert _action_ref("actions/checkout") == ("actions/checkout", "")
+        assert _major("release/v1") is None
+
+    def test_python_heredoc_without_matching_workflow_line_has_no_location(self):
+        check = _check()
+
+        findings = check._python_heredoc_findings(
+            "python <<'PY'\nif True:\nprint('x')\nPY",
+            ".github/workflows/ci.yml",
+            [],
+        )
+
+        assert findings[0].line is None
+
+    def test_extracts_multiple_python_heredocs(self):
+        heredocs = list(
+            _extract_python_heredocs(
+                "python <<'PY'\nprint('one')\nPY\npython3 <<EOF\nprint('two')\nEOF"
+            )
+        )
+
+        assert [code for _offset, code in heredocs] == [
+            "print('one')",
+            "print('two')",
+        ]
+
+    def test_actionlint_findings_parse_structured_output(self, tmp_path):
+        workflow = _write_workflow(tmp_path, "name: CI\non: push\n")
+        check = GitHubActionsHygieneCheck({"run_actionlint": True})
+        mock_result = MagicMock(
+            returncode=1,
+            output=f"{workflow}:2:5: bad event [syntax-check]\n",
+        )
+
+        with patch("shutil.which", return_value="/usr/bin/actionlint"):
+            with patch.object(check._runner, "run", return_value=mock_result):
+                findings = check._actionlint_findings(workflow, tmp_path)
+
+        assert findings[0].rule_id == "actionlint:syntax-check"
+        assert findings[0].file == ".github/workflows/ci.yml"
+        assert findings[0].line == 2
+
+    def test_actionlint_fallback_finding_for_unstructured_output(self, tmp_path):
+        workflow = _write_workflow(tmp_path, "name: CI\non: push\n")
+        check = GitHubActionsHygieneCheck({"run_actionlint": True})
+        mock_result = MagicMock(returncode=1, output="plain failure")
+
+        with patch("shutil.which", return_value="/usr/bin/actionlint"):
+            with patch.object(check._runner, "run", return_value=mock_result):
+                findings = check._actionlint_findings(workflow, tmp_path)
+
+        assert findings[0].rule_id == "actionlint"
+        assert findings[0].message == "plain failure"
+
+    def test_actionlint_success_and_disabled_return_no_findings(self, tmp_path):
+        workflow = _write_workflow(tmp_path, "name: CI\non: push\n")
+        check = GitHubActionsHygieneCheck({"run_actionlint": True})
+        mock_result = MagicMock(returncode=0, output="")
+
+        with patch("shutil.which", return_value="/usr/bin/actionlint"):
+            with patch.object(check._runner, "run", return_value=mock_result):
+                assert check._actionlint_findings(workflow, tmp_path) == []
+
+        assert _check()._actionlint_findings(workflow, tmp_path) == []
+
+    def test_with_repo_relative_file_handles_no_file_and_outside_root(self, tmp_path):
+        check = _check()
+        no_file = check._with_repo_relative_file(Finding(message="x"), tmp_path)
+        outside = check._with_repo_relative_file(
+            Finding(message="x", file="/outside/workflow.yml"),
+            tmp_path,
+        )
+
+        assert no_file.file is None
+        assert outside.file == "/outside/workflow.yml"
+
+    def test_workflow_files_only_scans_workflow_yaml_files(self, tmp_path):
+        workflow_dir = tmp_path / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "ci.yml").write_text("name: CI\n", encoding="utf-8")
+        (workflow_dir / "ci.yaml").write_text("name: CI\n", encoding="utf-8")
+        (workflow_dir / "notes.txt").write_text("nope", encoding="utf-8")
+
+        files = _workflow_files(tmp_path, [".github/workflows", "missing"])
+
+        assert [path.name for path in files] == ["ci.yaml", "ci.yml"]

--- a/tests/unit/test_summarize_scour_failure.py
+++ b/tests/unit/test_summarize_scour_failure.py
@@ -1,0 +1,45 @@
+"""Tests for CI scour failure summary formatting."""
+
+from __future__ import annotations
+
+from scripts.summarize_scour_failure import _classify_failed_gates
+
+
+def test_scour_only_gate_summary_includes_error_detail(capsys):
+    classification, swab_failed, scour_only_failed = _classify_failed_gates(
+        [
+            {
+                "name": "myopia:just-this-once.py",
+                "status": "failed",
+                "error": "Changed files have <80% coverage",
+            }
+        ]
+    )
+
+    out = capsys.readouterr().out
+
+    assert classification == "SCOUR-only failures"
+    assert swab_failed == []
+    assert scour_only_failed == [
+        "myopia:just-this-once.py — Changed files have <80% coverage"
+    ]
+    assert (
+        "::error::SCOUR-only failed gates: "
+        "myopia:just-this-once.py — Changed files have <80% coverage"
+    ) in out
+
+
+def test_failure_summary_falls_back_to_status_detail(capsys):
+    _classification, _swab_failed, scour_only_failed = _classify_failed_gates(
+        [
+            {
+                "name": "myopia:just-this-once.py",
+                "status": "failed",
+                "status_detail": "Diff coverage below threshold",
+            }
+        ]
+    )
+
+    assert scour_only_failed == [
+        "myopia:just-this-once.py — Diff coverage below threshold"
+    ]


### PR DESCRIPTION
Summary:
- adds `myopia:github-actions-hygiene`
- parses workflow YAML and embedded Python heredocs
- enforces high-confidence checkout/OIDC/deprecated-action policies
- fixes the release workflow indentation issue caught by the gate
- validation: `./sm swab --static`, `./sm scour --output-file .slopmop/last_scour.json`