### PR TITLE
fix: treat pip-audit timeout as warned skip instead of hard failure

### DIFF
--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -1276,6 +1276,12 @@ class SecurityCheck(SecurityLocalCheck):
                 True,
                 "pip-audit timed out fetching vulnerability data — skipped",
                 warned=True,
+                sarif_findings=[
+                    Finding(
+                        message="pip-audit timed out; vulnerability scan skipped",
+                        level=FindingLevel.WARNING,
+                    )
+                ],
             )
 
         try:

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -1173,6 +1173,28 @@ class SecurityCheck(SecurityLocalCheck):
             )
         return SecuritySubResult("pip-audit", False, detail, sarif)
 
+    def _pip_audit_no_fix_result(
+        self, no_fix_versions: List[Dict[str, Any]]
+    ) -> "SecuritySubResult":
+        """Build a WARNED pip-audit result when vulns have no fix versions."""
+        detail = self._format_pip_audit_detail(no_fix_versions)
+        sarif_warn: list[Finding] = [
+            Finding(
+                message=(
+                    f"{len(no_fix_versions)} vulnerable dependency/dependencies "
+                    "with no published fix versions"
+                ),
+                level=FindingLevel.WARNING,
+            )
+        ]
+        return SecuritySubResult(
+            "pip-audit",
+            True,
+            f"No fix versions available for the vulnerable dependencies below:\n{detail}",
+            warned=True,
+            sarif_findings=sarif_warn,
+        )
+
     @staticmethod
     def _project_has_python_manifest(project_root: str) -> bool:
         """Return True when the project has any Python dependency manifest."""
@@ -1246,7 +1268,15 @@ class SecurityCheck(SecurityLocalCheck):
             for req_file in req_files:
                 cmd.extend(["-r", req_file])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=30)
+        result = self._run_command(cmd, cwd=project_root, timeout=120)
+
+        if result.timed_out:
+            return SecuritySubResult(
+                "pip-audit",
+                True,
+                "pip-audit timed out fetching vulnerability data — skipped",
+                warned=True,
+            )
 
         try:
             report = json.loads(result.stdout)
@@ -1274,25 +1304,7 @@ class SecurityCheck(SecurityLocalCheck):
             if remediable:
                 return self._pip_audit_remediable_result(remediable, no_fix_versions)
 
-            detail = self._format_pip_audit_detail(no_fix_versions)
-            sarif_warn: list[Finding] = [
-                Finding(
-                    message=(
-                        f"{len(no_fix_versions)} vulnerable dependency/dependencies "
-                        "with no published fix versions"
-                    ),
-                    level=FindingLevel.WARNING,
-                )
-            ]
-            return SecuritySubResult(
-                "pip-audit",
-                True,
-                "No fix versions available for the vulnerable dependencies "
-                "below:\n"
-                f"{detail}",
-                warned=True,
-                sarif_findings=sarif_warn,
-            )
+            return self._pip_audit_no_fix_result(no_fix_versions)
         except json.JSONDecodeError:
             if result.success:
                 return SecuritySubResult("pip-audit", True, "No vulnerabilities found")

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -623,6 +623,11 @@ class TestRunPipAudit:
         mock_result.timed_out = False
         mock_result.stdout = "not valid json"
 
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_pip_audit(str(tmp_path))
+
+        assert result.passed is True
+
     def test_pip_audit_timed_out_warns_and_passes(self, tmp_path):
         """Timeout fetching vulnerability data should warn but not fail the gate."""
         (tmp_path / "requirements.txt").write_text("requests>=2.31.0\n")
@@ -636,11 +641,6 @@ class TestRunPipAudit:
         assert result.passed is True
         assert result.warned is True
         assert "timed out" in result.findings
