### PR TITLE
fix: restore persist-credentials: false so RELEASE_PR_TOKEN governs git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ github.token }}
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

- Restores `persist-credentials: false` on the `release-context` checkout, accidentally dropped in 0258610
- Without it, `actions/checkout` installs a credential helper that returns `GITHUB_TOKEN` for all git operations, overriding the `RELEASE_PR_TOKEN` embedded in the remote URL — causing the `403 denied to github-actions[bot]` on the release branch push

## Test plan
- [ ] Re-run the Release workflow (minor bump) — the "Create release PR and merge after green checks" step should push the release branch successfully