### PR TITLE
fix: align Claude marketplace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,6 +4,7 @@
     "name": "ScienceIsNeato",
     "url": "https://github.com/ScienceIsNeato"
   },
+  "description": "Slop-mop quality gates as a Claude skill — directed remediation for AI-assisted codebases.",
   "metadata": {
     "description": "Slop-mop quality gates as a Claude skill — directed remediation for AI-assisted codebases."
   },
@@ -15,7 +16,6 @@
         "repo": "ScienceIsNeato/slop-mop"
       },
       "description": "Protocols for highly efficient and directed remediation of known issues — refit onboarding, the swab/scour/buff/sail loop, and barnacle friction reporting as a skill and slash commands.",
-      "version": "1.0.2",
       "category": "code-quality",
       "keywords": [
         "quality-gate",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slopmop",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
   "author": {
     "name": "ScienceIsNeato",


### PR DESCRIPTION
## Summary

- bump `.claude-plugin/plugin.json` to `1.1.0` so Claude Code update detection is not pinned to stale `1.0.2`
- expose marketplace description at the documented top-level field while keeping `metadata.description` for the current validator
- remove the duplicate marketplace plugin `version` so `plugin.json` is the single explicit version source

## Validation

- `claude plugin validate .`
- `./sm swab --static`

## Notes

Claude Code documentation says plugin versions resolve first from `plugin.json`, then from marketplace entry, then from git SHA. It also warns not to set `version` in both places because stale `plugin.json` silently wins. This keeps the explicit version in `plugin.json` only.