-
-        with patch.object(check, "_run_command", return_value=mock_result):
-            result = check._run_pip_audit(str(tmp_path))
-
-        assert result.passed is True
 
     def test_pip_audit_uses_project_python(self, tmp_path):
         """pip-audit must use project Python, not sys.executable.

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -303,6 +303,7 @@ class TestRunSemgrep:
         check = SecurityLocalCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
 
         with patch.object(check, "_run_command", return_value=mock_result):
             result = check._run_semgrep(str(tmp_path))
@@ -316,6 +317,7 @@ class TestRunSemgrep:
         check = SecurityLocalCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps(
             {
                 "results": [
@@ -342,6 +344,7 @@ class TestRunSemgrep:
         check = SecurityLocalCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps(
             {
                 "results": [
@@ -368,6 +371,7 @@ class TestRunSemgrep:
         check = SecurityLocalCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps({"results": []})
 
         with patch.object(check, "_run_command", return_value=mock_result):
@@ -380,6 +384,7 @@ class TestRunSemgrep:
         check = SecurityLocalCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = "not valid json"
         mock_result.returncode = 1
         mock_result.stderr = "Some error"
@@ -505,6 +510,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps(
             {"dependencies": [{"name": "requests", "version": "2.31.0", "vulns": []}]}
         )
@@ -522,6 +528,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps(
             {
                 "dependencies": [
@@ -552,6 +559,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps(
             {
                 "dependencies": [
@@ -583,6 +591,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps({"dependencies": []})
 
         with patch.object(check, "_run_command", return_value=mock_result):
@@ -596,6 +605,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = False
+        mock_result.timed_out = False
         mock_result.stdout = "Error running pip-audit"
         mock_result.output = "Error running pip-audit"
 
@@ -610,7 +620,22 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = "not valid json"
+
+    def test_pip_audit_timed_out_warns_and_passes(self, tmp_path):
+        """Timeout fetching vulnerability data should warn but not fail the gate."""
+        (tmp_path / "requirements.txt").write_text("requests>=2.31.0\n")
+        check = SecurityCheck({})
+        mock_result = MagicMock()
+        mock_result.timed_out = True
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_pip_audit(str(tmp_path))
+
+        assert result.passed is True
+        assert result.warned is True
+        assert "timed out" in result.findings
 
         with patch.object(check, "_run_command", return_value=mock_result):
             result = check._run_pip_audit(str(tmp_path))
@@ -637,6 +662,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps({"dependencies": []})
 
         with patch.object(check, "_run_command", return_value=mock_result) as mock_cmd:
@@ -683,6 +709,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps({"dependencies": []})
 
         with patch.object(check, "_run_command", return_value=mock_result) as mock_cmd:
@@ -702,6 +729,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = json.dumps({"dependencies": []})
 
         with patch.object(check, "_run_command", return_value=mock_result) as mock_cmd:
@@ -752,6 +780,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = '{"dependencies": []}'
         with patch.object(check, "_run_command", return_value=mock_result) as mock_cmd:
             check._run_pip_audit(str(project))
@@ -777,6 +806,7 @@ class TestRunPipAudit:
         check = SecurityCheck({})
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.timed_out = False
         mock_result.stdout = '{"dependencies": []}'
         with patch.object(check, "_run_command", return_value=mock_result) as mock_cmd:
             check._run_pip_audit(str(project))


### PR DESCRIPTION
## Summary

- pip-audit fetches vuln data from PyPI over the network — in CI it reliably times out at the old 30s limit
- A **timeout is not a security finding**; previously it produced a hard gate failure and blocked the release
- Increase timeout to 120s and treat timeout as a non-blocking warning (skip the scan, log a message)
- Extract `_pip_audit_no_fix_result` helper to keep `_run_pip_audit` ≤ 100 lines
- Add `timed_out=False` to existing test mocks (MagicMock returns truthy for unknown attrs)
- Add `test_pip_audit_timed_out_warns_and_passes` to document the new behavior

## Root cause

The v1.3.0 and v1.3.1 release Quality Gate steps were failing because the release CI
environment (cold pip-audit cache, no VIRTUAL_ENV, scanning via `-r requirements.txt`)
consistently hit the 30s subprocess timeout — which was then misclassified as "pip-audit found issues".

## Test plan

- [ ] `TestRunPipAudit` — all 19 tests pass
- [ ] `sm swab --no-cache` — all 15 gates pass