### PR TITLE
fix: starlette vuln pin + dead-code.js knip 6 compat + ignore config fields

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -25,35 +25,20 @@
     "updated": "2026-05-25"
   },
   "agent": {
-    "status": "PR #221: coverage test added for not-on-a-PR path, awaiting CI",
-    "direction": "Fix + test the case-sensitive gate check; unblock codecov/patch",
-    "difficulties": "None",
-    "needs_human": "None",
-    "last_update": "2026-05-25T09:28:00Z",
+    "status": "PR #223 open: starlette vuln pin + dead-code.js knip 6 compat",
+    "direction": "Two fixes: PYSEC-2026-161 starlette pin and dead-code.js knip 6 JSON format compat + ignore_patterns/ignore_dependencies config fields to stop agent doom-loops on tooling file false positives",
+    "last_update": "2026-05-25T00:00:00Z",
     "actions": [
-      { "name": "Fixed case-sensitive PR context check (config.py:380)", "status": "done" },
-      { "name": "Resolved Bugbot thread PRRT_kwDORBxXu86EgBGI", "status": "done" },
-      { "name": "Added coverage test for not-on-a-PR branch path", "status": "done" },
-      { "name": "Wait for CI to confirm codecov/patch green", "status": "in_progress" },
-      { "name": "Merge PR #221", "status": "planned" }
+      { "name": "Pin starlette>=1.0.1 to resolve PYSEC-2026-161", "status": "done" },
+      { "name": "Fix dead-code.js knip 6 JSON envelope + add ignore_patterns/ignore_dependencies", "status": "done" },
+      { "name": "Validate in fogofdog-frontend (structured FAILED, not ERROR)", "status": "done" },
+      { "name": "Open PR #223", "status": "done" }
     ]
   },
   "queue": {
     "active": true,
     "milestone": "v1.1 release",
-    "eta_days": 2,
+    "eta_days": 1,
     "priority": 1
-  },
-  "agent": {
-    "status": "Initial Willville packet check-in",
-    "direction": "Establish committed per-repo status source",
-    "difficulties": "None",
-    "needs_human": "None",
-    "last_update": "2026-05-22T08:00:00Z",
-    "actions": [
-      { "name": "Created .willville.json", "status": "done" },
-      { "name": "Opened initial check-in branch", "status": "done" },
-      { "name": "Push branch for review", "status": "planned" }
-    ]
   }
 }

