### PR TITLE
fix: restore main-only release dispatch guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,7 @@ jobs:
           BUMP: ${{ github.event.inputs.bump }}
           GITHUB_REF: ${{ github.ref }}
         run: |
-          if [ "$GITHUB_REF" != "refs/heads/main" ] &&
-             [ "$GITHUB_REF" != "refs/heads/codex/live-release-workflow-test" ]; then
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
             echo "Manual releases must be dispatched from main." >&2
             exit 1
           fi

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,7 @@
 
 Branch: `fix/manual-only-release-workflow`
 
-**Work in progress:**
+**Work completed:**
 - Updating `.github/workflows/release.yml` after manual release failed against
   main branch protection and after the merge-triggered run incorrectly succeeded
   as a no-op when no release bump was detected.
@@ -38,6 +38,10 @@ Branch: `fix/manual-only-release-workflow`
 - `./sm scour -g myopia:dependency-risk.py --static --no-cache` ✅
 - `./sm swab --static` ✅
 - `./sm scour --output-file .slopmop/last_scour.json --static` ✅
+- Live release workflow run `25477547825` ✅
+- PyPI JSON shows `slopmop` `1.1.0` uploaded at `2026-05-07T05:24:42.782089Z` ✅
+- Clean install from `https://pypi.org/simple` with `slopmop==1.1.0` and
+  `sm --version` ✅
 
 ## 2026-05-06 Delta: GitHub Actions hygiene gate design
 


### PR DESCRIPTION
## Summary

- restore the Release workflow dispatch guard to `main` only
- record the successful live `1.1.0` release verification in `STATUS.md`

## Scientific Method Log

- Hypothesis: the previous one-click release failed because it required missing `RELEASE_PR_TOKEN` configuration.
- Test: `gh workflow run release.yml --ref main -f bump=minor` failed in run `25477249178` before branch/PR creation with `RELEASE_PR_TOKEN_CONFIGURED: false`.
- Update: remove the PAT dependency, use scoped `GITHUB_TOKEN`, validate/build before merge, and publish the merged commit in the same workflow run.
- Test: temporary dispatch branch run `25477547825` completed successfully: release PR update, quality gate, build, merge, PyPI publish, and GitHub release.
- Verification: PyPI JSON reports `slopmop` `1.1.0` uploaded at `2026-05-07T05:24:42.782089Z`; clean install from `https://pypi.org/simple` with `slopmop==1.1.0` returned `sm 1.1.0`.

## Validation

- `./sm swab --static`
- `./sm scour --output-file .slopmop/last_scour.json --static`
