### PR TITLE
fix: let buff continue without scan artifact

### DIFF
--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -10,14 +10,26 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any, Optional, cast
 
-from slopmop.checks.pr.comments import PRCommentsCheck
+from slopmop.cli.buff_common import fire_buff_hook as _fire_buff_hook
+from slopmop.cli.buff_common import get_current_branch as _get_current_branch
+from slopmop.cli.buff_common import get_repo_owner_name as _get_repo_owner_name
+from slopmop.cli.buff_common import get_repo_slug as _get_repo_slug
+from slopmop.cli.buff_common import project_root_from_cwd as _project_root_from_cwd
+from slopmop.cli.buff_common import run_pr_feedback_gate as _run_pr_feedback_gate
+from slopmop.cli.buff_narration import (
+    format_feedback_state,
+    pr_resolution_reason,
+    print_ci_state_summary,
+    print_inspect_state_summary,
+    print_pr_selection_trace,
+)
+from slopmop.cli.buff_scan import print_scan_unavailable, run_inspect_scan
 from slopmop.cli.ci import (
     _categorize_checks,
     _fetch_checks,
@@ -27,10 +39,11 @@ from slopmop.cli.ci import (
     _print_success_status,
 )
 from slopmop.cli.scan_triage import (
+    PRResolutionSource,
     TriageError,
     print_triage,
     resolve_pr_number,
-    run_triage,
+    resolve_pr_number_with_source,
     write_json_out,
 )
 from slopmop.core.result import CheckResult, CheckStatus
@@ -80,6 +93,24 @@ def _render_status_feedback_blocker(
     if feedback_result.error:
         print(f"ERROR: {feedback_result.error}")
     return 1
+
+
+def _resolve_buff_pr_number(
+    args: argparse.Namespace,
+    pr_number: int | None,
+    project_root: str,
+) -> tuple[int, PRResolutionSource, str]:
+    """Resolve and validate the PR before buff inspect reads scan results."""
+
+    repo = _buff_repo_slug(args, project_root)
+    number, source = resolve_pr_number_with_source(repo, pr_number, assume_latest=True)
+    return number, source, repo
+
+
+def _buff_repo_slug(args: argparse.Namespace, project_root: str) -> str:
+    """Resolve the repository slug used by buff."""
+
+    return getattr(args, "repo", None) or _get_repo_slug(project_root)
 
 
 def _parse_optional_int(value: str | None, label: str) -> int | None:
@@ -465,43 +496,6 @@ def _push_current_branch(project_root: str) -> int:
     return result.returncode
 
 
-def _get_repo_owner_name(project_root: str) -> tuple[str, str]:
-    """Return owner/name for the current repository."""
-
-    check = PRCommentsCheck({})
-    return check._get_repo_info(project_root)
-
-
-def _get_repo_slug(project_root: str) -> str:
-    """Return owner/repo slug for the current repository."""
-
-    owner, repo = _get_repo_owner_name(project_root)
-    if not owner or not repo:
-        raise TriageError("Could not determine repository owner/name")
-    return f"{owner}/{repo}"
-
-
-def _get_current_branch(project_root: Path) -> str | None:
-    """Return the current git branch name, if it can be resolved."""
-
-    try:
-        result = subprocess.run(
-            ["git", "branch", "--show-current"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            stdin=subprocess.DEVNULL,
-            cwd=project_root,
-            check=False,
-        )
-    except (FileNotFoundError, OSError, subprocess.SubprocessError):
-        return None
-    if result.returncode != 0:
-        return None
-    branch = result.stdout.strip()
-    return branch or None
-
-
 def _get_pr_head_branch(project_root: Path, pr_number: int) -> str | None:
     """Return the PR head branch name, if GitHub can provide it."""
 
@@ -658,7 +652,11 @@ def _cmd_buff_status(
 
     project_root = Path(_project_root_from_cwd())
     try:
-        resolved_pr = resolve_pr_number(_get_repo_slug(str(project_root)), pr_number)
+        repo = _get_repo_slug(str(project_root))
+        resolved_pr, pr_resolution_source = resolve_pr_number_with_source(
+            repo,
+            pr_number,
+        )
     except TriageError as exc:
         print(f"ERROR: {exc}")
         return 1
@@ -678,6 +676,15 @@ def _cmd_buff_status(
         print(f"👀 Watch mode: {flags}")
     print("=" * 60)
     print()
+    print_pr_selection_trace(
+        repo=repo,
+        current_branch=_get_current_branch(project_root),
+        json_output=False,
+        requested_pr_number=pr_number,
+        resolved_pr_number=resolved_pr,
+        source=pr_resolution_source,
+        assume_latest=False,
+    )
 
     settled_post_ci_feedback = False
     poll_count = 0
@@ -703,6 +710,8 @@ def _cmd_buff_status(
             return 2 if "not found" in error.lower() else 1
 
         if not checks:
+            print("Overall PR state: waiting for CI - no checks registered yet")
+            print()
             if watch and poll_count <= _MAX_EMPTY_POLLS:
                 print(
                     "⏳ No CI checks registered yet — waiting for GitHub to pick up workflows..."
@@ -720,6 +729,12 @@ def _cmd_buff_status(
                     no_checks=True,
                 )
 
+            print(format_feedback_state(feedback_result))
+            print(
+                "Final PR state: incomplete - no CI checks registered, "
+                "but PR feedback is resolved"
+            )
+            print()
             print("ℹ️  No CI checks found for this PR")
             print("   (CI workflow may not be set up yet)")
             _fire_buff_hook(has_issues=False)
@@ -727,6 +742,7 @@ def _cmd_buff_status(
 
         completed, in_progress, failed = _categorize_checks(checks)
         total = len(checks)
+        print_ci_state_summary(checks)
 
         if failed:
             _print_failed_status(completed, in_progress, failed)
@@ -776,6 +792,9 @@ def _cmd_buff_status(
                 no_checks=False,
             )
 
+        print(format_feedback_state(feedback_result))
+        print("Final PR state: clean - CI checks passed and PR feedback is resolved")
+        print()
         _print_success_status(completed, total)
         _fire_buff_hook(has_issues=False)
         if watch:
@@ -838,44 +857,6 @@ def _cmd_buff_resolve(
     action = "commented and resolved" if resolve_thread else "commented"
     print(f"Buff resolve complete: {action} {thread_id} on PR #{resolved_pr_number}.")
     return 0
-
-
-def _project_root_from_cwd() -> str:
-    """Resolve the git project root for the current working directory."""
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return os.getcwd()
-
-    root = (result.stdout or "").strip()
-    if result.returncode != 0 or not root:
-        return os.getcwd()
-    return str(Path(root))
-
-
-def _run_pr_feedback_gate(pr_number: int | None, project_root: str) -> CheckResult:
-    """Run ignored-feedback gate in blocking mode for buff semantics."""
-
-    check = PRCommentsCheck({"fail_on_unresolved": True})
-    original_pr_env = os.environ.get("GITHUB_PR_NUMBER")
-
-    try:
-        if pr_number is not None:
-            os.environ["GITHUB_PR_NUMBER"] = str(pr_number)
-        return check.run(project_root)
-    finally:
-        if pr_number is not None:
-            if original_pr_env is None:
-                os.environ.pop("GITHUB_PR_NUMBER", None)
-            else:
-                os.environ["GITHUB_PR_NUMBER"] = original_pr_env
 
 
 def _cmd_buff_iterate(pr_number: int | None) -> int:
@@ -1038,22 +1019,129 @@ def _cmd_buff_finalize(pr_number: int | None, push_changes: bool) -> int:
     return 0
 
 
+def _annotate_inspect_payload(
+    payload: dict[str, Any],
+    *,
+    repo: str,
+    pr_number: int | None,
+    resolved_pr_number: int,
+    pr_resolution_source: PRResolutionSource,
+    feedback_result: CheckResult,
+) -> None:
+    """Attach buff-specific resolution and feedback context to scan payload."""
+
+    payload["pr_resolution"] = {
+        "source": pr_resolution_source,
+        "pr_number": resolved_pr_number,
+        "requested_pr_number": pr_number,
+        "repo": repo,
+        "reason": pr_resolution_reason(
+            resolved_pr_number,
+            pr_resolution_source,
+            pr_number,
+            assume_latest=True,
+        ),
+    }
+    payload["pr_feedback"] = {
+        "gate": "myopia:ignored-feedback",
+        "status": feedback_result.status.value,
+        "status_detail": feedback_result.status_detail,
+        "error": feedback_result.error,
+        "fix_suggestion": feedback_result.fix_suggestion,
+    }
+
+
+def _print_inspect_output(
+    payload: dict[str, Any],
+    *,
+    scan_exit: int,
+    feedback_result: CheckResult,
+    json_output: bool,
+) -> bool:
+    """Print scan output and state summary, returning whether scan was unavailable."""
+
+    scan_unavailable = bool(payload.get("scan_unavailable"))
+    if json_output:
+        print(json.dumps(payload, indent=2))
+    elif scan_unavailable:
+        print_scan_unavailable(payload)
+    else:
+        print_triage(payload, show_low_coverage=False)
+    print_inspect_state_summary(
+        scan_exit=scan_exit,
+        payload=payload,
+        feedback_result=feedback_result,
+        json_output=json_output,
+    )
+    return scan_unavailable
+
+
+def _render_inspect_failure(
+    *,
+    scan_exit: int,
+    scan_unavailable: bool,
+    feedback_result: CheckResult,
+    json_output: bool,
+) -> None:
+    """Render human inspect failure details."""
+
+    if json_output:
+        return
+    if scan_exit != 0:
+        if scan_unavailable:
+            if feedback_result.status in {CheckStatus.FAILED, CheckStatus.ERROR}:
+                print("\nBuff inspect incomplete: CI scan artifact is still missing.")
+            else:
+                print(
+                    "\nBuff inspect incomplete: PR feedback is resolved, "
+                    "but the CI scan artifact is still missing."
+                )
+        else:
+            print("\nBuff inspect found unresolved CI scan signals.")
+    if feedback_result.status == CheckStatus.FAILED:
+        print("Buff inspect found unresolved PR review threads.")
+        print("Next step: run 'sm buff iterate' to take the highest-priority batch.")
+        if feedback_result.output:
+            print(feedback_result.output)
+    elif feedback_result.status == CheckStatus.ERROR:
+        print("Buff inspect failed: could not verify unresolved PR feedback.")
+        if feedback_result.error:
+            print(f"ERROR: {feedback_result.error}")
+
+
 def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
     """Run the post-PR inspection rail."""
 
     if not getattr(args, "json_output", False):
         print("== Buff inspect: checking CI code-scanning results ==")
 
+    project_root = _project_root_from_cwd()
     try:
-        scan_exit, payload = run_triage(
-            repo=args.repo,
-            run_id=args.run_id,
-            pr_number=pr_number,
-            workflow=args.workflow,
-            artifact=args.artifact,
-            show_low_coverage=False,
-            json_out=None,
-            print_output=False,
+        resolved_pr_number, pr_resolution_source, repo = _resolve_buff_pr_number(
+            args,
+            pr_number,
+            project_root,
+        )
+    except TriageError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    json_output = bool(getattr(args, "json_output", False))
+    print_pr_selection_trace(
+        repo=repo,
+        current_branch=_get_current_branch(Path(project_root)),
+        json_output=json_output,
+        requested_pr_number=pr_number,
+        resolved_pr_number=resolved_pr_number,
+        source=pr_resolution_source,
+        assume_latest=True,
+    )
+
+    try:
+        scan_exit, payload = run_inspect_scan(
+            args,
+            resolved_pr_number,
+            resolved_repo=repo,
         )
     except TriageError as exc:
         print(f"ERROR: {exc}")
@@ -1063,25 +1151,27 @@ def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
         print("ERROR: CI triage produced no payload.")
         return 1
 
-    resolved_pr_number = payload.get("pr_number", pr_number)
     feedback_result = _run_pr_feedback_gate(
         resolved_pr_number,
-        _project_root_from_cwd(),
+        project_root,
     )
-    payload["pr_feedback"] = {
-        "gate": "myopia:ignored-feedback",
-        "status": feedback_result.status.value,
-        "status_detail": feedback_result.status_detail,
-        "error": feedback_result.error,
-        "fix_suggestion": feedback_result.fix_suggestion,
-    }
+    _annotate_inspect_payload(
+        payload,
+        repo=repo,
+        pr_number=pr_number,
+        resolved_pr_number=resolved_pr_number,
+        pr_resolution_source=pr_resolution_source,
+        feedback_result=feedback_result,
+    )
 
     write_json_out(getattr(args, "output_file", None), payload)
 
-    if getattr(args, "json_output", False):
-        print(json.dumps(payload, indent=2))
-    else:
-        print_triage(payload, show_low_coverage=False)
+    scan_unavailable = _print_inspect_output(
+        payload=payload,
+        scan_exit=scan_exit,
+        feedback_result=feedback_result,
+        json_output=json_output,
+    )
 
     feedback_blocking = feedback_result.status in {
         CheckStatus.FAILED,
@@ -1089,23 +1179,15 @@ def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
     }
 
     if scan_exit != 0 or feedback_blocking:
-        if not getattr(args, "json_output", False):
-            if scan_exit != 0:
-                print("\nBuff inspect found unresolved CI scan signals.")
-            if feedback_result.status == CheckStatus.FAILED:
-                print("Buff inspect found unresolved PR review threads.")
-                print(
-                    "Next step: run 'sm buff iterate' to take the highest-priority batch."
-                )
-                if feedback_result.output:
-                    print(feedback_result.output)
-            elif feedback_result.status == CheckStatus.ERROR:
-                print("Buff inspect failed: could not verify unresolved PR feedback.")
-                if feedback_result.error:
-                    print(f"ERROR: {feedback_result.error}")
+        _render_inspect_failure(
+            scan_exit=scan_exit,
+            scan_unavailable=scan_unavailable,
+            feedback_result=feedback_result,
+            json_output=json_output,
+        )
         return 1
 
-    if not getattr(args, "json_output", False):
+    if not json_output:
         print("\nBuff inspect clean: CI scan signals and PR feedback are resolved.")
         print("Next step: run 'sm buff finalize --push' when you want to publish.")
     return 0
@@ -1168,12 +1250,3 @@ def cmd_buff(args: argparse.Namespace) -> int:
     exit_code = _cmd_buff_inspect(args, normalized.pr_number)
     _fire_buff_hook(has_issues=exit_code != 0)
     return exit_code
-
-
-def _fire_buff_hook(has_issues: bool) -> None:
-    try:
-        from slopmop.workflow.hooks import on_buff_complete
-
-        on_buff_complete(_project_root_from_cwd(), has_issues=has_issues)
-    except Exception:
-        pass

--- a/slopmop/cli/buff_common.py
+++ b/slopmop/cli/buff_common.py
@@ -1,0 +1,98 @@
+"""Shared helpers for buff subcommands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from slopmop.checks.pr.comments import PRCommentsCheck
+from slopmop.core.result import CheckResult
+
+
+def project_root_from_cwd() -> str:
+    """Resolve the git project root for the current working directory."""
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return os.getcwd()
+
+    root = (result.stdout or "").strip()
+    if result.returncode != 0 or not root:
+        return os.getcwd()
+    return str(Path(root))
+
+
+def get_repo_owner_name(project_root: str) -> tuple[str, str]:
+    """Return owner/name for the current repository."""
+
+    check = PRCommentsCheck({})
+    return check._get_repo_info(project_root)
+
+
+def get_repo_slug(project_root: str) -> str:
+    """Return owner/repo slug for the current repository."""
+
+    from slopmop.cli.scan_triage import TriageError
+
+    owner, repo = get_repo_owner_name(project_root)
+    if not owner or not repo:
+        raise TriageError("Could not determine repository owner/name")
+    return f"{owner}/{repo}"
+
+
+def get_current_branch(project_root: Path) -> str | None:
+    """Return the current git branch name, if it can be resolved."""
+
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+            cwd=project_root,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def run_pr_feedback_gate(pr_number: int | None, project_root: str) -> CheckResult:
+    """Run ignored-feedback gate in blocking mode for buff semantics."""
+
+    check = PRCommentsCheck({"fail_on_unresolved": True})
+    original_pr_env = os.environ.get("GITHUB_PR_NUMBER")
+
+    try:
+        if pr_number is not None:
+            os.environ["GITHUB_PR_NUMBER"] = str(pr_number)
+        return check.run(project_root)
+    finally:
+        if pr_number is not None:
+            if original_pr_env is None:
+                os.environ.pop("GITHUB_PR_NUMBER", None)
+            else:
+                os.environ["GITHUB_PR_NUMBER"] = original_pr_env
+
+
+def fire_buff_hook(has_issues: bool) -> None:
+    """Notify workflow hooks that buff completed."""
+
+    try:
+        from slopmop.workflow.hooks import on_buff_complete
+
+        on_buff_complete(project_root_from_cwd(), has_issues=has_issues)
+    except Exception:
+        pass

--- a/slopmop/cli/buff_narration.py
+++ b/slopmop/cli/buff_narration.py
@@ -1,0 +1,180 @@
+"""Human narration helpers for buff command state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from slopmop.cli.ci import _categorize_checks
+from slopmop.cli.scan_triage import PRResolutionSource
+from slopmop.core.result import CheckResult, CheckStatus
+
+
+def pr_resolution_reason(
+    pr_number: int,
+    source: PRResolutionSource,
+    requested_pr_number: int | None,
+    *,
+    assume_latest: bool,
+) -> str:
+    """Explain why a PR resolution source was chosen."""
+
+    if source == "explicit":
+        return (
+            f"Explicit PR #{requested_pr_number or pr_number} was provided, "
+            "so buff validated that it is still open and selected it."
+        )
+    if source == "branch":
+        return (
+            "No explicit PR was provided, so buff looked up the current branch "
+            f"and found open PR #{pr_number}."
+        )
+    if source == "configured":
+        return (
+            "No explicit PR or open current-branch PR was available, so buff "
+            f"used configured working PR #{pr_number} after validating it."
+        )
+    if assume_latest:
+        return (
+            "No explicit PR, current-branch PR, or configured working PR was "
+            f"available, so buff assumed the most recently updated open PR #{pr_number}."
+        )
+    return (
+        "Buff selected the resolved open PR after checking explicit, branch, "
+        "and configured PR sources."
+    )
+
+
+def print_pr_selection_trace(
+    *,
+    repo: str,
+    current_branch: str | None,
+    json_output: bool,
+    requested_pr_number: int | None,
+    resolved_pr_number: int,
+    source: PRResolutionSource,
+    assume_latest: bool,
+) -> None:
+    """Print how buff selected a PR for human output."""
+
+    if json_output:
+        return
+    requested = f"#{requested_pr_number}" if requested_pr_number is not None else "none"
+    order = ["explicit argument", "current branch", "configured working PR"]
+    if assume_latest:
+        order.append("most recently updated open PR")
+    print("== Buff PR selection ==")
+    print(f"Repository: {repo}")
+    print(f"Current branch: {current_branch or 'unknown'}")
+    print(f"Requested PR: {requested}")
+    print(f"Candidate order: {' -> '.join(order)}")
+    print(f"Selected PR: #{resolved_pr_number} ({source})")
+    if source == "latest_open":
+        print(
+            "WARNING: no PR matched the current branch and no working PR is selected. "
+            f"Assuming most recently updated open PR #{resolved_pr_number}."
+        )
+    print(
+        "Why: "
+        + pr_resolution_reason(
+            resolved_pr_number,
+            source,
+            requested_pr_number,
+            assume_latest=assume_latest,
+        )
+    )
+    print()
+
+
+def feedback_state_label(feedback_result: CheckResult) -> tuple[str, str]:
+    """Return a compact human status for PR feedback."""
+
+    if feedback_result.status == CheckStatus.PASSED:
+        return "resolved", "myopia:ignored-feedback found no unresolved threads"
+    if feedback_result.status == CheckStatus.FAILED:
+        detail = feedback_result.status_detail or feedback_result.error
+        return "unresolved", detail or "unresolved PR review threads remain"
+    detail = feedback_result.error or feedback_result.status_detail
+    return "error", detail or "could not verify PR feedback"
+
+
+def format_feedback_state(feedback_result: CheckResult) -> str:
+    """Format a one-line PR feedback state."""
+
+    state, detail = feedback_state_label(feedback_result)
+    return f"PR feedback: {state} - {detail}"
+
+
+def print_inspect_state_summary(
+    *,
+    scan_exit: int,
+    payload: dict[str, Any],
+    feedback_result: CheckResult,
+    json_output: bool,
+) -> None:
+    """Print buff's overall PR state after inspect has enough evidence."""
+
+    if json_output:
+        return
+    scan_state, scan_detail = _scan_state_label(scan_exit, payload)
+    feedback_state, feedback_detail = feedback_state_label(feedback_result)
+    overall_state, overall_detail = _inspect_overall_state(scan_state, feedback_state)
+    print("== Buff PR state ==")
+    print(f"Scan artifact: {scan_state} - {scan_detail}")
+    print(f"PR feedback: {feedback_state} - {feedback_detail}")
+    print(f"Overall: {overall_state} - {overall_detail}")
+    print()
+
+
+def print_ci_state_summary(checks: list[dict[str, Any]]) -> None:
+    """Print a one-line CI interpretation before detailed status output."""
+
+    state, detail = _ci_state_label(checks)
+    print(f"Overall PR state: {state} - {detail}")
+    print()
+
+
+def _scan_state_label(scan_exit: int, payload: dict[str, Any]) -> tuple[str, str]:
+    """Return a compact human status for the CI scan artifact."""
+
+    if payload.get("scan_unavailable"):
+        return "unavailable", "CI scan artifact is missing or not downloadable"
+    if scan_exit == 0:
+        return "clean", "CI scan artifact has no actionable signals"
+    return "needs work", "CI scan artifact contains actionable signals"
+
+
+def _inspect_overall_state(
+    scan_state: str,
+    feedback_state: str,
+) -> tuple[str, str]:
+    """Summarize the full inspect state in one line."""
+
+    if scan_state == "clean" and feedback_state == "resolved":
+        return "clean", "CI scan signals and PR feedback are resolved"
+    if scan_state == "unavailable":
+        if feedback_state == "resolved":
+            return (
+                "incomplete",
+                "PR feedback is resolved, but the scan artifact is missing",
+            )
+        return "incomplete", "scan artifact is missing and PR feedback is not clean"
+    if feedback_state == "error":
+        return "blocked", "buff could not verify PR feedback"
+    return "needs work", "CI scan signals or PR feedback still need attention"
+
+
+def _ci_state_label(checks: list[dict[str, Any]]) -> tuple[str, str]:
+    """Return buff's overall CI interpretation for a check set."""
+
+    completed, in_progress, failed = _categorize_checks(checks)
+    if failed:
+        return (
+            "blocked by CI",
+            f"{len(failed)} failed, {len(in_progress)} pending, {len(completed)} passed",
+        )
+    if in_progress:
+        return (
+            "waiting on CI",
+            f"{len(in_progress)} pending, {len(completed)} passed",
+        )
+    return "CI clean", f"{len(completed)}/{len(checks)} checks completed successfully"

--- a/slopmop/cli/buff_scan.py
+++ b/slopmop/cli/buff_scan.py
@@ -1,0 +1,108 @@
+"""CI scan helpers for buff inspect."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, cast
+
+from slopmop.cli.scan_triage import TriageError, run_triage
+
+_SCAN_UNAVAILABLE_MARKERS = (
+    "no workflow runs found for that pr/workflow",
+    "no artifact matches any of the names or patterns provided",
+    "no valid artifacts found to download",
+    "artifact downloaded but slopmop-results.json not found",
+)
+
+
+def is_scan_unavailable_error(exc: TriageError) -> bool:
+    """Return whether CI scan triage failed because the scan source is absent."""
+
+    message = str(exc).lower()
+    return any(marker in message for marker in _SCAN_UNAVAILABLE_MARKERS)
+
+
+def scan_unavailable_detail(error: str) -> str:
+    """Return a concise scan-unavailable detail line."""
+
+    lines = [line.strip() for line in error.splitlines() if line.strip()]
+    return lines[-1] if lines else error.strip()
+
+
+def build_scan_unavailable_payload(
+    *,
+    pr_number: int | None,
+    error: str,
+) -> dict[str, Any]:
+    """Build a buff payload when CI scan artifacts are unavailable."""
+
+    return {
+        "schema": "slopmop/ci-triage/v1",
+        "source": "code-scanning",
+        "pr_number": pr_number,
+        "summary": {
+            "failed": 0,
+            "errors": 0,
+            "warned": 0,
+            "all_passed": None,
+        },
+        "actionable": [],
+        "hard_failures": [],
+        "lowest_coverage": [],
+        "next_steps": [
+            "CI scan artifact unavailable; use 'sm buff status' or "
+            "'sm buff watch' to inspect check status.",
+            "Review PR feedback below and continue with 'sm buff iterate' "
+            "when threads remain.",
+        ],
+        "scan_unavailable": {
+            "error": error,
+        },
+    }
+
+
+def print_scan_unavailable(payload: dict[str, Any]) -> None:
+    """Render the scan-unavailable fallback for human buff output."""
+
+    unavailable = payload.get("scan_unavailable")
+    error = ""
+    if isinstance(unavailable, dict):
+        unavailable_obj = cast(dict[str, Any], unavailable)
+        error = str(unavailable_obj.get("error") or "")
+
+    print("WARNING: CI scan artifact unavailable; continuing with PR feedback only.")
+    detail = scan_unavailable_detail(error)
+    if detail:
+        print(f"Scan detail: {detail}")
+    print("Next step for CI status: run 'sm buff status' or 'sm buff watch'.")
+
+
+def run_inspect_scan(
+    args: argparse.Namespace,
+    resolved_pr_number: int,
+    *,
+    resolved_repo: str | None = None,
+) -> tuple[int, dict[str, Any] | None]:
+    """Run scan triage for buff inspect, keeping scan absence visible."""
+
+    try:
+        return run_triage(
+            repo=resolved_repo or args.repo,
+            run_id=args.run_id,
+            pr_number=resolved_pr_number,
+            workflow=args.workflow,
+            artifact=args.artifact,
+            show_low_coverage=False,
+            json_out=None,
+            print_output=False,
+        )
+    except TriageError as exc:
+        if not is_scan_unavailable_error(exc):
+            raise
+        return (
+            1,
+            build_scan_unavailable_payload(
+                pr_number=resolved_pr_number,
+                error=str(exc),
+            ),
+        )

--- a/slopmop/cli/scan_triage.py
+++ b/slopmop/cli/scan_triage.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, TypedDict, cast
+from typing import Any, Dict, List, Literal, TypedDict, cast
 
 from slopmop.core.config import get_current_pr_number
 from slopmop.reporting.rail import (
@@ -50,6 +50,9 @@ class _WorkflowRunState(TypedDict, total=False):
     latest: _RunEntry
     latest_completed: _RunEntry
     latest_for_head: _RunEntry
+
+
+PRResolutionSource = Literal["explicit", "branch", "configured", "latest_open"]
 
 
 def _run_gh(args: list[str]) -> str:
@@ -125,8 +128,8 @@ def current_pr_number(repo: str) -> int:
     return number
 
 
-def validate_open_pr(repo: str, pr_number: int) -> int:
-    """Validate that a PR exists and is open."""
+def _open_pr_metadata(repo: str, pr_number: int) -> Dict[str, Any]:
+    """Return PR metadata after validating the PR exists and is open."""
 
     out = _run_gh(
         [
@@ -136,30 +139,86 @@ def validate_open_pr(repo: str, pr_number: int) -> int:
             "--repo",
             repo,
             "--json",
-            "number,state",
+            "number,state,headRefName,headRefOid,closedAt,mergedAt",
         ]
     )
     data = json.loads(out)
-    number = data.get("number")
-    state = str(data.get("state") or "").upper()
+    if not isinstance(data, dict):
+        raise TriageError(f"PR #{pr_number} does not exist in {repo}.")
+    pr_data = cast(Dict[str, Any], data)
+    number = pr_data.get("number")
+    state = str(pr_data.get("state") or "").upper()
     if not isinstance(number, int):
         raise TriageError(f"PR #{pr_number} does not exist in {repo}.")
+    if state == "MERGED" or pr_data.get("mergedAt"):
+        raise TriageError(
+            f"PR #{pr_number} has already been merged. Pass an open PR number."
+        )
+    if state == "CLOSED" or pr_data.get("closedAt"):
+        raise TriageError(
+            f"PR #{pr_number} has already been closed. Pass an open PR number."
+        )
     if state != "OPEN":
         raise TriageError(
             f"PR #{pr_number} is not open (state={state.lower() or 'unknown'})."
         )
-    return number
+    return pr_data
 
 
-def resolve_pr_number(repo: str, explicit_pr_number: int | None) -> int:
-    """Resolve the working PR number from explicit arg or repo config."""
+def validate_open_pr(repo: str, pr_number: int) -> int:
+    """Validate that a PR exists and is open."""
+
+    return int(_open_pr_metadata(repo, pr_number)["number"])
+
+
+def latest_open_pr_number(repo: str) -> int:
+    """Return the most recently updated open PR for a repository."""
+
+    out = _run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,updatedAt",
+            "--limit",
+            "100",
+        ]
+    )
+    rows_raw = json.loads(out)
+    if not isinstance(rows_raw, list):
+        raise TriageError("Unexpected response shape while listing open PRs.")
+    row_list: List[Any] = cast(List[Any], rows_raw)
+
+    rows: list[Dict[str, Any]] = []
+    for row_raw in row_list:
+        if not isinstance(row_raw, dict):
+            continue
+        row = cast(Dict[str, Any], row_raw)
+        if isinstance(row.get("number"), int):
+            rows.append(row)
+
+    if not rows:
+        raise TriageError("No open PRs found in this repository.")
+
+    rows.sort(key=lambda row: str(row.get("updatedAt") or ""), reverse=True)
+    return int(rows[0]["number"])
+
+
+def resolve_pr_number_with_source(
+    repo: str, explicit_pr_number: int | None, *, assume_latest: bool = False
+) -> tuple[int, PRResolutionSource]:
+    """Resolve the working PR number and report where it came from."""
 
     if explicit_pr_number is not None:
-        return validate_open_pr(repo, explicit_pr_number)
+        return validate_open_pr(repo, explicit_pr_number), "explicit"
 
     branch_error: TriageError | None = None
     try:
-        return current_pr_number(repo)
+        return current_pr_number(repo), "branch"
     except TriageError as exc:
         branch_error = exc
 
@@ -167,7 +226,7 @@ def resolve_pr_number(repo: str, explicit_pr_number: int | None) -> int:
     configured_pr = get_current_pr_number(project_root)
     if configured_pr is not None:
         try:
-            return validate_open_pr(repo, configured_pr)
+            return validate_open_pr(repo, configured_pr), "configured"
         except TriageError as exc:
             raise TriageError(
                 f"Selected working PR #{configured_pr} is stale: {exc} "
@@ -175,11 +234,94 @@ def resolve_pr_number(repo: str, explicit_pr_number: int | None) -> int:
                 "or clear the stale selection with 'sm config --clear-current-pr'."
             ) from exc
 
+    if assume_latest:
+        try:
+            return latest_open_pr_number(repo), "latest_open"
+        except TriageError as exc:
+            raise TriageError(
+                "No open PR found for the current branch, no working PR is selected, "
+                "and no open PRs exist to assume. Open a PR first, set one with "
+                "'sm config --current-pr-number <n>', or pass an explicit PR number."
+            ) from (branch_error or exc)
+
     raise TriageError(
         "No open PR found for the current branch and no working PR is selected. "
         "Open a PR first, set one with 'sm config --current-pr-number <n>', or "
         "pass an explicit PR number."
     ) from branch_error
+
+
+def resolve_pr_number(repo: str, explicit_pr_number: int | None) -> int:
+    """Resolve the working PR number from explicit arg or repo config."""
+
+    number, _source = resolve_pr_number_with_source(repo, explicit_pr_number)
+    return number
+
+
+def validate_run_for_pr_head(
+    repo: str,
+    run_id: int,
+    pr_number: int,
+    workflow: str,
+) -> dict[str, Any]:
+    """Validate an explicit run belongs to the selected PR head and workflow."""
+
+    pr_data = _open_pr_metadata(repo, pr_number)
+    head_sha = str(pr_data.get("headRefOid") or "").strip()
+    if not head_sha:
+        raise TriageError(f"Could not resolve head commit for PR #{pr_number}.")
+
+    out = _run_gh(
+        [
+            "run",
+            "view",
+            str(run_id),
+            "--repo",
+            repo,
+            "--json",
+            "databaseId,headSha,name,status,conclusion,createdAt",
+        ]
+    )
+    run_raw = json.loads(out)
+    if not isinstance(run_raw, dict):
+        raise TriageError(f"Could not resolve workflow run {run_id}.")
+    run = cast(Dict[str, Any], run_raw)
+
+    run_name = str(run.get("name") or "")
+    if workflow not in run_name:
+        raise TriageError(
+            f"Run {run_id} is '{run_name or 'unknown'}', not '{workflow}'."
+        )
+
+    run_sha = str(run.get("headSha") or "").strip()
+    if run_sha != head_sha:
+        raise TriageError(
+            f"Run {run_id} does not match PR #{pr_number} head "
+            f"{_short_sha(head_sha)} (run head {_short_sha(run_sha)})."
+        )
+
+    run_status = str(run.get("status") or "unknown")
+    if run_status != "completed":
+        raise TriageError(
+            f"Run {run_id} for PR #{pr_number} is still {run_status}. "
+            "Wait for it to finish, then re-run buff."
+        )
+
+    latest_run_id = run.get("databaseId")
+    if not isinstance(latest_run_id, int):
+        latest_run_id = run_id
+
+    return {
+        "head_sha": head_sha,
+        "latest_run_id": latest_run_id,
+        "latest_status": run_status,
+        "latest_conclusion": run.get("conclusion"),
+        "latest_created_at": run.get("createdAt"),
+        "triaged_run_id": run_id,
+        "triaged_is_latest": True,
+        "pending_newer_run": False,
+        "note": "Using explicitly supplied workflow run.",
+    }
 
 
 def latest_completed_run_id(repo: str, pr_number: int, workflow: str) -> int:
@@ -189,18 +331,7 @@ def latest_completed_run_id(repo: str, pr_number: int, workflow: str) -> int:
 
 
 def _workflow_run_state(repo: str, pr_number: int, workflow: str) -> _WorkflowRunState:
-    pr_out = _run_gh(
-        [
-            "pr",
-            "view",
-            str(pr_number),
-            "--repo",
-            repo,
-            "--json",
-            "headRefName,headRefOid",
-        ]
-    )
-    pr_data = json.loads(pr_out)
+    pr_data = _open_pr_metadata(repo, pr_number)
     branch = str(pr_data.get("headRefName") or "").strip()
     head_sha = str(pr_data.get("headRefOid") or "").strip()
     if not branch:
@@ -563,6 +694,13 @@ def run_triage(
         resolved_run_id, ci_state = _resolve_fresh_run(
             state,
             resolved_pr,
+            workflow,
+        )
+    elif resolved_pr_number is not None:
+        ci_state = validate_run_for_pr_head(
+            resolved_repo,
+            resolved_run_id,
+            resolved_pr_number,
             workflow,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@
 
 from pathlib import Path
 from typing import Generator
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from slopmop.cli import buff as buff_mod
 from slopmop.cli.barnacle import AUTO_FILE_DISABLED_ENVAR
 from slopmop.core.result import CheckResult, CheckStatus
 
@@ -106,6 +107,19 @@ def make_feedback_result(status: CheckStatus, **kwargs) -> CheckResult:
         fix_suggestion=kwargs.get("fix_suggestion"),
         status_detail=kwargs.get("status_detail"),
     )
+
+
+def patch_buff_pr_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    pr_number: int,
+    source: str = "explicit",
+) -> Mock:
+    """Patch buff PR resolution for inspect command unit tests."""
+
+    resolver = Mock(return_value=(pr_number, source))
+    monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+    monkeypatch.setattr(buff_mod, "resolve_pr_number_with_source", resolver)
+    return resolver
 
 
 def make_mock_status_registry(all_gates=None, swab_gates=None, scour_gates=None):

--- a/tests/unit/test_buff_inspect_and_status.py
+++ b/tests/unit/test_buff_inspect_and_status.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 from slopmop.cli import buff as buff_mod
 from slopmop.cli import scan_triage as triage
 from slopmop.core.result import CheckStatus
-from tests.conftest import make_feedback_result
+from tests.conftest import make_feedback_result, patch_buff_pr_resolution
 
 
 class TestBuffInspectCommand:
@@ -25,7 +25,7 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(return_value=(0, {"summary": {}, "actionable": [], "next_steps": []})),
         )
         monkeypatch.setattr(buff_mod, "write_json_out", Mock())
@@ -33,6 +33,7 @@ class TestBuffInspectCommand:
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 84)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -42,6 +43,10 @@ class TestBuffInspectCommand:
         assert buff_mod.cmd_buff(args) == 0
         out = capsys.readouterr().out
         assert "== Buff inspect: checking CI code-scanning results ==" in out
+        assert "== Buff PR selection ==" in out
+        assert "Selected PR: #84 (explicit)" in out
+        assert "== Buff PR state ==" in out
+        assert "Overall: clean - CI scan signals and PR feedback are resolved" in out
         assert (
             "Buff inspect clean: CI scan signals and PR feedback are resolved." in out
         )
@@ -59,7 +64,7 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(
                 return_value=(
                     1,
@@ -72,6 +77,7 @@ class TestBuffInspectCommand:
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 84)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -95,10 +101,13 @@ class TestBuffInspectCommand:
         )
 
         payload = {"schema": "slopmop/ci-triage/v1", "summary": {}, "actionable": []}
-        monkeypatch.setattr(buff_mod, "run_triage", Mock(return_value=(0, payload)))
+        monkeypatch.setattr(
+            buff_mod, "run_inspect_scan", Mock(return_value=(0, payload))
+        )
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 84)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -108,7 +117,7 @@ class TestBuffInspectCommand:
         assert buff_mod.cmd_buff(args) == 0
         assert '"schema": "slopmop/ci-triage/v1"' in capsys.readouterr().out
 
-    def test_cmd_buff_uses_resolved_pr_number_from_triage_payload(self, monkeypatch):
+    def test_cmd_buff_uses_pre_resolved_pr_number(self, monkeypatch):
         args = argparse.Namespace(
             json_output=False,
             repo=None,
@@ -121,7 +130,7 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(
                 return_value=(
                     0,
@@ -139,6 +148,7 @@ class TestBuffInspectCommand:
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 85, "branch")
         feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
         monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
 
@@ -156,10 +166,11 @@ class TestBuffInspectCommand:
             output_file=None,
         )
 
-        monkeypatch.setattr(buff_mod, "run_triage", Mock(return_value=(0, None)))
+        monkeypatch.setattr(buff_mod, "run_inspect_scan", Mock(return_value=(0, None)))
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 84)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -182,9 +193,13 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(side_effect=buff_mod.TriageError("bad triage")),
         )
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        patch_buff_pr_resolution(monkeypatch, 84)
 
         assert buff_mod.cmd_buff(args) == 1
         assert "ERROR: bad triage" in capsys.readouterr().out
@@ -202,7 +217,7 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(return_value=(0, {"summary": {}, "actionable": [], "next_steps": []})),
         )
         monkeypatch.setattr(buff_mod, "write_json_out", Mock())
@@ -210,6 +225,7 @@ class TestBuffInspectCommand:
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 85)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -246,7 +262,7 @@ class TestBuffInspectCommand:
 
         monkeypatch.setattr(
             buff_mod,
-            "run_triage",
+            "run_inspect_scan",
             Mock(return_value=(0, {"summary": {}, "actionable": [], "next_steps": []})),
         )
         monkeypatch.setattr(buff_mod, "write_json_out", Mock())
@@ -254,6 +270,7 @@ class TestBuffInspectCommand:
         monkeypatch.setattr(
             buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
         )
+        patch_buff_pr_resolution(monkeypatch, 85)
         monkeypatch.setattr(
             buff_mod,
             "_run_pr_feedback_gate",
@@ -265,800 +282,3 @@ class TestBuffInspectCommand:
             "== Buff inspect: checking CI code-scanning results =="
             in capsys.readouterr().out
         )
-
-
-class TestBuffStatusCommand:
-    def test_get_current_branch_returns_branch(self, monkeypatch):
-        monkeypatch.setattr(
-            buff_mod.subprocess,
-            "run",
-            Mock(return_value=Mock(returncode=0, stdout="feature/demo\n")),
-        )
-
-        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) == "feature/demo"
-
-    def test_get_current_branch_returns_none_on_command_failure(self, monkeypatch):
-        monkeypatch.setattr(
-            buff_mod.subprocess,
-            "run",
-            Mock(return_value=Mock(returncode=1, stdout="")),
-        )
-
-        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) is None
-
-    def test_get_pr_head_branch_returns_branch(self, monkeypatch):
-        monkeypatch.setattr(
-            buff_mod.subprocess,
-            "run",
-            Mock(return_value=Mock(returncode=0, stdout='{"headRefName":"feat-x"}')),
-        )
-
-        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) == "feat-x"
-
-    def test_get_pr_head_branch_returns_none_on_invalid_json(self, monkeypatch):
-        monkeypatch.setattr(
-            buff_mod.subprocess,
-            "run",
-            Mock(return_value=Mock(returncode=0, stdout="not-json")),
-        )
-
-        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) is None
-
-    def test_cmd_buff_status_fires_buff_hook_on_clean_terminal_state(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(
-            buff_mod,
-            "_fetch_checks",
-            Mock(
-                return_value=(
-                    [
-                        {
-                            "name": "Primary Code Scanning Gate (blocking)",
-                            "bucket": "pass",
-                            "state": "SUCCESS",
-                            "link": "https://example.test/check",
-                        }
-                    ],
-                    "",
-                )
-            ),
-        )
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
-        )
-        fire_hook = Mock()
-        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
-
-        assert buff_mod.cmd_buff(args) == 0
-        assert "CI CLEAN" in capsys.readouterr().out
-        fire_hook.assert_called_once_with(has_issues=False)
-
-    def test_cmd_buff_status_fires_buff_hook_on_failed_terminal_state(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(
-            buff_mod,
-            "_fetch_checks",
-            Mock(
-                return_value=(
-                    [
-                        {
-                            "name": "Primary Code Scanning Gate (blocking)",
-                            "bucket": "fail",
-                            "state": "FAILURE",
-                            "link": "https://example.test/check",
-                        }
-                    ],
-                    "",
-                )
-            ),
-        )
-        fire_hook = Mock()
-        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
-
-        assert buff_mod.cmd_buff(args) == 1
-        out = capsys.readouterr().out
-        assert "Primary Code Scanning Gate (blocking)" in out
-        assert "failed" in out.lower()
-        fire_hook.assert_called_once_with(has_issues=True)
-
-    def test_cmd_buff_status_reports_stale_selected_pr(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=[],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(
-            buff_mod,
-            "resolve_pr_number",
-            Mock(side_effect=buff_mod.TriageError("Selected working PR #92 is stale")),
-        )
-
-        assert buff_mod.cmd_buff(args) == 1
-        assert "Selected working PR #92 is stale" in capsys.readouterr().out
-
-    def test_cmd_buff_status_blocks_on_unresolved_feedback(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(
-            buff_mod,
-            "_fetch_checks",
-            Mock(
-                return_value=(
-                    [
-                        {
-                            "name": "Primary Code Scanning Gate (blocking)",
-                            "bucket": "pass",
-                            "state": "SUCCESS",
-                            "link": "https://example.test/check",
-                        }
-                    ],
-                    "",
-                )
-            ),
-        )
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(
-                return_value=make_feedback_result(
-                    CheckStatus.FAILED,
-                    output="PR #85 has unresolved review threads.",
-                )
-            ),
-        )
-
-        assert buff_mod.cmd_buff(args) == 1
-        out = capsys.readouterr().out
-        assert "CI checks are clean, but unresolved PR review threads remain." in out
-        assert "PR #85 has unresolved review threads." in out
-
-    def test_cmd_buff_status_warns_on_pr_worktree_mismatch(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(buff_mod, "_get_current_branch", Mock(return_value="main"))
-        monkeypatch.setattr(
-            buff_mod, "_get_pr_head_branch", Mock(return_value="feature/pr-85")
-        )
-        monkeypatch.setattr(
-            buff_mod,
-            "_fetch_checks",
-            Mock(
-                return_value=(
-                    [
-                        {
-                            "name": "Primary Code Scanning Gate (blocking)",
-                            "bucket": "pass",
-                            "state": "SUCCESS",
-                            "link": "https://example.test/check",
-                        }
-                    ],
-                    "",
-                )
-            ),
-        )
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
-        )
-        monkeypatch.setattr(buff_mod, "_fire_buff_hook", Mock())
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "PR/worktree mismatch detected" in out
-        assert "Current branch: main" in out
-        assert "PR #85 head branch: feature/pr-85" in out
-        assert "run buff from the PR worktree" in out
-
-    def test_cmd_buff_watch_waits_once_for_post_ci_feedback_settle(
-        self, monkeypatch, capsys
-    ):
-        """Bugbot settle requires one extra poll wait after all CI checks complete.
-
-        When Bugbot's completedAt is set (truly finished), the watch loop fires
-        one settle sleep then runs the feedback gate once as the final verdict.
-        """
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=7,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        checks = [
-            {
-                "name": "Primary Code Scanning Gate (blocking)",
-                "bucket": "pass",
-                "state": "SUCCESS",
-                "link": "https://example.test/check",
-            },
-            {
-                "name": "Cursor Bugbot",
-                "bucket": "neutral",
-                "state": "NEUTRAL",
-                "link": "https://cursor.com/docs/bugbot",
-                # completedAt set — Bugbot has truly finished
-                "completedAt": "2026-03-18T12:00:00Z",
-            },
-        ]
-        # Two fetches: settle wait, final check.
-        fetch_checks = Mock(side_effect=[(checks, ""), (checks, "")])
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "Waiting one extra interval for review feedback to settle" in out
-        assert "CI CLEAN" in out
-        # Two loop iterations, two fetch calls.
-        assert fetch_checks.call_count == 2
-        # Gate called once: final verdict only.
-        assert feedback_gate.call_count == 1
-        # One settle sleep.
-        assert sleep_mock.call_count == 1
-        sleep_mock.assert_called_with(7)
-
-    def test_cmd_buff_watch_treats_bugbot_with_no_completed_at_as_in_progress(
-        self, monkeypatch, capsys
-    ):
-        """Bugbot with no completedAt is still running — buff keeps polling.
-
-        Root cause of the bug: Bugbot shows bucket=skipping/neutral before it
-        has set completedAt, so it isn't actually done yet.  The fix is to
-        treat neutral/skipping checks without completedAt as in_progress.
-        """
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=7,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        # First two polls: Bugbot has no completedAt — still in_progress
-        in_flight_checks = [
-            {
-                "name": "Primary Code Scanning Gate (blocking)",
-                "bucket": "pass",
-                "state": "SUCCESS",
-                "link": "https://example.test/check",
-            },
-            {
-                "name": "Cursor Bugbot",
-                "bucket": "skipping",
-                "state": "NEUTRAL",
-                "link": "https://cursor.com/docs/bugbot",
-                # No completedAt — Bugbot hasn't finished yet
-            },
-        ]
-        # Third poll: Bugbot sets completedAt — now truly done
-        done_checks = [
-            {
-                "name": "Primary Code Scanning Gate (blocking)",
-                "bucket": "pass",
-                "state": "SUCCESS",
-                "link": "https://example.test/check",
-            },
-            {
-                "name": "Cursor Bugbot",
-                "bucket": "skipping",
-                "state": "NEUTRAL",
-                "link": "https://cursor.com/docs/bugbot",
-                "completedAt": "2026-03-18T12:00:00Z",
-            },
-        ]
-        fetch_checks = Mock(
-            side_effect=[
-                (in_flight_checks, ""),  # poll 1: Bugbot in_progress
-                (in_flight_checks, ""),  # poll 2: still in_progress
-                (done_checks, ""),  # poll 3: Bugbot done — settle fires
-                (done_checks, ""),  # poll 4: final gate check
-            ]
-        )
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "CI CLEAN" in out
-        # 4 fetches: 2 in_progress polls, settle, final
-        assert fetch_checks.call_count == 4
-        # Gate called once after settle
-        assert feedback_gate.call_count == 1
-        # 3 sleeps: 2 in_progress polls + 1 settle
-        assert sleep_mock.call_count == 3
-
-    def test_cmd_buff_status_no_checks_still_blocks_on_unresolved_feedback(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=([], "")))
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(
-                return_value=make_feedback_result(
-                    CheckStatus.FAILED,
-                    output="PR #85 has unresolved review threads.",
-                )
-            ),
-        )
-
-        assert buff_mod.cmd_buff(args) == 1
-        out = capsys.readouterr().out
-        assert "no CI checks found, but unresolved PR review threads remain" in out
-        assert "PR #85 has unresolved review threads." in out
-
-    def test_cmd_buff_status_no_checks_clean_fires_success_hook(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=([], "")))
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
-        )
-        fire_hook = Mock()
-        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "No CI checks found for this PR" in out
-        fire_hook.assert_called_once_with(has_issues=False)
-
-    def test_cmd_buff_status_blocks_when_feedback_not_verified(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="status",
-            action_args=["85"],
-            interval=30,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        monkeypatch.setattr(
-            buff_mod,
-            "_fetch_checks",
-            Mock(
-                return_value=(
-                    [
-                        {
-                            "name": "Primary Code Scanning Gate (blocking)",
-                            "bucket": "pass",
-                            "state": "SUCCESS",
-                            "link": "https://example.test/check",
-                        }
-                    ],
-                    "",
-                )
-            ),
-        )
-        monkeypatch.setattr(
-            buff_mod,
-            "_run_pr_feedback_gate",
-            Mock(return_value=make_feedback_result(CheckStatus.SKIPPED)),
-        )
-
-        assert buff_mod.cmd_buff(args) == 1
-        out = capsys.readouterr().out
-        assert "Buff status error: could not verify unresolved PR feedback." in out
-        assert "CI CLEAN" not in out
-
-    def test_cmd_buff_watch_resets_settle_flag_after_failed_pending_poll(
-        self, monkeypatch, capsys
-    ):
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=7,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        passing_checks = [
-            {
-                "name": "Primary Code Scanning Gate (blocking)",
-                "bucket": "pass",
-                "state": "SUCCESS",
-                "link": "https://example.test/check",
-            },
-            {
-                "name": "Cursor Bugbot",
-                "bucket": "neutral",
-                "state": "NEUTRAL",
-                "link": "https://cursor.com/docs/bugbot",
-                # completedAt set — Bugbot has truly finished
-                "completedAt": "2026-03-18T12:00:00Z",
-            },
-        ]
-        failed_pending_checks = [
-            {
-                "name": "Primary Code Scanning Gate (blocking)",
-                "bucket": "fail",
-                "state": "FAILURE",
-                "link": "https://example.test/fail",
-            },
-            {
-                "name": "Cursor Bugbot",
-                "bucket": "pending",
-                "state": "IN_PROGRESS",
-                "link": "https://cursor.com/docs/bugbot",
-            },
-        ]
-        # Sequence (single-phase settle with completedAt fix):
-        # 1. passing → settle fires (Bugbot has completedAt), sleep1, settled=True
-        # 2. failed+pending → reset settled=False, sleep2, continue
-        # 3. passing → settle fires again (settled=False), sleep3, settled=True
-        # 4. passing → final gate check → PASSED → success
-        fetch_checks = Mock(
-            side_effect=[
-                (passing_checks, ""),
-                (failed_pending_checks, ""),
-                (passing_checks, ""),
-                (passing_checks, ""),
-            ]
-        )
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert (
-            out.count("Waiting one extra interval for review feedback to settle") == 2
-        )
-        assert fetch_checks.call_count == 4
-        # Gate called once: final verdict only (no phase-2).
-        assert feedback_gate.call_count == 1
-        # 3 sleeps: settle, failed-reset, settle-again.
-        assert sleep_mock.call_count == 3
-
-    def test_cmd_buff_watch_fail_fast_exits_immediately(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=7,
-            fail_fast=True,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        checks = [
-            {
-                "name": "lint",
-                "bucket": "fail",
-                "state": "FAILURE",
-                "link": "https://example.test/fail",
-            },
-            {
-                "name": "build",
-                "bucket": "pending",
-                "state": "IN_PROGRESS",
-                "link": "",
-            },
-        ]
-        fetch_checks = Mock(return_value=(checks, ""))
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 1
-        out = capsys.readouterr().out
-        assert "fail-fast" in out
-        assert "SLOP IN CI" in out
-        # Should NOT have slept — fail-fast exits immediately
-        sleep_mock.assert_not_called()
-        assert fetch_checks.call_count == 1
-
-    def test_cmd_buff_watch_retries_empty_checks(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=5,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        passing_checks = [
-            {
-                "name": "lint",
-                "bucket": "pass",
-                "state": "SUCCESS",
-                "link": "",
-            },
-        ]
-        # First 2 polls return empty, third returns checks
-        fetch_checks = Mock(side_effect=[([], ""), ([], ""), (passing_checks, "")])
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "No CI checks registered yet" in out
-        assert fetch_checks.call_count == 3
-        assert sleep_mock.call_count == 2
-
-    def test_cmd_buff_watch_shows_poll_counter(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=5,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        pending = [
-            {"name": "build", "bucket": "pending", "state": "PENDING", "link": ""}
-        ]
-        passing = [{"name": "build", "bucket": "pass", "state": "SUCCESS", "link": ""}]
-        fetch_checks = Mock(side_effect=[(pending, ""), (passing, "")])
-        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-        sleep_mock = Mock()
-        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "Poll #2" in out
-        assert "CI CLEAN" in out
-
-    def test_cmd_buff_watch_shows_total_watch_time(self, monkeypatch, capsys):
-        args = argparse.Namespace(
-            pr_or_action="watch",
-            action_args=["85"],
-            interval=5,
-            json_output=False,
-            repo=None,
-            run_id=None,
-            workflow=triage.WORKFLOW_NAME,
-            artifact=triage.ARTIFACT_NAME,
-            output_file=None,
-            scenario=None,
-            message=None,
-            no_resolve=False,
-        )
-
-        monkeypatch.setattr(
-            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
-        )
-        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
-        monkeypatch.setattr(buff_mod, "resolve_pr_number", Mock(return_value=85))
-        checks = [{"name": "lint", "bucket": "pass", "state": "SUCCESS", "link": ""}]
-        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=(checks, "")))
-        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
-        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
-
-        assert buff_mod.cmd_buff(args) == 0
-        out = capsys.readouterr().out
-        assert "Total watch time:" in out

--- a/tests/unit/test_buff_inspect_edges.py
+++ b/tests/unit/test_buff_inspect_edges.py
@@ -1,0 +1,90 @@
+"""Focused edge tests for buff inspect argument and feedback handling."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import Mock
+
+from slopmop.cli import buff as buff_mod
+from slopmop.cli import scan_triage as triage
+from slopmop.core.result import CheckStatus
+from tests.conftest import make_feedback_result, patch_buff_pr_resolution
+
+
+def _inspect_args(**overrides) -> argparse.Namespace:
+    defaults = {
+        "json_output": False,
+        "repo": None,
+        "run_id": None,
+        "pr_number": 84,
+        "workflow": triage.WORKFLOW_NAME,
+        "artifact": triage.ARTIFACT_NAME,
+        "output_file": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_cmd_buff_rejects_non_integer_inspect_pr(capsys):
+    args = argparse.Namespace(
+        pr_or_action="inspect",
+        action_args=["notint"],
+    )
+
+    assert buff_mod.cmd_buff(args) == 2
+    assert "PR number must be an integer" in capsys.readouterr().out
+
+
+def test_cmd_buff_rejects_extra_inspect_pr_args(capsys):
+    args = argparse.Namespace(
+        pr_or_action="inspect",
+        action_args=["84", "85"],
+    )
+
+    assert buff_mod.cmd_buff(args) == 2
+    assert "buff inspect accepts at most one PR number" in capsys.readouterr().out
+
+
+def test_cmd_buff_rejects_extra_status_pr_args(capsys):
+    args = argparse.Namespace(
+        pr_or_action="status",
+        action_args=["84", "85"],
+        interval=30,
+        fail_fast=False,
+    )
+
+    assert buff_mod.cmd_buff(args) == 2
+    assert "buff status accepts at most one PR number" in capsys.readouterr().out
+
+
+def test_cmd_buff_reports_pr_feedback_error(monkeypatch, capsys):
+    args = _inspect_args()
+
+    monkeypatch.setattr(
+        buff_mod,
+        "run_inspect_scan",
+        Mock(return_value=(0, {"summary": {}, "actionable": [], "next_steps": []})),
+    )
+    monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+    monkeypatch.setattr(buff_mod, "print_triage", Mock())
+    monkeypatch.setattr(
+        buff_mod,
+        "_project_root_from_cwd",
+        Mock(return_value="/repo"),
+    )
+    patch_buff_pr_resolution(monkeypatch, 84)
+    monkeypatch.setattr(
+        buff_mod,
+        "_run_pr_feedback_gate",
+        Mock(
+            return_value=make_feedback_result(
+                CheckStatus.ERROR,
+                error="feedback lookup failed",
+            )
+        ),
+    )
+
+    assert buff_mod.cmd_buff(args) == 1
+    out = capsys.readouterr().out
+    assert "Buff inspect failed: could not verify unresolved PR feedback." in out
+    assert "ERROR: feedback lookup failed" in out

--- a/tests/unit/test_buff_scan_fallback.py
+++ b/tests/unit/test_buff_scan_fallback.py
@@ -1,0 +1,335 @@
+"""Unit tests for buff inspect scan-unavailable fallback."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import Mock
+
+from slopmop.cli import buff as buff_mod
+from slopmop.cli import buff_scan
+from slopmop.cli import scan_triage as triage
+from slopmop.core.result import CheckStatus
+from tests.conftest import make_feedback_result, patch_buff_pr_resolution
+
+
+class TestBuffScanFallback:
+    def test_cmd_buff_resolves_pr_when_scan_fails_before_payload(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            json_output=False,
+            repo=None,
+            run_id=None,
+            pr_number=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+        )
+
+        monkeypatch.setattr(
+            buff_mod,
+            "run_inspect_scan",
+            Mock(
+                return_value=(
+                    1,
+                    buff_scan.build_scan_unavailable_payload(
+                        pr_number=86,
+                        error=(
+                            "No workflow runs found for that PR/workflow. "
+                            "Pass --run-id explicitly."
+                        ),
+                    ),
+                )
+            ),
+        )
+        monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+        monkeypatch.setattr(
+            buff_mod,
+            "_project_root_from_cwd",
+            Mock(return_value="/repo"),
+        )
+        patch_buff_pr_resolution(monkeypatch, 86, "branch")
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "Buff inspect incomplete: PR feedback is resolved" in out
+        assert "CI scan artifact is still missing" in out
+        feedback_gate.assert_called_once_with(86, "/repo")
+
+    def test_cmd_buff_falls_back_when_scan_artifact_missing(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            json_output=False,
+            repo=None,
+            run_id=25540673430,
+            pr_number=84,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+        )
+
+        monkeypatch.setattr(
+            buff_mod,
+            "run_inspect_scan",
+            Mock(
+                return_value=(
+                    1,
+                    buff_scan.build_scan_unavailable_payload(
+                        pr_number=84,
+                        error=(
+                            "gh command failed: gh run download 25540673430 "
+                            "--name slopmop-results\n"
+                            "no artifact matches any of the names or patterns provided"
+                        ),
+                    ),
+                )
+            ),
+        )
+        monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+        monkeypatch.setattr(
+            buff_mod,
+            "_project_root_from_cwd",
+            Mock(return_value="/repo"),
+        )
+        patch_buff_pr_resolution(monkeypatch, 84)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "CI scan artifact unavailable" in out
+        assert "Buff inspect incomplete: PR feedback is resolved" in out
+        feedback_gate.assert_called_once_with(84, "/repo")
+
+    def test_cmd_buff_scan_fallback_still_blocks_on_review_feedback(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            json_output=False,
+            repo=None,
+            run_id=None,
+            pr_number=85,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+        )
+
+        monkeypatch.setattr(
+            buff_mod,
+            "run_inspect_scan",
+            Mock(
+                return_value=(
+                    1,
+                    buff_scan.build_scan_unavailable_payload(
+                        pr_number=85,
+                        error=(
+                            "No workflow runs found for that PR/workflow. "
+                            "Pass --run-id explicitly."
+                        ),
+                    ),
+                )
+            ),
+        )
+        monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+        monkeypatch.setattr(
+            buff_mod,
+            "_project_root_from_cwd",
+            Mock(return_value="/repo"),
+        )
+        patch_buff_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(
+                return_value=make_feedback_result(
+                    CheckStatus.FAILED,
+                    status_detail="1 unresolved",
+                    output="PR #85 has unresolved review threads.",
+                    error="1 unresolved PR comment(s)",
+                )
+            ),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "CI scan artifact unavailable" in out
+        assert "Buff inspect incomplete: CI scan artifact is still missing." in out
+        assert "PR feedback is resolved" not in out
+        assert "Buff inspect found unresolved PR review threads." in out
+        assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_warns_when_assuming_latest_open_pr(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            json_output=False,
+            repo=None,
+            run_id=None,
+            pr_number=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+        )
+
+        run_scan = Mock(
+            return_value=(0, {"summary": {}, "actionable": [], "next_steps": []})
+        )
+        monkeypatch.setattr(buff_mod, "run_inspect_scan", run_scan)
+        monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+        monkeypatch.setattr(buff_mod, "print_triage", Mock())
+        monkeypatch.setattr(
+            buff_mod,
+            "_project_root_from_cwd",
+            Mock(return_value="/repo"),
+        )
+        patch_buff_pr_resolution(monkeypatch, 90, "latest_open")
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "Assuming most recently updated open PR #90" in out
+        run_scan.assert_called_once_with(args, 90, resolved_repo="o/r")
+
+    def test_print_scan_unavailable_handles_missing_error(self, capsys):
+        buff_scan.print_scan_unavailable({"scan_unavailable": None})
+
+        out = capsys.readouterr().out
+        assert "CI scan artifact unavailable" in out
+        assert "Scan detail:" not in out
+
+    def test_cmd_buff_json_mode_keeps_scan_absence_nonzero(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            json_output=True,
+            repo=None,
+            run_id=None,
+            pr_number=84,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+        )
+
+        monkeypatch.setattr(
+            buff_mod,
+            "run_inspect_scan",
+            Mock(
+                return_value=(
+                    1,
+                    buff_scan.build_scan_unavailable_payload(
+                        pr_number=84,
+                        error="no artifact matches any of the names provided",
+                    ),
+                )
+            ),
+        )
+        monkeypatch.setattr(buff_mod, "write_json_out", Mock())
+        monkeypatch.setattr(
+            buff_mod,
+            "_project_root_from_cwd",
+            Mock(return_value="/repo"),
+        )
+        patch_buff_pr_resolution(monkeypatch, 84)
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert '"scan_unavailable"' in out
+        assert "Buff inspect incomplete" not in out
+
+
+class TestBuffScanHelpers:
+    def test_is_scan_unavailable_error_matches_known_missing_sources(self):
+        assert buff_scan.is_scan_unavailable_error(
+            triage.TriageError("No workflow runs found for that PR/workflow")
+        )
+        assert buff_scan.is_scan_unavailable_error(
+            triage.TriageError("no valid artifacts found to download")
+        )
+        assert not buff_scan.is_scan_unavailable_error(
+            triage.TriageError("Could not parse JSON")
+        )
+
+    def test_run_inspect_scan_success(self, monkeypatch):
+        args = argparse.Namespace(
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+        )
+        triage_runner = Mock(return_value=(0, {"summary": {}, "actionable": []}))
+        monkeypatch.setattr(buff_scan, "run_triage", triage_runner)
+
+        code, payload = buff_scan.run_inspect_scan(args, 84)
+
+        assert code == 0
+        assert payload is not None
+        assert triage_runner.call_args.kwargs["repo"] is None
+
+    def test_run_inspect_scan_uses_resolved_repo(self, monkeypatch):
+        args = argparse.Namespace(
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+        )
+        triage_runner = Mock(return_value=(0, {"summary": {}, "actionable": []}))
+        monkeypatch.setattr(buff_scan, "run_triage", triage_runner)
+
+        code, payload = buff_scan.run_inspect_scan(
+            args,
+            84,
+            resolved_repo="o/r",
+        )
+
+        assert code == 0
+        assert payload is not None
+        assert triage_runner.call_args.kwargs["repo"] == "o/r"
+
+    def test_run_inspect_scan_reraises_real_triage_errors(self, monkeypatch):
+        args = argparse.Namespace(
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+        )
+        monkeypatch.setattr(
+            buff_scan,
+            "run_triage",
+            Mock(side_effect=triage.TriageError("Could not parse JSON")),
+        )
+
+        try:
+            buff_scan.run_inspect_scan(args, 84)
+        except triage.TriageError as exc:
+            assert "Could not parse JSON" in str(exc)
+        else:
+            raise AssertionError("Expected TriageError")
+
+    def test_run_inspect_scan_returns_scan_unavailable_payload(self, monkeypatch):
+        args = argparse.Namespace(
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+        )
+        monkeypatch.setattr(
+            buff_scan,
+            "run_triage",
+            Mock(
+                side_effect=triage.TriageError(
+                    "no artifact matches any of the names or patterns provided"
+                )
+            ),
+        )
+
+        code, payload = buff_scan.run_inspect_scan(args, 84)
+
+        assert code == 1
+        assert payload is not None
+        assert payload["scan_unavailable"]["error"]

--- a/tests/unit/test_buff_status.py
+++ b/tests/unit/test_buff_status.py
@@ -1,0 +1,825 @@
+"""Unit tests for buff inspect/status paths."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import Mock
+
+from slopmop.cli import buff as buff_mod
+from slopmop.cli import buff_common as common_mod
+from slopmop.cli import scan_triage as triage
+from slopmop.core.result import CheckStatus
+from tests.conftest import make_feedback_result
+
+
+def patch_status_pr_resolution(monkeypatch, pr_number=85, source="explicit"):
+    """Patch buff PR resolution for status/watch command tests."""
+
+    resolver = Mock(return_value=(pr_number, source))
+    monkeypatch.setattr(buff_mod, "resolve_pr_number_with_source", resolver)
+    return resolver
+
+
+class TestBuffStatusCommand:
+    def test_get_current_branch_returns_branch(self, monkeypatch):
+        monkeypatch.setattr(
+            common_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout="feature/demo\n")),
+        )
+
+        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) == "feature/demo"
+
+    def test_get_current_branch_returns_none_on_command_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            common_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=1, stdout="")),
+        )
+
+        assert buff_mod._get_current_branch(buff_mod.Path("/repo")) is None
+
+    def test_get_pr_head_branch_returns_branch(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout='{"headRefName":"feat-x"}')),
+        )
+
+        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) == "feat-x"
+
+    def test_get_pr_head_branch_returns_none_on_invalid_json(self, monkeypatch):
+        monkeypatch.setattr(
+            buff_mod.subprocess,
+            "run",
+            Mock(return_value=Mock(returncode=0, stdout="not-json")),
+        )
+
+        assert buff_mod._get_pr_head_branch(buff_mod.Path("/repo"), 85) is None
+
+    def test_cmd_buff_status_fires_buff_hook_on_clean_terminal_state(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+        fire_hook = Mock()
+        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "== Buff PR selection ==" in out
+        assert "Selected PR: #85 (explicit)" in out
+        assert "Overall PR state: CI clean - 1/1 checks completed successfully" in out
+        assert (
+            "Final PR state: clean - CI checks passed and PR feedback is resolved"
+            in out
+        )
+        assert "CI CLEAN" in out
+        fire_hook.assert_called_once_with(has_issues=False)
+
+    def test_cmd_buff_status_fires_buff_hook_on_failed_terminal_state(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "fail",
+                            "state": "FAILURE",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        fire_hook = Mock()
+        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "Primary Code Scanning Gate (blocking)" in out
+        assert "failed" in out.lower()
+        fire_hook.assert_called_once_with(has_issues=True)
+
+    def test_cmd_buff_status_reports_stale_selected_pr(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=[],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        monkeypatch.setattr(
+            buff_mod,
+            "resolve_pr_number_with_source",
+            Mock(side_effect=buff_mod.TriageError("Selected working PR #92 is stale")),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        assert "Selected working PR #92 is stale" in capsys.readouterr().out
+
+    def test_cmd_buff_status_blocks_on_unresolved_feedback(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(
+                return_value=make_feedback_result(
+                    CheckStatus.FAILED,
+                    output="PR #85 has unresolved review threads.",
+                )
+            ),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "CI checks are clean, but unresolved PR review threads remain." in out
+        assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_status_warns_on_pr_worktree_mismatch(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(buff_mod, "_get_current_branch", Mock(return_value="main"))
+        monkeypatch.setattr(
+            buff_mod, "_get_pr_head_branch", Mock(return_value="feature/pr-85")
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+        monkeypatch.setattr(buff_mod, "_fire_buff_hook", Mock())
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "PR/worktree mismatch detected" in out
+        assert "Current branch: main" in out
+        assert "PR #85 head branch: feature/pr-85" in out
+        assert "run buff from the PR worktree" in out
+
+    def test_cmd_buff_watch_waits_once_for_post_ci_feedback_settle(
+        self, monkeypatch, capsys
+    ):
+        """Bugbot settle requires one extra poll wait after all CI checks complete.
+
+        When Bugbot's completedAt is set (truly finished), the watch loop fires
+        one settle sleep then runs the feedback gate once as the final verdict.
+        """
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "neutral",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+                # completedAt set — Bugbot has truly finished
+                "completedAt": "2026-03-18T12:00:00Z",
+            },
+        ]
+        # Two fetches: settle wait, final check.
+        fetch_checks = Mock(side_effect=[(checks, ""), (checks, "")])
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "Waiting one extra interval for review feedback to settle" in out
+        assert "CI CLEAN" in out
+        # Two loop iterations, two fetch calls.
+        assert fetch_checks.call_count == 2
+        # Gate called once: final verdict only.
+        assert feedback_gate.call_count == 1
+        # One settle sleep.
+        assert sleep_mock.call_count == 1
+        sleep_mock.assert_called_with(7)
+
+    def test_cmd_buff_watch_treats_bugbot_with_no_completed_at_as_in_progress(
+        self, monkeypatch, capsys
+    ):
+        """Bugbot with no completedAt is still running — buff keeps polling.
+
+        Root cause of the bug: Bugbot shows bucket=skipping/neutral before it
+        has set completedAt, so it isn't actually done yet.  The fix is to
+        treat neutral/skipping checks without completedAt as in_progress.
+        """
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        # First two polls: Bugbot has no completedAt — still in_progress
+        in_flight_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "skipping",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+                # No completedAt — Bugbot hasn't finished yet
+            },
+        ]
+        # Third poll: Bugbot sets completedAt — now truly done
+        done_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "skipping",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+                "completedAt": "2026-03-18T12:00:00Z",
+            },
+        ]
+        fetch_checks = Mock(
+            side_effect=[
+                (in_flight_checks, ""),  # poll 1: Bugbot in_progress
+                (in_flight_checks, ""),  # poll 2: still in_progress
+                (done_checks, ""),  # poll 3: Bugbot done — settle fires
+                (done_checks, ""),  # poll 4: final gate check
+            ]
+        )
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "CI CLEAN" in out
+        # 4 fetches: 2 in_progress polls, settle, final
+        assert fetch_checks.call_count == 4
+        # Gate called once after settle
+        assert feedback_gate.call_count == 1
+        # 3 sleeps: 2 in_progress polls + 1 settle
+        assert sleep_mock.call_count == 3
+
+    def test_cmd_buff_status_no_checks_still_blocks_on_unresolved_feedback(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=([], "")))
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(
+                return_value=make_feedback_result(
+                    CheckStatus.FAILED,
+                    output="PR #85 has unresolved review threads.",
+                )
+            ),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "no CI checks found, but unresolved PR review threads remain" in out
+        assert "PR #85 has unresolved review threads." in out
+
+    def test_cmd_buff_status_no_checks_clean_fires_success_hook(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=([], "")))
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
+        )
+        fire_hook = Mock()
+        monkeypatch.setattr(buff_mod, "_fire_buff_hook", fire_hook)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "No CI checks found for this PR" in out
+        fire_hook.assert_called_once_with(has_issues=False)
+
+    def test_cmd_buff_status_blocks_when_feedback_not_verified(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="status",
+            action_args=["85"],
+            interval=30,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        monkeypatch.setattr(
+            buff_mod,
+            "_fetch_checks",
+            Mock(
+                return_value=(
+                    [
+                        {
+                            "name": "Primary Code Scanning Gate (blocking)",
+                            "bucket": "pass",
+                            "state": "SUCCESS",
+                            "link": "https://example.test/check",
+                        }
+                    ],
+                    "",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            buff_mod,
+            "_run_pr_feedback_gate",
+            Mock(return_value=make_feedback_result(CheckStatus.SKIPPED)),
+        )
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "Buff status error: could not verify unresolved PR feedback." in out
+        assert "CI CLEAN" not in out
+
+    def test_cmd_buff_watch_resets_settle_flag_after_failed_pending_poll(
+        self, monkeypatch, capsys
+    ):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        passing_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "https://example.test/check",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "neutral",
+                "state": "NEUTRAL",
+                "link": "https://cursor.com/docs/bugbot",
+                # completedAt set — Bugbot has truly finished
+                "completedAt": "2026-03-18T12:00:00Z",
+            },
+        ]
+        failed_pending_checks = [
+            {
+                "name": "Primary Code Scanning Gate (blocking)",
+                "bucket": "fail",
+                "state": "FAILURE",
+                "link": "https://example.test/fail",
+            },
+            {
+                "name": "Cursor Bugbot",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "https://cursor.com/docs/bugbot",
+            },
+        ]
+        # Sequence (single-phase settle with completedAt fix):
+        # 1. passing → settle fires (Bugbot has completedAt), sleep1, settled=True
+        # 2. failed+pending → reset settled=False, sleep2, continue
+        # 3. passing → settle fires again (settled=False), sleep3, settled=True
+        # 4. passing → final gate check → PASSED → success
+        fetch_checks = Mock(
+            side_effect=[
+                (passing_checks, ""),
+                (failed_pending_checks, ""),
+                (passing_checks, ""),
+                (passing_checks, ""),
+            ]
+        )
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert (
+            out.count("Waiting one extra interval for review feedback to settle") == 2
+        )
+        assert fetch_checks.call_count == 4
+        # Gate called once: final verdict only (no phase-2).
+        assert feedback_gate.call_count == 1
+        # 3 sleeps: settle, failed-reset, settle-again.
+        assert sleep_mock.call_count == 3
+
+    def test_cmd_buff_watch_fail_fast_exits_immediately(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=7,
+            fail_fast=True,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        checks = [
+            {
+                "name": "lint",
+                "bucket": "fail",
+                "state": "FAILURE",
+                "link": "https://example.test/fail",
+            },
+            {
+                "name": "build",
+                "bucket": "pending",
+                "state": "IN_PROGRESS",
+                "link": "",
+            },
+        ]
+        fetch_checks = Mock(return_value=(checks, ""))
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 1
+        out = capsys.readouterr().out
+        assert "fail-fast" in out
+        assert "SLOP IN CI" in out
+        # Should NOT have slept — fail-fast exits immediately
+        sleep_mock.assert_not_called()
+        assert fetch_checks.call_count == 1
+
+    def test_cmd_buff_watch_retries_empty_checks(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=5,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        passing_checks = [
+            {
+                "name": "lint",
+                "bucket": "pass",
+                "state": "SUCCESS",
+                "link": "",
+            },
+        ]
+        # First 2 polls return empty, third returns checks
+        fetch_checks = Mock(side_effect=[([], ""), ([], ""), (passing_checks, "")])
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "No CI checks registered yet" in out
+        assert fetch_checks.call_count == 3
+        assert sleep_mock.call_count == 2
+
+    def test_cmd_buff_watch_shows_poll_counter(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=5,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        pending = [
+            {"name": "build", "bucket": "pending", "state": "PENDING", "link": ""}
+        ]
+        passing = [{"name": "build", "bucket": "pass", "state": "SUCCESS", "link": ""}]
+        fetch_checks = Mock(side_effect=[(pending, ""), (passing, "")])
+        monkeypatch.setattr(buff_mod, "_fetch_checks", fetch_checks)
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+        sleep_mock = Mock()
+        monkeypatch.setattr(buff_mod.time, "sleep", sleep_mock)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "Poll #2" in out
+        assert "CI CLEAN" in out
+
+    def test_cmd_buff_watch_shows_total_watch_time(self, monkeypatch, capsys):
+        args = argparse.Namespace(
+            pr_or_action="watch",
+            action_args=["85"],
+            interval=5,
+            json_output=False,
+            repo=None,
+            run_id=None,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            output_file=None,
+            scenario=None,
+            message=None,
+            no_resolve=False,
+        )
+
+        monkeypatch.setattr(
+            buff_mod, "_project_root_from_cwd", Mock(return_value="/repo")
+        )
+        monkeypatch.setattr(buff_mod, "_get_repo_slug", Mock(return_value="o/r"))
+        patch_status_pr_resolution(monkeypatch, 85)
+        checks = [{"name": "lint", "bucket": "pass", "state": "SUCCESS", "link": ""}]
+        monkeypatch.setattr(buff_mod, "_fetch_checks", Mock(return_value=(checks, "")))
+        feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
+        monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
+
+        assert buff_mod.cmd_buff(args) == 0
+        out = capsys.readouterr().out
+        assert "Total watch time:" in out

--- a/tests/unit/test_buff_workflow_actions.py
+++ b/tests/unit/test_buff_workflow_actions.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from slopmop.cli import buff as buff_mod
+from slopmop.cli import buff_common as common_mod
 from slopmop.cli import scan_triage as triage
 from slopmop.core.result import CheckStatus
 from tests.conftest import make_feedback_result
@@ -405,7 +406,7 @@ class TestBuffVerifyAndResolve:
 class TestBuffProjectRootHelpers:
     def test_project_root_from_cwd_uses_git_toplevel(self, monkeypatch):
         monkeypatch.setattr(
-            buff_mod.subprocess,
+            common_mod.subprocess,
             "run",
             Mock(return_value=SimpleNamespace(returncode=0, stdout="/repo\n")),
         )
@@ -414,11 +415,11 @@ class TestBuffProjectRootHelpers:
 
     def test_project_root_from_cwd_falls_back_to_cwd(self, monkeypatch):
         monkeypatch.setattr(
-            buff_mod.subprocess,
+            common_mod.subprocess,
             "run",
             Mock(return_value=SimpleNamespace(returncode=1, stdout="")),
         )
-        monkeypatch.setattr(buff_mod.os, "getcwd", Mock(return_value="/cwd"))
+        monkeypatch.setattr(common_mod.os, "getcwd", Mock(return_value="/cwd"))
 
         assert buff_mod._project_root_from_cwd() == "/cwd"
 

--- a/tests/unit/test_ci_triage_and_buff.py
+++ b/tests/unit/test_ci_triage_and_buff.py
@@ -142,7 +142,16 @@ class TestScanTriageInternals:
 
     def test_latest_completed_run_id(self, monkeypatch):
         responses = [
-            json.dumps({"headRefName": "feat-x", "headRefOid": "abc1234def5678"}),
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
             json.dumps(
                 [
                     {
@@ -166,7 +175,16 @@ class TestScanTriageInternals:
 
     def test_workflow_run_state_tracks_current_head_runs(self, monkeypatch):
         responses = [
-            json.dumps({"headRefName": "feat-x", "headRefOid": "abc1234def5678"}),
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
             json.dumps(
                 [
                     {
@@ -199,7 +217,16 @@ class TestScanTriageInternals:
 
     def test_latest_completed_run_id_error(self, monkeypatch):
         responses = [
-            json.dumps({"headRefName": "feat-x", "headRefOid": "abc1234def5678"}),
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
             json.dumps([]),
         ]
 
@@ -209,7 +236,16 @@ class TestScanTriageInternals:
 
     def test_latest_completed_run_id_rejects_stale_branch_run(self, monkeypatch):
         responses = [
-            json.dumps({"headRefName": "feat-x", "headRefOid": "abc1234def5678"}),
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
             json.dumps(
                 [
                     {
@@ -233,11 +269,77 @@ class TestScanTriageInternals:
         monkeypatch.setattr(
             triage,
             "_run_gh",
-            Mock(return_value=json.dumps({"number": 85, "state": "CLOSED"})),
+            Mock(
+                return_value=json.dumps(
+                    {
+                        "number": 85,
+                        "state": "CLOSED",
+                        "closedAt": "2026-05-08T07:00:00Z",
+                        "mergedAt": None,
+                    }
+                )
+            ),
         )
 
-        with pytest.raises(triage.TriageError, match="is not open"):
+        with pytest.raises(triage.TriageError, match="has already been closed"):
             triage.validate_open_pr("o/r", 85)
+
+    def test_validate_open_pr_rejects_merged_pr(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "_run_gh",
+            Mock(
+                return_value=json.dumps(
+                    {
+                        "number": 86,
+                        "state": "MERGED",
+                        "closedAt": "2026-05-08T07:00:00Z",
+                        "mergedAt": "2026-05-08T07:00:00Z",
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(triage.TriageError, match="has already been merged"):
+            triage.validate_open_pr("o/r", 86)
+
+    def test_latest_open_pr_number_selects_most_recent_update(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "_run_gh",
+            Mock(
+                return_value=json.dumps(
+                    [
+                        {"number": 80, "updatedAt": "2026-05-08T06:00:00Z"},
+                        {"number": 82, "updatedAt": "2026-05-08T07:00:00Z"},
+                    ]
+                )
+            ),
+        )
+
+        assert triage.latest_open_pr_number("o/r") == 82
+
+    def test_open_pr_metadata_rejects_invalid_shape(self, monkeypatch):
+        monkeypatch.setattr(triage, "_run_gh", Mock(return_value="[]"))
+
+        with pytest.raises(triage.TriageError, match="does not exist"):
+            triage.validate_open_pr("o/r", 84)
+
+    def test_latest_open_pr_number_rejects_invalid_shape(self, monkeypatch):
+        monkeypatch.setattr(triage, "_run_gh", Mock(return_value="{}"))
+
+        with pytest.raises(triage.TriageError, match="Unexpected response shape"):
+            triage.latest_open_pr_number("o/r")
+
+    def test_latest_open_pr_number_rejects_no_valid_rows(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "_run_gh",
+            Mock(return_value=json.dumps([{}, {"number": "84"}])),
+        )
+
+        with pytest.raises(triage.TriageError, match="No open PRs found"):
+            triage.latest_open_pr_number("o/r")
 
     def test_resolve_pr_number_prefers_open_branch_pr(self, monkeypatch):
         monkeypatch.setattr(triage, "current_pr_number", Mock(return_value=84))
@@ -285,6 +387,215 @@ class TestScanTriageInternals:
             triage.TriageError, match="Selected working PR #92 is stale"
         ):
             triage.resolve_pr_number("o/r", None)
+
+    def test_resolve_pr_number_with_source_can_assume_latest_open_pr(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "current_pr_number",
+            Mock(side_effect=triage.TriageError("no open PR for branch")),
+        )
+        monkeypatch.setattr(triage, "_resolve_project_root", Mock(return_value="/repo"))
+        monkeypatch.setattr(triage, "get_current_pr_number", Mock(return_value=None))
+        monkeypatch.setattr(triage, "latest_open_pr_number", Mock(return_value=89))
+        monkeypatch.setattr(triage, "validate_open_pr", Mock(return_value=89))
+
+        number, source = triage.resolve_pr_number_with_source(
+            "o/r", None, assume_latest=True
+        )
+
+        assert number == 89
+        assert source == "latest_open"
+
+    def test_resolve_pr_number_with_source_explicit_validates(self, monkeypatch):
+        monkeypatch.setattr(triage, "validate_open_pr", Mock(return_value=88))
+
+        number, source = triage.resolve_pr_number_with_source("o/r", 88)
+
+        assert number == 88
+        assert source == "explicit"
+
+    def test_resolve_pr_number_reports_no_open_prs_to_assume(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "current_pr_number",
+            Mock(side_effect=triage.TriageError("no branch PR")),
+        )
+        monkeypatch.setattr(triage, "_resolve_project_root", Mock(return_value="/repo"))
+        monkeypatch.setattr(triage, "get_current_pr_number", Mock(return_value=None))
+        monkeypatch.setattr(
+            triage,
+            "latest_open_pr_number",
+            Mock(side_effect=triage.TriageError("no open PRs")),
+        )
+
+        with pytest.raises(triage.TriageError, match="no open PRs exist to assume"):
+            triage.resolve_pr_number_with_source("o/r", None, assume_latest=True)
+
+    def test_resolve_pr_number_does_not_silently_assume_latest_open_pr(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            triage,
+            "current_pr_number",
+            Mock(side_effect=triage.TriageError("no open PR for branch")),
+        )
+        monkeypatch.setattr(triage, "_resolve_project_root", Mock(return_value="/repo"))
+        monkeypatch.setattr(triage, "get_current_pr_number", Mock(return_value=None))
+        latest = Mock(return_value=89)
+        monkeypatch.setattr(triage, "latest_open_pr_number", latest)
+
+        with pytest.raises(triage.TriageError, match="no working PR is selected"):
+            triage.resolve_pr_number("o/r", None)
+        latest.assert_not_called()
+
+    def test_validate_run_for_pr_head_rejects_sha_mismatch(self, monkeypatch):
+        responses = [
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
+            json.dumps(
+                {
+                    "databaseId": 200,
+                    "headSha": "old1111deadbeef",
+                    "name": triage.WORKFLOW_NAME,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "createdAt": "2026-05-08T07:00:00Z",
+                }
+            ),
+        ]
+        monkeypatch.setattr(triage, "_run_gh", lambda _cmd: responses.pop(0))
+
+        with pytest.raises(triage.TriageError, match="does not match PR #84 head"):
+            triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+    def test_validate_run_for_pr_head_rejects_missing_head_sha(self, monkeypatch):
+        monkeypatch.setattr(
+            triage,
+            "_run_gh",
+            Mock(
+                return_value=json.dumps(
+                    {
+                        "number": 84,
+                        "state": "OPEN",
+                        "headRefName": "feat-x",
+                        "headRefOid": "",
+                        "closedAt": None,
+                        "mergedAt": None,
+                    }
+                )
+            ),
+        )
+
+        with pytest.raises(triage.TriageError, match="head commit"):
+            triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+    def test_validate_run_for_pr_head_rejects_invalid_run_shape(self, monkeypatch):
+        responses = [
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
+            "[]",
+        ]
+        monkeypatch.setattr(triage, "_run_gh", lambda _cmd: responses.pop(0))
+
+        with pytest.raises(triage.TriageError, match="workflow run 200"):
+            triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+    def test_validate_run_for_pr_head_rejects_wrong_workflow(self, monkeypatch):
+        responses = [
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
+            json.dumps(
+                {
+                    "databaseId": 200,
+                    "headSha": "abc1234def5678",
+                    "name": "other workflow",
+                    "status": "completed",
+                }
+            ),
+        ]
+        monkeypatch.setattr(triage, "_run_gh", lambda _cmd: responses.pop(0))
+
+        with pytest.raises(triage.TriageError, match="not 'slop-mop"):
+            triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+    def test_validate_run_for_pr_head_rejects_pending_run(self, monkeypatch):
+        responses = [
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
+            json.dumps(
+                {
+                    "databaseId": 200,
+                    "headSha": "abc1234def5678",
+                    "name": triage.WORKFLOW_NAME,
+                    "status": "in_progress",
+                }
+            ),
+        ]
+        monkeypatch.setattr(triage, "_run_gh", lambda _cmd: responses.pop(0))
+
+        with pytest.raises(triage.TriageError, match="still in_progress"):
+            triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+    def test_validate_run_for_pr_head_uses_explicit_id_when_database_id_missing(
+        self, monkeypatch
+    ):
+        responses = [
+            json.dumps(
+                {
+                    "number": 84,
+                    "state": "OPEN",
+                    "headRefName": "feat-x",
+                    "headRefOid": "abc1234def5678",
+                    "closedAt": None,
+                    "mergedAt": None,
+                }
+            ),
+            json.dumps(
+                {
+                    "headSha": "abc1234def5678",
+                    "name": triage.WORKFLOW_NAME,
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            ),
+        ]
+        monkeypatch.setattr(triage, "_run_gh", lambda _cmd: responses.pop(0))
+
+        state = triage.validate_run_for_pr_head("o/r", 200, 84, triage.WORKFLOW_NAME)
+
+        assert state["latest_run_id"] == 200
 
     def test_load_json_and_coverage_value(self, tmp_path):
         path = tmp_path / "ok.json"
@@ -460,6 +771,51 @@ class TestScanTriageInternals:
         )
         assert code == 0
         assert payload is not None
+
+    def test_run_triage_explicit_run_reuses_run_validation_pr_check(self, monkeypatch):
+        monkeypatch.setattr(triage, "default_repo", Mock(return_value="o/r"))
+        open_pr_validator = Mock(side_effect=AssertionError("redundant PR check"))
+        monkeypatch.setattr(triage, "validate_open_pr", open_pr_validator)
+        run_validator = Mock(
+            return_value={
+                "head_sha": "abc1234def5678",
+                "latest_run_id": 201,
+                "pending_newer_run": False,
+            }
+        )
+        monkeypatch.setattr(triage, "validate_run_for_pr_head", run_validator)
+        monkeypatch.setattr(
+            triage, "download_results_json", Mock(return_value=Path("x.json"))
+        )
+        monkeypatch.setattr(
+            triage, "_load_json", Mock(return_value={"summary": {}, "results": []})
+        )
+
+        def fake_build(doc, run_id, json_path, show_low_coverage, pr_number, ci_state):
+            assert run_id == 201
+            assert pr_number == 84
+            assert ci_state is not None
+            assert ci_state["head_sha"] == "abc1234def5678"
+            return ({"summary": {}, "actionable": [], "next_steps": []}, 0)
+
+        monkeypatch.setattr(triage, "build_triage_payload", fake_build)
+        monkeypatch.setattr(triage, "write_json_out", Mock())
+
+        code, payload = triage.run_triage(
+            repo=None,
+            run_id=201,
+            pr_number=84,
+            workflow=triage.WORKFLOW_NAME,
+            artifact=triage.ARTIFACT_NAME,
+            show_low_coverage=False,
+            json_out=None,
+            print_output=False,
+        )
+
+        assert code == 0
+        assert payload is not None
+        open_pr_validator.assert_not_called()
+        run_validator.assert_called_once_with("o/r", 201, 84, triage.WORKFLOW_NAME)
 
     def test_run_triage_rejects_pending_current_head_run(self, monkeypatch):
         monkeypatch.setattr(triage, "default_repo", Mock(return_value="o/r"))

--- a/tests/unit/test_scour_fail_fast.py
+++ b/tests/unit/test_scour_fail_fast.py
@@ -1,0 +1,180 @@
+"""Tests for swab/scour fail-fast behavior."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+
+class TestScourDisablesFailFast:
+    """Scour must never use fail-fast so every gate runs to completion."""
+
+    def _make_args(self, tmp_path, no_fail_fast=False):
+        return argparse.Namespace(
+            project_root=str(tmp_path),
+            quiet=True,
+            verbose=False,
+            no_fail_fast=no_fail_fast,
+            no_auto_fix=True,
+            static=True,
+            clear_history=False,
+            swabbing_timeout=None,
+            json_output=False,
+        )
+
+    @patch("slopmop.cli.validate.ConsoleAdapter")
+    @patch("slopmop.cli.validate.ConsoleReporter")
+    @patch("slopmop.cli.validate.CheckExecutor")
+    @patch("slopmop.cli.validate.get_registry")
+    @patch("slopmop.cli.validate.read_phase")
+    @patch("slopmop.sm.load_config", return_value={})
+    def test_scour_forces_fail_fast_off(
+        self,
+        _mock_config,
+        mock_read_phase,
+        mock_reg,
+        mock_executor_cls,
+        _mock_reporter,
+        _mock_adapter,
+        tmp_path,
+    ):
+        """Scour always creates executor with fail_fast=False."""
+        from slopmop.cli.validate import _run_validation
+        from slopmop.workflow.state_machine import RepoPhase
+
+        mock_executor = MagicMock()
+        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
+        mock_executor_cls.return_value = mock_executor
+        mock_read_phase.return_value = RepoPhase.REMEDIATION
+
+        _run_validation(self._make_args(tmp_path), ["gate1"], "scour")
+
+        mock_executor_cls.assert_called_once()
+        _, kwargs = mock_executor_cls.call_args
+        assert kwargs["fail_fast"] is False
+        assert kwargs["process_results_in_remediation_order"] is True
+
+    @patch("slopmop.cli.validate.ConsoleAdapter")
+    @patch("slopmop.cli.validate.ConsoleReporter")
+    @patch("slopmop.cli.validate.CheckExecutor")
+    @patch("slopmop.cli.validate.get_registry")
+    @patch("slopmop.cli.validate.read_phase")
+    @patch("slopmop.sm.load_config", return_value={})
+    def test_scour_ignores_no_fail_fast_flag(
+        self,
+        _mock_config,
+        mock_read_phase,
+        mock_reg,
+        mock_executor_cls,
+        _mock_reporter,
+        _mock_adapter,
+        tmp_path,
+    ):
+        """Even with --no-fail-fast omitted, scour still disables fail-fast."""
+        from slopmop.cli.validate import _run_validation
+        from slopmop.workflow.state_machine import RepoPhase
+
+        mock_executor = MagicMock()
+        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
+        mock_executor_cls.return_value = mock_executor
+        mock_read_phase.return_value = RepoPhase.REMEDIATION
+
+        # no_fail_fast=False means the user did NOT pass --no-fail-fast,
+        # which normally means fail_fast=True. Scour overrides this.
+        _run_validation(
+            self._make_args(tmp_path, no_fail_fast=False), ["gate1"], "scour"
+        )
+
+        _, kwargs = mock_executor_cls.call_args
+        assert kwargs["fail_fast"] is False
+
+    @patch("slopmop.cli.validate.ConsoleAdapter")
+    @patch("slopmop.cli.validate.ConsoleReporter")
+    @patch("slopmop.cli.validate.CheckExecutor")
+    @patch("slopmop.cli.validate.get_registry")
+    @patch("slopmop.cli.validate.read_phase")
+    @patch("slopmop.sm.load_config", return_value={})
+    def test_swab_defaults_to_fail_fast(
+        self,
+        _mock_config,
+        mock_read_phase,
+        mock_reg,
+        mock_executor_cls,
+        _mock_reporter,
+        _mock_adapter,
+        tmp_path,
+    ):
+        """Swab defaults to fail_fast=True."""
+        from slopmop.cli.validate import _run_validation
+        from slopmop.workflow.state_machine import RepoPhase
+
+        mock_executor = MagicMock()
+        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
+        mock_executor_cls.return_value = mock_executor
+        mock_read_phase.return_value = RepoPhase.REMEDIATION
+
+        _run_validation(self._make_args(tmp_path), ["gate1"], "swab")
+
+        _, kwargs = mock_executor_cls.call_args
+        assert kwargs["fail_fast"] is True
+        assert kwargs["process_results_in_remediation_order"] is True
+
+    @patch("slopmop.cli.validate.ConsoleAdapter")
+    @patch("slopmop.cli.validate.ConsoleReporter")
+    @patch("slopmop.cli.validate.CheckExecutor")
+    @patch("slopmop.cli.validate.get_registry")
+    @patch("slopmop.cli.validate.read_phase")
+    @patch("slopmop.sm.load_config", return_value={})
+    def test_swab_respects_no_fail_fast_flag(
+        self,
+        _mock_config,
+        mock_read_phase,
+        mock_reg,
+        mock_executor_cls,
+        _mock_reporter,
+        _mock_adapter,
+        tmp_path,
+    ):
+        """Swab with --no-fail-fast creates executor with fail_fast=False."""
+        from slopmop.cli.validate import _run_validation
+        from slopmop.workflow.state_machine import RepoPhase
+
+        mock_executor = MagicMock()
+        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
+        mock_executor_cls.return_value = mock_executor
+        mock_read_phase.return_value = RepoPhase.REMEDIATION
+
+        _run_validation(self._make_args(tmp_path, no_fail_fast=True), ["gate1"], "swab")
+
+        _, kwargs = mock_executor_cls.call_args
+        assert kwargs["fail_fast"] is False
+
+    @patch("slopmop.cli.validate.ConsoleAdapter")
+    @patch("slopmop.cli.validate.ConsoleReporter")
+    @patch("slopmop.cli.validate.CheckExecutor")
+    @patch("slopmop.cli.validate.get_registry")
+    @patch("slopmop.cli.validate.read_phase")
+    @patch("slopmop.sm.load_config", return_value={})
+    def test_maintenance_phase_disables_remediation_order_processing(
+        self,
+        _mock_config,
+        mock_read_phase,
+        mock_reg,
+        mock_executor_cls,
+        _mock_reporter,
+        _mock_adapter,
+        tmp_path,
+    ):
+        """Maintenance mode keeps default completion-order processing."""
+        from slopmop.cli.validate import _run_validation
+        from slopmop.workflow.state_machine import RepoPhase
+
+        mock_executor = MagicMock()
+        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
+        mock_executor_cls.return_value = mock_executor
+        mock_read_phase.return_value = RepoPhase.MAINTENANCE
+
+        _run_validation(self._make_args(tmp_path), ["gate1"], "swab")
+
+        _, kwargs = mock_executor_cls.call_args
+        assert kwargs["process_results_in_remediation_order"] is False

--- a/tests/unit/test_sm_cli.py
+++ b/tests/unit/test_sm_cli.py
@@ -509,7 +509,7 @@ class TestBuffStatus:
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
                 with patch(
-                    "slopmop.cli.buff.resolve_pr_number",
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
                     side_effect=TriageError("No open PR found for the current branch."),
                 ):
                     result = cmd_buff(args)
@@ -526,7 +526,10 @@ class TestBuffStatus:
 
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
-                with patch("slopmop.cli.buff.resolve_pr_number", return_value=42):
+                with patch(
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
+                    return_value=(42, "explicit"),
+                ):
                     with patch(
                         "slopmop.cli.buff._fetch_checks", return_value=(checks, "")
                     ):
@@ -561,7 +564,10 @@ class TestBuffStatus:
 
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
-                with patch("slopmop.cli.buff.resolve_pr_number", return_value=1):
+                with patch(
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
+                    return_value=(1, "explicit"),
+                ):
                     with patch(
                         "slopmop.cli.buff._fetch_checks", return_value=(checks, "")
                     ):
@@ -582,7 +588,10 @@ class TestBuffStatus:
 
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
-                with patch("slopmop.cli.buff.resolve_pr_number", return_value=1):
+                with patch(
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
+                    return_value=(1, "explicit"),
+                ):
                     with patch(
                         "slopmop.cli.buff._fetch_checks", return_value=(checks, "")
                     ):
@@ -599,7 +608,10 @@ class TestBuffStatus:
 
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
-                with patch("slopmop.cli.buff.resolve_pr_number", return_value=1):
+                with patch(
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
+                    return_value=(1, "explicit"),
+                ):
                     with patch("slopmop.cli.buff._fetch_checks", return_value=([], "")):
                         with patch(
                             "slopmop.cli.buff._run_pr_feedback_gate",
@@ -621,7 +633,10 @@ class TestBuffStatus:
 
         with patch("slopmop.cli.buff._project_root_from_cwd", return_value="/repo"):
             with patch("slopmop.cli.buff._get_repo_slug", return_value="o/r"):
-                with patch("slopmop.cli.buff.resolve_pr_number", return_value=1):
+                with patch(
+                    "slopmop.cli.buff.resolve_pr_number_with_source",
+                    return_value=(1, "explicit"),
+                ):
                     with patch(
                         "slopmop.cli.buff._fetch_checks",
                         return_value=(
@@ -634,180 +649,6 @@ class TestBuffStatus:
         captured = capsys.readouterr()
         assert result == 2
         assert "gh" in captured.out.lower()
-
-
-class TestScourDisablesFailFast:
-    """Scour must never use fail-fast so every gate runs to completion."""
-
-    def _make_args(self, tmp_path, no_fail_fast=False):
-        return argparse.Namespace(
-            project_root=str(tmp_path),
-            quiet=True,
-            verbose=False,
-            no_fail_fast=no_fail_fast,
-            no_auto_fix=True,
-            static=True,
-            clear_history=False,
-            swabbing_timeout=None,
-            json_output=False,
-        )
-
-    @patch("slopmop.cli.validate.ConsoleAdapter")
-    @patch("slopmop.cli.validate.ConsoleReporter")
-    @patch("slopmop.cli.validate.CheckExecutor")
-    @patch("slopmop.cli.validate.get_registry")
-    @patch("slopmop.cli.validate.read_phase")
-    @patch("slopmop.sm.load_config", return_value={})
-    def test_scour_forces_fail_fast_off(
-        self,
-        _mock_config,
-        mock_read_phase,
-        mock_reg,
-        mock_executor_cls,
-        _mock_reporter,
-        _mock_adapter,
-        tmp_path,
-    ):
-        """Scour always creates executor with fail_fast=False."""
-        from slopmop.cli.validate import _run_validation
-        from slopmop.workflow.state_machine import RepoPhase
-
-        mock_executor = MagicMock()
-        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
-        mock_executor_cls.return_value = mock_executor
-        mock_read_phase.return_value = RepoPhase.REMEDIATION
-
-        _run_validation(self._make_args(tmp_path), ["gate1"], "scour")
-
-        mock_executor_cls.assert_called_once()
-        _, kwargs = mock_executor_cls.call_args
-        assert kwargs["fail_fast"] is False
-        assert kwargs["process_results_in_remediation_order"] is True
-
-    @patch("slopmop.cli.validate.ConsoleAdapter")
-    @patch("slopmop.cli.validate.ConsoleReporter")
-    @patch("slopmop.cli.validate.CheckExecutor")
-    @patch("slopmop.cli.validate.get_registry")
-    @patch("slopmop.cli.validate.read_phase")
-    @patch("slopmop.sm.load_config", return_value={})
-    def test_scour_ignores_no_fail_fast_flag(
-        self,
-        _mock_config,
-        mock_read_phase,
-        mock_reg,
-        mock_executor_cls,
-        _mock_reporter,
-        _mock_adapter,
-        tmp_path,
-    ):
-        """Even with --no-fail-fast omitted, scour still disables fail-fast."""
-        from slopmop.cli.validate import _run_validation
-        from slopmop.workflow.state_machine import RepoPhase
-
-        mock_executor = MagicMock()
-        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
-        mock_executor_cls.return_value = mock_executor
-        mock_read_phase.return_value = RepoPhase.REMEDIATION
-
-        # no_fail_fast=False means the user did NOT pass --no-fail-fast,
-        # which normally means fail_fast=True. Scour overrides this.
-        _run_validation(
-            self._make_args(tmp_path, no_fail_fast=False), ["gate1"], "scour"
-        )
-
-        _, kwargs = mock_executor_cls.call_args
-        assert kwargs["fail_fast"] is False
-
-    @patch("slopmop.cli.validate.ConsoleAdapter")
-    @patch("slopmop.cli.validate.ConsoleReporter")
-    @patch("slopmop.cli.validate.CheckExecutor")
-    @patch("slopmop.cli.validate.get_registry")
-    @patch("slopmop.cli.validate.read_phase")
-    @patch("slopmop.sm.load_config", return_value={})
-    def test_swab_defaults_to_fail_fast(
-        self,
-        _mock_config,
-        mock_read_phase,
-        mock_reg,
-        mock_executor_cls,
-        _mock_reporter,
-        _mock_adapter,
-        tmp_path,
-    ):
-        """Swab defaults to fail_fast=True."""
-        from slopmop.cli.validate import _run_validation
-        from slopmop.workflow.state_machine import RepoPhase
-
-        mock_executor = MagicMock()
-        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
-        mock_executor_cls.return_value = mock_executor
-        mock_read_phase.return_value = RepoPhase.REMEDIATION
-
-        _run_validation(self._make_args(tmp_path), ["gate1"], "swab")
-
-        _, kwargs = mock_executor_cls.call_args
-        assert kwargs["fail_fast"] is True
-        assert kwargs["process_results_in_remediation_order"] is True
-
-    @patch("slopmop.cli.validate.ConsoleAdapter")
-    @patch("slopmop.cli.validate.ConsoleReporter")
-    @patch("slopmop.cli.validate.CheckExecutor")
-    @patch("slopmop.cli.validate.get_registry")
-    @patch("slopmop.cli.validate.read_phase")
-    @patch("slopmop.sm.load_config", return_value={})
-    def test_swab_respects_no_fail_fast_flag(
-        self,
-        _mock_config,
-        mock_read_phase,
-        mock_reg,
-        mock_executor_cls,
-        _mock_reporter,
-        _mock_adapter,
-        tmp_path,
-    ):
-        """Swab with --no-fail-fast creates executor with fail_fast=False."""
-        from slopmop.cli.validate import _run_validation
-        from slopmop.workflow.state_machine import RepoPhase
-
-        mock_executor = MagicMock()
-        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
-        mock_executor_cls.return_value = mock_executor
-        mock_read_phase.return_value = RepoPhase.REMEDIATION
-
-        _run_validation(self._make_args(tmp_path, no_fail_fast=True), ["gate1"], "swab")
-
-        _, kwargs = mock_executor_cls.call_args
-        assert kwargs["fail_fast"] is False
-
-    @patch("slopmop.cli.validate.ConsoleAdapter")
-    @patch("slopmop.cli.validate.ConsoleReporter")
-    @patch("slopmop.cli.validate.CheckExecutor")
-    @patch("slopmop.cli.validate.get_registry")
-    @patch("slopmop.cli.validate.read_phase")
-    @patch("slopmop.sm.load_config", return_value={})
-    def test_maintenance_phase_disables_remediation_order_processing(
-        self,
-        _mock_config,
-        mock_read_phase,
-        mock_reg,
-        mock_executor_cls,
-        _mock_reporter,
-        _mock_adapter,
-        tmp_path,
-    ):
-        """Maintenance mode keeps default completion-order processing."""
-        from slopmop.cli.validate import _run_validation
-        from slopmop.workflow.state_machine import RepoPhase
-
-        mock_executor = MagicMock()
-        mock_executor.run_checks.return_value = MagicMock(all_passed=True)
-        mock_executor_cls.return_value = mock_executor
-        mock_read_phase.return_value = RepoPhase.MAINTENANCE
-
-        _run_validation(self._make_args(tmp_path), ["gate1"], "swab")
-
-        _, kwargs = mock_executor_cls.call_args
-        assert kwargs["process_results_in_remediation_order"] is False
 
 
 class TestSetupDynamicDisplay:

--- a/tests/unit/test_workflow_hooks.py
+++ b/tests/unit/test_workflow_hooks.py
@@ -317,7 +317,10 @@ class TestFireBuffHook:
         from slopmop.cli.buff import _fire_buff_hook
 
         with (
-            patch("slopmop.cli.buff._project_root_from_cwd", return_value=tmp_path),
+            patch(
+                "slopmop.cli.buff_common.project_root_from_cwd",
+                return_value=tmp_path,
+            ),
             patch("slopmop.workflow.hooks.on_buff_complete") as mock_hook,
         ):
             _fire_buff_hook(has_issues=True)
@@ -328,7 +331,10 @@ class TestFireBuffHook:
         from slopmop.cli.buff import _fire_buff_hook
 
         with (
-            patch("slopmop.cli.buff._project_root_from_cwd", return_value=tmp_path),
+            patch(
+                "slopmop.cli.buff_common.project_root_from_cwd",
+                return_value=tmp_path,
+            ),
             patch("slopmop.workflow.hooks.on_buff_complete") as mock_hook,
         ):
             _fire_buff_hook(has_issues=False)
@@ -339,7 +345,10 @@ class TestFireBuffHook:
         from slopmop.cli.buff import _fire_buff_hook
 
         with (
-            patch("slopmop.cli.buff._project_root_from_cwd", return_value=tmp_path),
+            patch(
+                "slopmop.cli.buff_common.project_root_from_cwd",
+                return_value=tmp_path,
+            ),
             patch(
                 "slopmop.workflow.hooks.on_buff_complete",
                 side_effect=RuntimeError("boom"),


### PR DESCRIPTION
## Summary

- Let `sm buff <PR>` continue into PR feedback verification when the CI scan workflow or `slopmop-results` artifact is absent.
- Keep unrelated triage failures blocking.
- Add focused coverage for missing-artifact and missing-workflow fallback paths.

Fixes #189.

## Validation

- `pytest tests/unit/test_buff_scan_fallback.py tests/unit/test_buff_inspect_and_status.py tests/unit/test_ci_triage_and_buff.py -q`
- `./sm swab -g myopia:code-sprawl`
- `./sm swab -g overconfidence:type-blindness.py`
- `./sm swab`