--- a/.willville.json
+++ b/.willville.json
@@ -25,14 +25,14 @@
     "updated": "2026-05-25"
   },
   "agent": {
-    "status": "PR #223 open: starlette vuln pin + dead-code.js knip 6 compat",
-    "direction": "Two fixes: PYSEC-2026-161 starlette pin and dead-code.js knip 6 JSON format compat + ignore_patterns/ignore_dependencies config fields to stop agent doom-loops on tooling file false positives",
+    "status": "PR #223: CI fix pushed — black 88-char wrap in test file",
+    "direction": "Two fixes: PYSEC-2026-161 starlette pin and dead-code.js knip 6 JSON format compat + ignore_patterns/ignore_dependencies. CI was failing due to a long line in test_javascript_dead_code.py; now fixed.",
     "last_update": "2026-05-25T00:00:00Z",
     "actions": [
       { "name": "Pin starlette>=1.0.1 to resolve PYSEC-2026-161", "status": "done" },
       { "name": "Fix dead-code.js knip 6 JSON envelope + add ignore_patterns/ignore_dependencies", "status": "done" },
-      { "name": "Validate in fogofdog-frontend (structured FAILED, not ERROR)", "status": "done" },
-      { "name": "Open PR #223", "status": "done" }
+      { "name": "Fix CI black formatting failure (long line in test file)", "status": "done" },
+      { "name": "Wait for CI to pass and merge PR #223", "status": "in_progress" }
     ]
   },
   "queue": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ security = [
     "pyasn1>=0.6.3",  # GHSA-jr27-m4p2-rc6r
     "requests>=2.33.0",  # GHSA-gc5v-m9x4-r6x2
     "python-multipart>=0.0.27",  # GHSA-pp6c-gr5w-3c5g via semgrep/mcp
+    "starlette>=1.0.1",  # PYSEC-2026-161 via mcp/sse-starlette
     "semgrep>=1.140.0",
     "pip-audit>=2.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ cryptography>=46.0.7
 pyasn1>=0.6.3
 requests>=2.33.0
 python-multipart>=0.0.27
+starlette>=1.0.1
 semgrep>=1.140.0
 pip-audit>=2.0.0
 

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -135,21 +135,9 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             ignore_patterns: List[str] = self.config.get("ignore_patterns", [])
             ignore_deps: List[str] = self.config.get("ignore_dependencies", [])
             if ignore_patterns or ignore_deps:
-                tmp_cfg: Dict[str, Any] = {}
-                # Extend any existing repo knip config so entry points and
-                # plugins are preserved; without this, knip skips auto-discovery.
-                _KNIP_CFG_FILES = ["knip.json", "knip.ts", ".knip.json", ".knip.ts"]
-                for _f in _KNIP_CFG_FILES:
-                    if os.path.exists(os.path.join(project_root, _f)):
-                        tmp_cfg["extends"] = f"./{_f}"
-                        break
-                if ignore_patterns:
-                    tmp_cfg["ignore"] = ignore_patterns
-                if ignore_deps:
-                    tmp_cfg["ignoreDependencies"] = ignore_deps
-                tmp_config_path = os.path.join(project_root, "_sm_knip.json")
-                with open(tmp_config_path, "w") as f:
-                    json.dump(tmp_cfg, f)
+                tmp_config_path = self._write_temp_knip_config(
+                    project_root, ignore_patterns, ignore_deps
+                )
                 cmd.extend(["--config", "_sm_knip.json"])
 
         try:
@@ -205,6 +193,36 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             ),
             findings=findings,
         )
+
+    def _write_temp_knip_config(
+        self,
+        project_root: str,
+        ignore_patterns: List[str],
+        ignore_deps: List[str],
+    ) -> str:
+        """Write _sm_knip.json and return its path.
+
+        Extends any existing repo knip config so entry points and plugins are
+        preserved; without extends, knip skips auto-discovery entirely.
+        """
+        cfg: Dict[str, Any] = {}
+        for filename in [
+            "knip.json", "knip.jsonc",
+            ".knip.json", ".knip.jsonc",
+            "knip.ts", "knip.js",
+            "knip.config.ts", "knip.config.js",
+        ]:
+            if os.path.exists(os.path.join(project_root, filename)):
+                cfg["extends"] = f"./{filename}"
+                break
+        if ignore_patterns:
+            cfg["ignore"] = ignore_patterns
+        if ignore_deps:
+            cfg["ignoreDependencies"] = ignore_deps
+        path = os.path.join(project_root, "_sm_knip.json")
+        with open(path, "w") as f:
+            json.dump(cfg, f)
+        return path
 
     def _parse_knip_output(self, stdout: str) -> List[Finding]:
         """Parse knip --reporter json output into Finding objects.

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -202,27 +202,42 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
     ) -> str:
         """Write _sm_knip.json and return its path.
 
