### PR TITLE
fix: remove redundant assert_called_with that breaks under Python 3.13 thread noise

### DIFF
--- a/tests/unit/test_buff_status.py
+++ b/tests/unit/test_buff_status.py
@@ -370,7 +370,6 @@ class TestBuffStatusCommand:
         assert feedback_gate.call_count == 1
         # One settle sleep.
         assert sum(1 for c in sleep_mock.call_args_list if c.args == (7,)) == 1
-        sleep_mock.assert_called_with(7)
 
     def test_cmd_buff_watch_treats_bugbot_with_no_completed_at_as_in_progress(
         self, monkeypatch, capsys


### PR DESCRIPTION
## Summary

- `sleep_mock.assert_called_with(7)` was left behind by #202's `2f4baae` fix
- `assert_called_with` checks the **last** call; background threads in Python 3.13 CI call `time.sleep` after the settle wait, causing spurious failures
- The `sum()`/filter assertion on the preceding line already verifies exactly one `sleep(7)` occurred — the `assert_called_with` is redundant and fragile

## Test plan

- [ ] `test_cmd_buff_watch_waits_once_for_post_ci_feedback_settle` passes locally
- [ ] Release CI unblocked after cherry-pick to `release/v1.3.0`