### PR TITLE
chore: keep .cursor-plugin/plugin.json version in sync with pyproject.toml

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "displayName": "slop-mop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Wraps pytest, black, mypy, gh, and every other tool behind a single `sm` CLI with caching, ordering, and directed remediation built in.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,17 @@ jobs:
                   raise SystemExit("Could not update version in pyproject.toml")
               pyproject.write_text(updated)
 
+              plugin_json = Path(".cursor-plugin/plugin.json")
+              if plugin_json.exists():
+                  plugin_text = plugin_json.read_text()
+                  plugin_updated = re.sub(
+                      r'"version"\s*:\s*"[^"]+"',
+                      f'"version": "{version}"',
+                      plugin_text,
+                      count=1,
+                  )
+                  plugin_json.write_text(plugin_updated)
+
           if version == previous:
               raise SystemExit("Release workflow requires a version bump")
           should_release = "true"


### PR DESCRIPTION
## Summary

- Bumps `.cursor-plugin/plugin.json` to `1.2.0` to match the current release
- Adds a `re.sub` to the release workflow's version-bump step so future releases update `plugin.json` automatically — same script, same commit, no manual step

## Why
The plugin version was hardcoded and diverged from `pyproject.toml` immediately after the v1.2.0 release. The release workflow is the single source of truth for the version bump, so this hooks into it directly.