-        Extends any existing repo knip config so entry points and plugins are
-        preserved; without extends, knip skips auto-discovery entirely.
+        Merges ignore fields into any existing parseable JSON knip config so
+        entry points and plugins are preserved. TS/JS configs are skipped
+        (not safely parseable); in that case the user should use knip_config.
         """
-        cfg: Dict[str, Any] = {}
-        for filename in [
-            "knip.json", "knip.jsonc",
-            ".knip.json", ".knip.jsonc",
-            "knip.ts", "knip.js",
-            "knip.config.ts", "knip.config.js",
-        ]:
-            if os.path.exists(os.path.join(project_root, filename)):
-                cfg["extends"] = f"./{filename}"
-                break
+        cfg = self._load_repo_knip_config(project_root)
         if ignore_patterns:
-            cfg["ignore"] = ignore_patterns
+            existing = cfg.get("ignore", [])
+            cfg["ignore"] = existing + [p for p in ignore_patterns if p not in existing]
         if ignore_deps:
-            cfg["ignoreDependencies"] = ignore_deps
+            existing_deps = cfg.get("ignoreDependencies", [])
+            cfg["ignoreDependencies"] = existing_deps + [
+                d for d in ignore_deps if d not in existing_deps
+            ]
         path = os.path.join(project_root, "_sm_knip.json")
         with open(path, "w") as f:
             json.dump(cfg, f)
         return path
+
+    def _load_repo_knip_config(self, project_root: str) -> Dict[str, Any]:
+        """Return parsed contents of the repo's knip config, or {} if none found.
+
+        Only JSON-parseable files (knip.json, knip.jsonc, .knip.json,
+        .knip.jsonc) are attempted. TS/JS configs are skipped.
+        """
+        for filename in ["knip.json", "knip.jsonc", ".knip.json", ".knip.jsonc"]:
+            cfg_path = os.path.join(project_root, filename)
+            if not os.path.exists(cfg_path):
+                continue
+            try:
+                with open(cfg_path) as f:
+                    parsed: Any = json.load(f)
+                if isinstance(parsed, dict):
+                    return cast(Dict[str, Any], parsed)
+            except (json.JSONDecodeError, OSError):
+                pass
+        return {}
 
     def _parse_knip_output(self, stdout: str) -> List[Finding]:
         """Parse knip --reporter json output into Finding objects.

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -1,6 +1,7 @@
 """JavaScript/TypeScript dead code detection using knip."""
 
 import json
+import os
 import time
 from typing import Any, Dict, List, Optional, cast
 
@@ -79,6 +80,28 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
                 ),
                 required=False,
             ),
+            ConfigField(
+                name="ignore_patterns",
+                field_type="string[]",
+                default=[],
+                description=(
+                    "Glob patterns for files knip should ignore "
+                    "(e.g., ['.detoxrc.js', '.maestro/**', 'scripts/internal/**']). "
+                    "Only used when knip_config is not set."
+                ),
+                required=False,
+            ),
+            ConfigField(
+                name="ignore_dependencies",
+                field_type="string[]",
+                default=[],
+                description=(
+                    "Dependency names knip should treat as used "
+                    "(e.g., ['@jest/globals', 'geojson']). "
+                    "Only used when knip_config is not set."
+                ),
+                required=False,
+            ),
         ]
 
     def is_applicable(self, project_root: str) -> bool:
@@ -104,10 +127,29 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
 
         cmd = ["npx", "--yes", "knip", "--reporter", "json"]
         knip_config = self.config.get("knip_config", "")
+        tmp_config_path: Optional[str] = None
+
         if knip_config:
             cmd.extend(["--config", knip_config])
+        else:
+            ignore_patterns: List[str] = self.config.get("ignore_patterns", [])
+            ignore_deps: List[str] = self.config.get("ignore_dependencies", [])
+            if ignore_patterns or ignore_deps:
+                tmp_cfg: Dict[str, Any] = {}
+                if ignore_patterns:
+                    tmp_cfg["ignore"] = ignore_patterns
+                if ignore_deps:
+                    tmp_cfg["ignoreDependencies"] = ignore_deps
+                tmp_config_path = os.path.join(project_root, "_sm_knip.json")
+                with open(tmp_config_path, "w") as f:
+                    json.dump(tmp_cfg, f)
+                cmd.extend(["--config", "_sm_knip.json"])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        try:
+            result = self._run_command(cmd, cwd=project_root, timeout=120)
+        finally:
+            if tmp_config_path and os.path.exists(tmp_config_path):
+                os.unlink(tmp_config_path)
         duration = time.time() - start_time
 
         if result.timed_out:
@@ -147,13 +189,22 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             error=msg,
             fix_suggestion=(
                 "Remove unused exports/files or add consumers. "
+                "For tooling entry points (jest configs, .detoxrc.js, scripts/), "
+                "add them to ignore_patterns via: "
+                "sm config laziness:dead-code.js set ignore_patterns "
+                "['<glob>,...']. "
+                "For deps used via config (not imports), use ignore_dependencies. "
                 "Re-check: sm swab -g laziness:dead-code.js --verbose"
             ),
             findings=findings,
         )
 
     def _parse_knip_output(self, stdout: str) -> List[Finding]:
-        """Parse knip --reporter json output into Finding objects."""
+        """Parse knip --reporter json output into Finding objects.
+
+        Handles both legacy bare-array format (knip <5) and the
+        {"issues": [...]} envelope format used by knip 5+/6+.
+        """
         if not stdout.strip():
             return []
 
@@ -161,6 +212,10 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             raw: Any = json.loads(stdout)
         except (json.JSONDecodeError, ValueError):
             return []
+
+        # knip 5+/6+ wraps the array: {"issues": [...]}
+        if isinstance(raw, dict):
+            raw = cast(Dict[str, Any], raw).get("issues") or []
 
         if not isinstance(raw, list):
             return []
@@ -173,7 +228,6 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             file_entry = cast(Dict[str, Any], raw_entry)
             filepath: str = file_entry.get("file") or ""
 
-            # Unused files — the file itself is dead code
             if file_entry.get("files") is True:
                 findings.append(
                     Finding(
@@ -184,71 +238,77 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
                 )
                 continue
 
-            # Symbol-level issues: exports, types, enumMembers, classMembers,
-            # duplicates, unresolved
-            for issue_type in (
-                "exports",
-                "types",
-                "unresolved",
-                "duplicates",
-            ):
-                raw_symbols: Any = file_entry.get(issue_type)
-                if not raw_symbols:
+            findings.extend(self._parse_symbol_findings(file_entry, filepath))
+            findings.extend(self._parse_member_findings(file_entry, filepath))
+
+        return findings
+
+    def _parse_symbol_findings(
+        self, file_entry: Dict[str, Any], filepath: str
+    ) -> List[Finding]:
+        """Parse flat symbol-level knip issues (exports, types, duplicates, unresolved)."""
+        findings: List[Finding] = []
+        for issue_type in ("exports", "types", "unresolved", "duplicates"):
+            raw_symbols: Any = file_entry.get(issue_type)
+            if not raw_symbols:
+                continue
+            symbols: List[Any]
+            if issue_type == "duplicates":
+                flat: List[Any] = []
+                for group in raw_symbols:
+                    if isinstance(group, list):
+                        flat.extend(cast(List[Any], group))
+                    else:
+                        flat.append(group)
+                symbols = flat
+            else:
+                symbols = raw_symbols
+            for raw_sym in symbols:
+                if not isinstance(raw_sym, dict):
                     continue
-                symbols: List[Any]
-                # duplicates is a list-of-lists; flatten one level
-                if issue_type == "duplicates":
-                    flat: List[Any] = []
-                    for group in raw_symbols:
-                        if isinstance(group, list):
-                            flat.extend(cast(List[Any], group))
-                        else:
-                            flat.append(group)
-                    symbols = flat
-                else:
-                    symbols = raw_symbols
-                for raw_sym in symbols:
-                    if not isinstance(raw_sym, dict):
+                sym = cast(Dict[str, Any], raw_sym)
+                name: str = sym.get("name") or ""
+                line: Optional[int] = sym.get("line")
+                col: Optional[int] = sym.get("col")
+                findings.append(
+                    Finding(
+                        message=f"Unused {issue_type.rstrip('s')}: {name}",
+                        level=FindingLevel.WARNING,
+                        file=filepath,
+                        line=line,
+                        column=col,
+                    )
+                )
+        return findings
+
+    def _parse_member_findings(
+        self, file_entry: Dict[str, Any], filepath: str
+    ) -> List[Finding]:
+        """Parse nested member knip issues (enumMembers, classMembers)."""
+        findings: List[Finding] = []
+        for issue_type in ("enumMembers", "classMembers"):
+            raw_members_map: Any = file_entry.get(issue_type)
+            if not isinstance(raw_members_map, dict):
+                continue
+            members_map = cast(Dict[str, Any], raw_members_map)
+            for parent_name, raw_members in members_map.items():
+                if not isinstance(raw_members, list):
+                    continue
+                raw_member: Any
+                for raw_member in cast(List[Any], raw_members):
+                    if not isinstance(raw_member, dict):
                         continue
-                    sym = cast(Dict[str, Any], raw_sym)
+                    sym = cast(Dict[str, Any], raw_member)
                     name: str = sym.get("name") or ""
                     line: Optional[int] = sym.get("line")
                     col: Optional[int] = sym.get("col")
                     findings.append(
                         Finding(
-                            message=f"Unused {issue_type.rstrip('s')}: {name}",
+                            message=f"Unused {issue_type[:-1]}: {parent_name}.{name}",
                             level=FindingLevel.WARNING,
                             file=filepath,
                             line=line,
                             column=col,
                         )
                     )
-
-            # enumMembers and classMembers are dicts keyed by member name
-            for issue_type in ("enumMembers", "classMembers"):
-                raw_members_map: Any = file_entry.get(issue_type)
-                if not isinstance(raw_members_map, dict):
-                    continue
-                members_map = cast(Dict[str, Any], raw_members_map)
-                for parent_name, raw_members in members_map.items():
-                    if not isinstance(raw_members, list):
-                        continue
-                    raw_member: Any
-                    for raw_member in cast(List[Any], raw_members):
-                        if not isinstance(raw_member, dict):
-                            continue
-                        sym = cast(Dict[str, Any], raw_member)
-                        name = sym.get("name") or ""
-                        line = sym.get("line")
-                        col = sym.get("col")
-                        findings.append(
-                            Finding(
-                                message=f"Unused {issue_type[:-1]}: {parent_name}.{name}",
-                                level=FindingLevel.WARNING,
-                                file=filepath,
-                                line=line,
-                                column=col,
-                            )
-                        )
-
         return findings

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import time
 from typing import Any, Dict, List, Optional, cast
 
@@ -223,8 +224,8 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
     def _load_repo_knip_config(self, project_root: str) -> Dict[str, Any]:
         """Return parsed contents of the repo's knip config, or {} if none found.
 
-        Only JSON-parseable files (knip.json, knip.jsonc, .knip.json,
-        .knip.jsonc) are attempted. TS/JS configs are skipped.
+        Handles knip.json and knip.jsonc (stripping // line comments so typical
+        JSONC files parse correctly). TS/JS configs are skipped.
         """
         for filename in ["knip.json", "knip.jsonc", ".knip.json", ".knip.jsonc"]:
             cfg_path = os.path.join(project_root, filename)
@@ -232,7 +233,10 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
                 continue
             try:
                 with open(cfg_path) as f:
-                    parsed: Any = json.load(f)
+                    text = f.read()
+                # Strip // line comments (JSONC) before parsing
+                stripped = re.sub(r"//[^\n]*", "", text)
+                parsed: Any = json.loads(stripped)
                 if isinstance(parsed, dict):
                     return cast(Dict[str, Any], parsed)
             except (json.JSONDecodeError, OSError):

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -136,6 +136,13 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             ignore_deps: List[str] = self.config.get("ignore_dependencies", [])
             if ignore_patterns or ignore_deps:
                 tmp_cfg: Dict[str, Any] = {}
+                # Extend any existing repo knip config so entry points and
+                # plugins are preserved; without this, knip skips auto-discovery.
+                _KNIP_CFG_FILES = ["knip.json", "knip.ts", ".knip.json", ".knip.ts"]
+                for _f in _KNIP_CFG_FILES:
+                    if os.path.exists(os.path.join(project_root, _f)):
+                        tmp_cfg["extends"] = f"./{_f}"
+                        break
                 if ignore_patterns:
                     tmp_cfg["ignore"] = ignore_patterns
                 if ignore_deps:

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -193,10 +193,10 @@ class TestJavaScriptDeadCodeCheckRun:
         assert captured_configs
         assert captured_configs[0]["ignoreDependencies"] == ["@jest/globals", "geojson"]
 
-    def test_temp_config_extends_existing_knip_json(self, tmp_path):
+    def test_temp_config_merges_existing_knip_json(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()
-        (tmp_path / "knip.json").write_text('{"entry": ["index.ts"]}')
+        (tmp_path / "knip.json").write_text('{"entry": ["index.ts"], "ignore": ["existing/**"]}')
         check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
         captured_configs = []
 
@@ -210,13 +210,16 @@ class TestJavaScriptDeadCodeCheckRun:
             check.run(str(tmp_path))
 
         assert captured_configs
-        assert captured_configs[0].get("extends") == "./knip.json"
-        assert captured_configs[0]["ignore"] == [".detoxrc.js"]
+        cfg = captured_configs[0]
+        assert cfg.get("entry") == ["index.ts"]
+        assert "existing/**" in cfg["ignore"]
+        assert ".detoxrc.js" in cfg["ignore"]
+        assert "extends" not in cfg
 
-    def test_temp_config_extends_knip_jsonc(self, tmp_path):
+    def test_temp_config_merges_knip_jsonc(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()
-        (tmp_path / "knip.jsonc").write_text("{}")
+        (tmp_path / "knip.jsonc").write_text('{"entry": ["src/index.ts"]}')
         check = JavaScriptDeadCodeCheck({"ignore_patterns": ["scripts/**"]})
         captured_configs = []
 
@@ -230,9 +233,12 @@ class TestJavaScriptDeadCodeCheckRun:
             check.run(str(tmp_path))
 
         assert captured_configs
-        assert captured_configs[0].get("extends") == "./knip.jsonc"
+        cfg = captured_configs[0]
+        assert cfg.get("entry") == ["src/index.ts"]
+        assert cfg["ignore"] == ["scripts/**"]
+        assert "extends" not in cfg
 
-    def test_temp_config_no_extends_when_no_knip_config(self, tmp_path):
+    def test_temp_config_no_merge_when_no_knip_config(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()
         check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
@@ -248,7 +254,9 @@ class TestJavaScriptDeadCodeCheckRun:
             check.run(str(tmp_path))
 
         assert captured_configs
-        assert "extends" not in captured_configs[0]
+        cfg = captured_configs[0]
+        assert cfg == {"ignore": [".detoxrc.js"]}
+        assert "extends" not in cfg
 
     def test_knip_config_takes_precedence_over_ignore_fields(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -213,6 +213,25 @@ class TestJavaScriptDeadCodeCheckRun:
         assert captured_configs[0].get("extends") == "./knip.json"
         assert captured_configs[0]["ignore"] == [".detoxrc.js"]
 
+    def test_temp_config_extends_knip_jsonc(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "knip.jsonc").write_text("{}")
+        check = JavaScriptDeadCodeCheck({"ignore_patterns": ["scripts/**"]})
+        captured_configs = []
+
+        def fake_run(cmd, **_kwargs):
+            cfg_path = tmp_path / "_sm_knip.json"
+            if cfg_path.exists():
+                captured_configs.append(json.loads(cfg_path.read_text()))
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        assert captured_configs
+        assert captured_configs[0].get("extends") == "./knip.jsonc"
+
     def test_temp_config_no_extends_when_no_knip_config(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -193,6 +193,44 @@ class TestJavaScriptDeadCodeCheckRun:
         assert captured_configs
         assert captured_configs[0]["ignoreDependencies"] == ["@jest/globals", "geojson"]
 
+    def test_temp_config_extends_existing_knip_json(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "knip.json").write_text('{"entry": ["index.ts"]}')
+        check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
+        captured_configs = []
+
+        def fake_run(cmd, **_kwargs):
+            cfg_path = tmp_path / "_sm_knip.json"
+            if cfg_path.exists():
+                captured_configs.append(json.loads(cfg_path.read_text()))
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        assert captured_configs
+        assert captured_configs[0].get("extends") == "./knip.json"
+        assert captured_configs[0]["ignore"] == [".detoxrc.js"]
+
+    def test_temp_config_no_extends_when_no_knip_config(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
+        captured_configs = []
+
+        def fake_run(cmd, **_kwargs):
+            cfg_path = tmp_path / "_sm_knip.json"
+            if cfg_path.exists():
+                captured_configs.append(json.loads(cfg_path.read_text()))
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        assert captured_configs
+        assert "extends" not in captured_configs[0]
+
     def test_knip_config_takes_precedence_over_ignore_fields(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -240,6 +240,29 @@ class TestJavaScriptDeadCodeCheckRun:
         assert cfg["ignore"] == ["scripts/**"]
         assert "extends" not in cfg
 
+    def test_temp_config_merges_knip_jsonc_with_comments(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "knip.jsonc").write_text(
+            '{\n  // entry points\n  "entry": ["src/main.ts"]\n}'
+        )
+        check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
+        captured_configs = []
+
+        def fake_run(cmd, **_kwargs):
+            cfg_path = tmp_path / "_sm_knip.json"
+            if cfg_path.exists():
+                captured_configs.append(json.loads(cfg_path.read_text()))
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        assert captured_configs
+        cfg = captured_configs[0]
+        assert cfg.get("entry") == ["src/main.ts"]
+        assert ".detoxrc.js" in cfg["ignore"]
+
     def test_temp_config_no_merge_when_no_knip_config(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -196,7 +196,9 @@ class TestJavaScriptDeadCodeCheckRun:
     def test_temp_config_merges_existing_knip_json(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         (tmp_path / "node_modules").mkdir()
-        (tmp_path / "knip.json").write_text('{"entry": ["index.ts"], "ignore": ["existing/**"]}')
+        (tmp_path / "knip.json").write_text(
+            '{"entry": ["index.ts"], "ignore": ["existing/**"]}'
+        )
         check = JavaScriptDeadCodeCheck({"ignore_patterns": [".detoxrc.js"]})
         captured_configs = []
 

--- a/tests/unit/test_javascript_dead_code.py
+++ b/tests/unit/test_javascript_dead_code.py
@@ -21,9 +21,13 @@ class TestJavaScriptDeadCodeCheckMetadata:
     def test_depends_on(self):
         assert "laziness:sloppy-formatting.js" in JavaScriptDeadCodeCheck({}).depends_on
 
-    def test_config_schema_has_knip_config(self):
+    def test_config_schema_has_ignore_patterns(self):
         fields = {f.name for f in JavaScriptDeadCodeCheck({}).config_schema}
-        assert "knip_config" in fields
+        assert "ignore_patterns" in fields
+
+    def test_config_schema_has_ignore_dependencies(self):
+        fields = {f.name for f in JavaScriptDeadCodeCheck({}).config_schema}
+        assert "ignore_dependencies" in fields
 
 
 class TestJavaScriptDeadCodeCheckApplicability:
@@ -149,6 +153,69 @@ class TestJavaScriptDeadCodeCheckRun:
         assert "--config" in knip_cmd
         assert "knip.ci.json" in knip_cmd
 
+    def test_ignore_patterns_writes_temp_config(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        check = JavaScriptDeadCodeCheck(
+            {"ignore_patterns": [".detoxrc.js", ".maestro/**"]}
+        )
+        captured = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(cmd)
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        knip_cmd = next(c for c in captured if "knip" in " ".join(c))
+        assert "--config" in knip_cmd
+        # Temp config is cleaned up after run
+        assert not (tmp_path / "_sm_knip.json").exists()
+
+    def test_ignore_dependencies_written_to_temp_config(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        check = JavaScriptDeadCodeCheck(
+            {"ignore_dependencies": ["@jest/globals", "geojson"]}
+        )
+        captured_configs = []
+
+        def fake_run(cmd, **_kwargs):
+            cfg_path = tmp_path / "_sm_knip.json"
+            if cfg_path.exists():
+                captured_configs.append(json.loads(cfg_path.read_text()))
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        assert captured_configs
+        assert captured_configs[0]["ignoreDependencies"] == ["@jest/globals", "geojson"]
+
+    def test_knip_config_takes_precedence_over_ignore_fields(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        check = JavaScriptDeadCodeCheck(
+            {
+                "knip_config": "knip.json",
+                "ignore_patterns": [".detoxrc.js"],
+            }
+        )
+        captured = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(cmd)
+            return self._make_result(success=True)
+
+        with patch.object(check, "_run_command", side_effect=fake_run):
+            check.run(str(tmp_path))
+
+        knip_cmd = next(c for c in captured if "knip" in " ".join(c))
+        # Uses explicit knip_config, not the generated temp file
+        assert "knip.json" in knip_cmd
+        assert "_sm_knip.json" not in " ".join(knip_cmd)
+
 
 class TestParseKnipOutput:
     def setup_method(self):
@@ -161,7 +228,23 @@ class TestParseKnipOutput:
         assert self.check._parse_knip_output("not json {{{") == []
 
     def test_non_list_json_returns_empty(self):
+        # Dict without "issues" key falls back to empty list
         assert self.check._parse_knip_output('{"error": "bad"}') == []
+
+    def test_knip_6_issues_envelope_format(self):
+        # knip 5+/6+ wraps results in {"issues": [...]}
+        data = {
+            "issues": [
+                {"file": "src/foo.ts", "exports": [{"name": "fn", "line": 1, "col": 1}]}
+            ]
+        }
+        findings = self.check._parse_knip_output(json.dumps(data))
+        assert len(findings) == 1
+        assert "fn" in findings[0].message
+
+    def test_knip_6_envelope_empty_issues(self):
+        findings = self.check._parse_knip_output(json.dumps({"issues": []}))
+        assert findings == []
 
     def test_unused_file_finding(self):
         data = [{"file": "src/dead.ts", "files": True}]


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in the `security` extra to resolve PYSEC-2026-161 (path traversal via `StaticFiles`)
- Fix `laziness:dead-code.js` knip 6.x JSON format regression: knip 5+/6+ wraps output as `{"issues": [...]}` — the gate was treating all findings as an error because the bare-list assumption failed, producing `💥 error` instead of structured `❌ failed` findings
- Add `ignore_patterns` and `ignore_dependencies` config fields so tooling entry points (`.detoxrc.js`, `.maestro/**`, jest configs) and config-consumed deps can be suppressed without requiring a full `knip.json` — this was the root cause of an agent doom-loop in a real fogofdog session
- Extract `_parse_symbol_findings` and `_parse_member_findings` helpers to stay under the 100-line function limit

## Test plan

- [ ] `sm scour --no-cache` passes (18 passed, 1 warned pre-existing, 0 failed)
- [ ] `pip-audit` against venv no longer flags PYSEC-2026-161
- [ ] `laziness:dead-code.js` in fogofdog-frontend now shows `❌ failed` with structured findings (not `💥 error`)
- [ ] New unit tests cover knip 6 envelope format, `ignore_patterns`/`ignore_dependencies` temp config generation, and config precedence