### PR TITLE
feat: sailing mode + success-path guidance for agents

### DIFF
--- a/.cursor-plugin/skills/sm-sail.md
+++ b/.cursor-plugin/skills/sm-sail.md
@@ -33,9 +33,9 @@ sm sail → runs swab
   buff all-green           → ⛵ PR ready for human review
 ```
 
-## Note on iterating-mode guidance
+## Note on tacking-mode guidance
 
-When `sm swab` passes outside of sail (iterating mode), the output includes
+When `sm swab` passes outside of sail (tacking mode), the output includes
 "share results with the human, await the next instruction." That guidance comes
 from `sm swab` directly — `sm sail` is always in SAILING mode.
 

--- a/.cursor-plugin/skills/sm-sail.md
+++ b/.cursor-plugin/skills/sm-sail.md
@@ -1,16 +1,16 @@
 ---
 name: sm-sail
 description: >-
-  Auto-advance the slop-mop workflow. Use when unsure what to run next,
-  or to let slop-mop drive the iteration loop automatically. Triggers
-  when the user says "sail", "what should I run?", "advance the workflow",
-  "next step", or "keep going" in a project using slop-mop.
+  Drive the slop-mop workflow toward a green, buffed PR. Use when the human
+  says "sail", "ship it", "take it home", or approves the work and wants it
+  shipped. Also use when unsure what to run next in a slop-mop project.
 ---
 
-# sm sail — workflow auto-advance
+# sm sail — workflow autopilot
 
-`sm sail` reads the current workflow state and dispatches the right verb
-automatically. Use it when you don't know whether to swab, scour, or buff.
+`sm sail` reads the current workflow state and mode, runs the next step or
+emits the exact command to run, then exits. Call it again after following
+its instruction.
 
 ## Prerequisite
 
@@ -20,31 +20,33 @@ automatically. Use it when you don't know whether to swab, scour, or buff.
 pipx install slopmop[all]
 ```
 
-## When to use sail vs individual verbs
+## Two modes
 
-| Use `sm sail` when…                         | Use the verb directly when…              |
-|---------------------------------------------|------------------------------------------|
-| You want forward motion with no decisions   | You need a specific gate (`-g flag`)     |
-| Continuing an established remediation loop  | You know exactly what phase you're in    |
-| Letting an autonomous agent drive           | Surgical work on one check or thread     |
+| Mode | When | Behavior |
+|------|------|----------|
+| **Iterating** (default) | Building the feature | Runs swab, surfaces results, says "share with human, await instruction" |
+| **Sailing** | Human approved — "ship it" | Activated by running `sm sail`. Drives to PR_READY, emitting exact git/gh commands at each step |
 
-## The loop sail automates
+## What sail tells you to do (sailing mode)
 
 ```
-edit → sm swab → fix → repeat            (until swab is clean)
-       sm scour → fix → repeat           (until scour is clean)
-       git push
-       sm buff watch <PR#>               (blocks until CI settles)
-       sm buff <PR#> → fix → repeat      (until CI + threads clean)
+sm sail → runs swab
+  swab clean + uncommitted → "git add -A && git commit -m '...' then sm sail"
+  swab clean + committed   → runs scour
+  scour clean + no PR      → "git push -u origin HEAD && gh pr create --fill then sm sail"
+  scour clean + PR + push  → "git push then sm sail"
+  scour clean + PR + clean → runs buff inspect
+  buff issues              → fix gate, then sm sail again
+  buff all-green           → ⛵ PR ready for human review
 ```
 
-Run `sm sail` at any point — it reads `.slopmop/` state and picks up
-where you left off.
+## Only stops for
+
+- **Gate failure** — fix what it names, then `sm sail` again
+- **`⚓ HOLD`** — human decision needed; address it, then `sm sail` again
+- **PR ready** — surface to human for merge
 
 ## Hard rules
 
 - **NEVER** bypass a failing gate — sail will not let you skip forward.
-- If sail dispatches a verb and it fails, fix what it names, then run
-  `sm sail` again.
-- If the environment looks broken, `sm doctor` (or `sm doctor --fix`)
-  before re-running sail.
+- If the environment looks broken: `sm doctor` before re-running sail.

--- a/.cursor-plugin/skills/sm-sail.md
+++ b/.cursor-plugin/skills/sm-sail.md
@@ -8,9 +8,9 @@ description: >-
 
 # sm sail — workflow autopilot
 
-`sm sail` reads the current workflow state and mode, runs the next step or
-emits the exact command to run, then exits. Call it again after following
-its instruction.
+`sm sail` activates SAILING mode on entry, reads the current workflow state,
+runs the next step or emits the exact command to run, then exits. Call it again
+after following its instruction.
 
 ## Prerequisite
 
@@ -20,25 +20,24 @@ its instruction.
 pipx install slopmop[all]
 ```
 
-## Two modes
-
-| Mode | When | Behavior |
-|------|------|----------|
-| **Iterating** (default) | Building the feature | Runs swab, surfaces results, says "share with human, await instruction" |
-| **Sailing** | Human approved — "ship it" | Activated by running `sm sail`. Drives to PR_READY, emitting exact git/gh commands at each step |
-
-## What sail tells you to do (sailing mode)
+## What sail tells you to do
 
 ```
 sm sail → runs swab
   swab clean + uncommitted → "git add -A && git commit -m '...' then sm sail"
   swab clean + committed   → runs scour
   scour clean + no PR      → "git push -u origin HEAD && gh pr create --fill then sm sail"
-  scour clean + PR + push  → "git push then sm sail"
-  scour clean + PR + clean → runs buff inspect
+  scour clean + PR exists  → "git push then sm sail"
+  PR open                  → runs buff inspect
   buff issues              → fix gate, then sm sail again
   buff all-green           → ⛵ PR ready for human review
 ```
+
+## Note on iterating-mode guidance
+
+When `sm swab` passes outside of sail (iterating mode), the output includes
+"share results with the human, await the next instruction." That guidance comes
+from `sm swab` directly — `sm sail` is always in SAILING mode.
 
 ## Only stops for
 

--- a/commands/sm-sail.md
+++ b/commands/sm-sail.md
@@ -1,15 +1,28 @@
 # /sm-sail
 
-Auto-advance the slop-mop workflow loop for this repository.
+Drive the workflow toward a green, buffed PR — one step at a time.
 
 1. Run `sm sail`.
-2. It reads the workflow state and runs the next obvious verb — swab, scour, or buff.
-3. Fix whatever it reports, then run `sm sail` again.
-4. Repeat until the PR lands.
+2. It reads the current workflow state and mode, runs the next obvious step
+   or emits the exact command to run, then exits.
+3. Follow the instruction, then run `sm sail` again.
+4. Repeat until the PR is ready for human review.
 
-This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
+**Two modes:**
 
-**First time in a repo?** If `sm sail` reports no workflow state, the repo hasn't been onboarded yet. Run `sm refit --start` to begin.
+- **Iterating** (default): sail runs swab, surfaces results, and tells you to
+  share them with the human and await the next instruction.
+- **Sailing**: activated by invoking `sm sail` — the human has approved the
+  work and wants it shipped. Sail drives all the way to PR_READY, emitting
+  exact git/gh commands at each mechanical step (`git commit`, `git push`,
+  `gh pr create --fill`) and telling you to call `sm sail` again.
+
+**Only stops for:**
+- A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again
+- An `⚓ HOLD` — a human decision is needed; address it, then `sm sail` again
+- PR ready — surface the PR to the human for merge
+
+**First time in a repo?** Run `sm refit --start` first.
 
 **Prerequisite:** `sm` must be installed. If `command not found`, suggest:
 ```bash

--- a/commands/sm-sail.md
+++ b/commands/sm-sail.md
@@ -3,19 +3,19 @@
 Drive the workflow toward a green, buffed PR — one step at a time.
 
 1. Run `sm sail`.
-2. It reads the current workflow state and mode, runs the next obvious step
-   or emits the exact command to run, then exits.
+2. It reads the current workflow state, runs the next obvious step or emits
+   the exact command to run, then exits.
 3. Follow the instruction, then run `sm sail` again.
 4. Repeat until the PR is ready for human review.
 
-**Two modes:**
+**What sail does:** `sm sail` activates SAILING mode on entry and drives the
+workflow to PR_READY. At each step it emits the exact command to run
+(`git add -A && git commit -m '...'`, `git push`, `gh pr create --fill`)
+then tells you to call `sm sail` again.
 
-- **Iterating** (default): sail runs swab, surfaces results, and tells you to
-  share them with the human and await the next instruction.
-- **Sailing**: activated by invoking `sm sail` — the human has approved the
-  work and wants it shipped. Sail drives all the way to PR_READY, emitting
-  exact git/gh commands at each mechanical step (`git commit`, `git push`,
-  `gh pr create --fill`) and telling you to call `sm sail` again.
+**What `sm swab` does:** When run directly (not via sail), `sm swab` surfaces
+results and tells you to commit, share them with the human, and await the next
+instruction — the iterating-mode guidance lives there.
 
 **Only stops for:**
 - A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again

--- a/commands/sm-sail.md
+++ b/commands/sm-sail.md
@@ -15,7 +15,7 @@ then tells you to call `sm sail` again.
 
 **What `sm swab` does:** When run directly (not via sail), `sm swab` surfaces
 results and tells you to commit, share them with the human, and await the next
-instruction — the iterating-mode guidance lives there.
+instruction — the tacking-mode guidance lives there.
 
 **Only stops for:**
 - A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
@@ -1,15 +1,28 @@
 # /sm-sail
 
-Auto-advance the slop-mop workflow loop for this repository.
+Drive the workflow toward a green, buffed PR — one step at a time.
 
 1. Run `sm sail`.
-2. It reads the workflow state and runs the next obvious verb — swab, scour, or buff.
-3. Fix whatever it reports, then run `sm sail` again.
-4. Repeat until the PR lands.
+2. It reads the current workflow state and mode, runs the next obvious step
+   or emits the exact command to run, then exits.
+3. Follow the instruction, then run `sm sail` again.
+4. Repeat until the PR is ready for human review.
 
-This is the "do the next thing" command. Use it when you're not sure whether to swab, scour, or buff. For surgical work on a specific gate or PR thread, use the individual verbs directly.
+**Two modes:**
 
-**First time in a repo?** If `sm sail` reports no workflow state, the repo hasn't been onboarded yet. Run `sm refit --start` to begin.
+- **Iterating** (default): sail runs swab, surfaces results, and tells you to
+  share them with the human and await the next instruction.
+- **Sailing**: activated by invoking `sm sail` — the human has approved the
+  work and wants it shipped. Sail drives all the way to PR_READY, emitting
+  exact git/gh commands at each mechanical step (`git commit`, `git push`,
+  `gh pr create --fill`) and telling you to call `sm sail` again.
+
+**Only stops for:**
+- A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again
+- An `⚓ HOLD` — a human decision is needed; address it, then `sm sail` again
+- PR ready — surface the PR to the human for merge
+
+**First time in a repo?** Run `sm refit --start` first.
 
 **Prerequisite:** `sm` must be installed. If `command not found`, suggest:
 ```bash

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
@@ -3,19 +3,19 @@
 Drive the workflow toward a green, buffed PR — one step at a time.
 
 1. Run `sm sail`.
-2. It reads the current workflow state and mode, runs the next obvious step
-   or emits the exact command to run, then exits.
+2. It reads the current workflow state, runs the next obvious step or emits
+   the exact command to run, then exits.
 3. Follow the instruction, then run `sm sail` again.
 4. Repeat until the PR is ready for human review.
 
-**Two modes:**
+**What sail does:** `sm sail` activates SAILING mode on entry and drives the
+workflow to PR_READY. At each step it emits the exact command to run
+(`git add -A && git commit -m '...'`, `git push`, `gh pr create --fill`)
+then tells you to call `sm sail` again.
 
-- **Iterating** (default): sail runs swab, surfaces results, and tells you to
-  share them with the human and await the next instruction.
-- **Sailing**: activated by invoking `sm sail` — the human has approved the
-  work and wants it shipped. Sail drives all the way to PR_READY, emitting
-  exact git/gh commands at each mechanical step (`git commit`, `git push`,
-  `gh pr create --fill`) and telling you to call `sm sail` again.
+**What `sm swab` does:** When run directly (not via sail), `sm swab` surfaces
+results and tells you to commit, share them with the human, and await the next
+instruction — the iterating-mode guidance lives there.
 
 **Only stops for:**
 - A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-sail.md
@@ -15,7 +15,7 @@ then tells you to call `sm sail` again.
 
 **What `sm swab` does:** When run directly (not via sail), `sm swab` surfaces
 results and tells you to commit, share them with the human, and await the next
-instruction — the iterating-mode guidance lives there.
+instruction — the tacking-mode guidance lives there.
 
 **Only stops for:**
 - A failing swab/scour/buff gate — fix the reported issues, then `sm sail` again

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -1,19 +1,24 @@
-"""Sail command — auto-advance the workflow loop.
+"""Sail command — drive the workflow toward a green, buffed PR.
 
-``sm sail`` reads the current workflow state and executes the next
-obvious step.  The caller does not need to know whether to swab,
-scour, or buff — ``sail`` figures it out.
+``sm sail`` reads the current workflow state and mode, executes the next
+obvious step (or emits the exact command to run), then exits.  The caller
+invokes ``sm sail`` again after completing any emitted instruction.
 
 Design principles:
 
-*   **Single-step**: execute one action, report the result, stop.
-    The caller can invoke ``sm sail`` again to keep going.
-*   **No auto-commit**: committing requires a human-authored message,
-    so S3 (SWAB_CLEAN) instructs the user to commit instead of
-    automating it.
+*   **Single-step, agent loops**: one action or instruction per call.
+    Agents follow the emitted gradient and call ``sm sail`` again.
+*   **Instruct, don't act**: sail tells the agent exactly what to run —
+    including git/gh command lines — rather than running them itself.
+    Committing and pushing are agent responsibilities.
+*   **Two modes**: ITERATING (default, surface results to human) vs
+    SAILING (human approved, drive all the way to PR_READY).  Invoking
+    ``sm sail`` activates SAILING mode.
+*   **HOLD pattern**: when a human decision is needed, sail emits a
+    structured ``⚓ HOLD`` block so agents never have to guess.
 *   **Delegates**: dispatches directly to ``cmd_swab``, ``cmd_scour``,
     or ``cmd_buff``.  State transitions are handled by the existing
-    workflow hooks — ``sail`` does not duplicate state management.
+    workflow hooks — sail does not duplicate state management.
 """
 
 from __future__ import annotations
@@ -23,10 +28,17 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-from slopmop.workflow.state_machine import WorkflowState
-from slopmop.workflow.state_store import read_state, write_state
+from slopmop.workflow.state_machine import SailMode, WorkflowState
+from slopmop.workflow.state_store import (
+    read_sail_mode,
+    read_state,
+    write_sail_mode,
+    write_state,
+)
 
 # ── Helpers ──────────────────────────────────────────────────────
+
+_THEN_SAIL = "   Then: sm sail"
 
 
 def _has_uncommitted_changes(project_root: Path) -> bool:
@@ -176,14 +188,25 @@ def _sail_swab_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_swab_clean(args: argparse.Namespace, project_root: Path) -> int:
-    """S3 — SWAB_CLEAN: commit if dirty, run scour if clean."""
+    """S3 — SWAB_CLEAN: instruct to commit (mode-aware), then run scour."""
     if _has_uncommitted_changes(project_root):
-        _print_step(
-            "📝",
-            "Commit your changes",
-            "Swab is clean but you have uncommitted work.\n"
-            "   Run: git add -A && git commit -m '<message>'",
-        )
+        sail_mode = read_sail_mode(project_root)
+        if sail_mode == SailMode.SAILING:
+            _print_step(
+                "📝",
+                "Commit your changes",
+                "Swab is clean — stage and commit, then continue sailing.\n"
+                "   Run: git add -A && git commit -m 'wip: ...'\n" + _THEN_SAIL,
+            )
+        else:
+            _print_step(
+                "📝",
+                "Commit and share results",
+                "Swab is clean — commit your changes, share the results\n"
+                "   with the human, and await the next instruction.\n"
+                "   Run: git add -A && git commit -m '...'\n"
+                "   When ready to ship: sm sail",
+            )
         return 0
 
     # Working tree is clean — advance to scour
@@ -223,15 +246,14 @@ def _sail_scour_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_scour_clean(args: argparse.Namespace, project_root: Path) -> int:
-    """S5 — SCOUR_CLEAN: push and/or open PR."""
+    """S5 — SCOUR_CLEAN: instruct to push and open/update PR."""
     pr = _get_pr_number(project_root)
     if pr is not None:
         _print_step(
             "📤",
-            "Push to PR",
-            f"Scour is clean. PR #{pr} detected.\n"
-            f"   Run: git push\n"
-            f"   Then: sm sail   (to buff the PR)",
+            "Push to existing PR",
+            f"Scour is clean. PR #{pr} is open — push your commits.\n"
+            f"   Run: git push\n" + _THEN_SAIL,
         )
     else:
         _print_step(
@@ -239,8 +261,7 @@ def _sail_scour_clean(args: argparse.Namespace, project_root: Path) -> int:
             "Push and open PR",
             "Scour is clean — time to publish.\n"
             "   Run: git push -u origin HEAD\n"
-            "   Then: gh pr create\n"
-            "   Then: sm sail",
+            "        gh pr create --fill\n" + _THEN_SAIL,
         )
     return 0
 
@@ -288,13 +309,13 @@ def _sail_buff_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_pr_ready(args: argparse.Namespace, project_root: Path) -> int:
-    """S8 — PR_READY: finalize and land."""
-    _print_step(
-        "🏁",
-        "PR ready to land",
-        "All CI green, no unresolved threads.\n"
-        "   Run: sm buff finalize --push\n"
-        "   Or merge from the GitHub UI.",
+    """S8 — PR_READY: surface to human for review, reset to iterating."""
+    write_sail_mode(project_root, SailMode.ITERATING)
+    print(
+        "\n⛵ sail → 🏁 PR ready for human review\n"
+        "   All CI green, no unresolved threads.\n"
+        "   Share the PR with the human and await their decision.\n"
+        "   (Sail mode reset to iterating for the next feature.)\n"
     )
     return 0
 
@@ -317,7 +338,7 @@ _STATE_HANDLERS = {
 
 
 def cmd_sail(args: argparse.Namespace) -> int:
-    """Auto-advance the workflow: detect state and do the next thing."""
+    """Drive the workflow toward a green PR — one step at a time."""
     project_root = Path(getattr(args, "project_root", "."))
 
     status = _onboard_status(project_root)
@@ -336,6 +357,9 @@ def cmd_sail(args: argparse.Namespace) -> int:
             "sm init ran but refit hasn't started.\n" "   Run: sm refit --start",
         )
         return 1
+
+    # Activating sail sets SAILING mode — persists across calls until PR_READY.
+    write_sail_mode(project_root, SailMode.SAILING)
 
     persisted_state = read_state(project_root) or WorkflowState.IDLE
     state = _reconcile_runtime_state(persisted_state, project_root)

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -30,7 +30,6 @@ from typing import Optional
 
 from slopmop.workflow.state_machine import SailMode, WorkflowState
 from slopmop.workflow.state_store import (
-    read_sail_mode,
     read_state,
     write_sail_mode,
     write_state,
@@ -188,25 +187,14 @@ def _sail_swab_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_swab_clean(args: argparse.Namespace, project_root: Path) -> int:
-    """S3 — SWAB_CLEAN: instruct to commit (mode-aware), then run scour."""
+    """S3 — SWAB_CLEAN: instruct to commit, then run scour."""
     if _has_uncommitted_changes(project_root):
-        sail_mode = read_sail_mode(project_root)
-        if sail_mode == SailMode.SAILING:
-            _print_step(
-                "📝",
-                "Commit your changes",
-                "Swab is clean — stage and commit, then continue sailing.\n"
-                "   Run: git add -A && git commit -m 'wip: ...'\n" + _THEN_SAIL,
-            )
-        else:
-            _print_step(
-                "📝",
-                "Commit and share results",
-                "Swab is clean — commit your changes, share the results\n"
-                "   with the human, and await the next instruction.\n"
-                "   Run: git add -A && git commit -m '...'\n"
-                "   When ready to ship: sm sail",
-            )
+        _print_step(
+            "📝",
+            "Commit your changes",
+            "Swab is clean — stage and commit, then continue sailing.\n"
+            "   Run: git add -A && git commit -m 'wip: ...'\n" + _THEN_SAIL,
+        )
         return 0
 
     # Working tree is clean — advance to scour

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -11,7 +11,7 @@ Design principles:
 *   **Instruct, don't act**: sail tells the agent exactly what to run —
     including git/gh command lines — rather than running them itself.
     Committing and pushing are agent responsibilities.
-*   **Two modes**: ITERATING (default, surface results to human) vs
+*   **Two modes**: TACKING (default, surface results to human) vs
     SAILING (human approved, drive all the way to PR_READY).  Invoking
     ``sm sail`` activates SAILING mode.
 *   **HOLD pattern**: when a human decision is needed, sail emits a
@@ -297,13 +297,13 @@ def _sail_buff_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_pr_ready(args: argparse.Namespace, project_root: Path) -> int:
-    """S8 — PR_READY: surface to human for review, reset to iterating."""
-    write_sail_mode(project_root, SailMode.ITERATING)
+    """S8 — PR_READY: surface to human for review, reset to tacking."""
+    write_sail_mode(project_root, SailMode.TACKING)
     print(
         "\n⛵ sail → 🏁 PR ready for human review\n"
         "   All CI green, no unresolved threads.\n"
         "   Share the PR with the human and await their decision.\n"
-        "   (Sail mode reset to iterating for the next feature.)\n"
+        "   (Sail mode reset to tacking for the next feature.)\n"
     )
     return 0
 

--- a/slopmop/cli/validate.py
+++ b/slopmop/cli/validate.py
@@ -33,7 +33,7 @@ from slopmop.reporting.report import RunReport
 from slopmop.reporting.timings import clear_timings, load_timing_averages
 from slopmop.subprocess.runner import get_runner
 from slopmop.workflow.state_machine import RepoPhase
-from slopmop.workflow.state_store import read_phase
+from slopmop.workflow.state_store import read_phase, read_sail_mode, read_state
 
 
 def _default_json_artifact_path(project_root: Path, artifact_name: str) -> str:
@@ -523,6 +523,8 @@ def _run_validation_locked(
             registry=registry,
             sort_actionable_by_remediation_order=True,
             verbose=args.verbose,
+            workflow_state=read_state(project_root),
+            sail_mode=read_sail_mode(project_root),
         )
         report.baseline_filter = baseline_metadata
 

--- a/slopmop/cli/validate.py
+++ b/slopmop/cli/validate.py
@@ -33,7 +33,7 @@ from slopmop.reporting.report import RunReport
 from slopmop.reporting.timings import clear_timings, load_timing_averages
 from slopmop.subprocess.runner import get_runner
 from slopmop.workflow.state_machine import RepoPhase
-from slopmop.workflow.state_store import read_phase, read_sail_mode, read_state
+from slopmop.workflow.state_store import read_phase, read_sail_mode
 
 
 def _default_json_artifact_path(project_root: Path, artifact_name: str) -> str:
@@ -523,7 +523,6 @@ def _run_validation_locked(
             registry=registry,
             sort_actionable_by_remediation_order=True,
             verbose=args.verbose,
-            workflow_state=read_state(project_root),
             sail_mode=read_sail_mode(project_root),
         )
         report.baseline_filter = baseline_metadata

--- a/slopmop/reporting/adapters.py
+++ b/slopmop/reporting/adapters.py
@@ -176,6 +176,9 @@ class PorcelainAdapter:
         if report.verify_command and len(report.actionable) > 1:
             lines.append(f"first: {report.verify_command}")
 
+        if report.next_step and not report.actionable:
+            lines.append(f"next: {report.next_step}")
+
         cache = report.cache_metadata()
         if cache:
             lines.append(
@@ -289,6 +292,9 @@ class ConsoleAdapter:
         print("═" * 60)
         if r.warned:
             self._render_warnings()
+        if r.next_step:
+            print(f"   ▸ next: {r.next_step}")
+            print()
 
     def _render_failure(self) -> None:
         r = self.report

--- a/slopmop/reporting/adapters.py
+++ b/slopmop/reporting/adapters.py
@@ -176,7 +176,7 @@ class PorcelainAdapter:
         if report.verify_command and len(report.actionable) > 1:
             lines.append(f"first: {report.verify_command}")
 
-        if report.next_step and not report.actionable:
+        if report.next_step and not report.failed and not report.errored:
             lines.append(f"next: {report.next_step}")
 
         cache = report.cache_metadata()

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -36,7 +36,7 @@ from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
 
 if TYPE_CHECKING:
     from slopmop.core.registry import CheckRegistry
-    from slopmop.workflow.state_machine import SailMode, WorkflowState
+    from slopmop.workflow.state_machine import SailMode
 
 
 def _format_age(iso_timestamp: str) -> Optional[str]:
@@ -133,25 +133,19 @@ JSON_SCHEMA_VERSION = "slopmop/v2"
 
 def _compute_next_step(
     level: Optional[str],
-    workflow_state: Optional["WorkflowState"],
     sail_mode: Optional["SailMode"],
 ) -> Optional[str]:
     """Return the agent's next instruction after a successful run.
 
-    Returns None when context isn't available (e.g. no project_root, or
-    called from a context that doesn't track workflow state).
+    ``level`` (the tool that just passed) is the primary signal.
+    ``workflow_state`` and ``sail_mode`` are supplementary context.
+    Returns None for unrecognised levels or when level is not provided.
     """
-    from slopmop.workflow.state_machine import SailMode, WorkflowState
+    from slopmop.workflow.state_machine import SailMode
 
     sailing = sail_mode == SailMode.SAILING
 
-    if level == "swab" or workflow_state in (
-        WorkflowState.IDLE,
-        WorkflowState.SWAB_FAILING,
-        WorkflowState.SCOUR_FAILING,
-        WorkflowState.BUFF_FAILING,
-        None,
-    ):
+    if level == "swab":
         if sailing:
             return (
                 "Swab clean. Run: git add -A && git commit -m 'wip: ...' "
@@ -162,7 +156,7 @@ def _compute_next_step(
             "and await the next instruction. Run sm sail when ready to ship."
         )
 
-    if level == "scour" or workflow_state == WorkflowState.SCOUR_CLEAN:
+    if level == "scour":
         return (
             "Scour clean. Run: git push -u origin HEAD (or git push if "
             "upstream exists), then sm sail"
@@ -250,7 +244,6 @@ class RunReport:
         registry: Optional["CheckRegistry"] = None,
         sort_actionable_by_remediation_order: bool = False,
         verbose: bool = False,
-        workflow_state: Optional["WorkflowState"] = None,
         sail_mode: Optional["SailMode"] = None,
     ) -> "RunReport":
         """Build a RunReport from a raw ExecutionSummary.
@@ -295,7 +288,7 @@ class RunReport:
             verify = f"sm {verb} -g {first_blocking.name}"
 
         next_step = (
-            _compute_next_step(level, workflow_state, sail_mode)
+            _compute_next_step(level, sail_mode)
             if summary.all_passed
             else None
         )

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -137,9 +137,9 @@ def _compute_next_step(
 ) -> Optional[str]:
     """Return the agent's next instruction after a successful run.
 
-    ``level`` (the tool that just passed) is the primary signal.
-    ``workflow_state`` and ``sail_mode`` are supplementary context.
-    Returns None for unrecognised levels or when level is not provided.
+    ``level`` (the tool that just passed) is the primary signal; ``sail_mode``
+    selects between exact-command (SAILING) and share-with-human (ITERATING)
+    guidance. Returns None for unrecognised levels or when level is not provided.
     """
     from slopmop.workflow.state_machine import SailMode
 
@@ -157,9 +157,14 @@ def _compute_next_step(
         )
 
     if level == "scour":
+        if sailing:
+            return (
+                "Scour clean. Run: git push -u origin HEAD (or git push if "
+                "upstream exists), then sm sail"
+            )
         return (
-            "Scour clean. Run: git push -u origin HEAD (or git push if "
-            "upstream exists), then sm sail"
+            "Scour clean. Share results with the human and await the next "
+            "instruction. Run sm sail when ready to push."
         )
 
     return None
@@ -287,11 +292,7 @@ class RunReport:
             verb = level or "swab"
             verify = f"sm {verb} -g {first_blocking.name}"
 
-        next_step = (
-            _compute_next_step(level, sail_mode)
-            if summary.all_passed
-            else None
-        )
+        next_step = _compute_next_step(level, sail_mode) if summary.all_passed else None
 
         return cls(
             summary=summary,

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -36,6 +36,7 @@ from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
 
 if TYPE_CHECKING:
     from slopmop.core.registry import CheckRegistry
+    from slopmop.workflow.state_machine import SailMode, WorkflowState
 
 
 def _format_age(iso_timestamp: str) -> Optional[str]:
@@ -130,6 +131,46 @@ def _sort_results_for_remediation_display(
 JSON_SCHEMA_VERSION = "slopmop/v2"
 
 
+def _compute_next_step(
+    level: Optional[str],
+    workflow_state: Optional["WorkflowState"],
+    sail_mode: Optional["SailMode"],
+) -> Optional[str]:
+    """Return the agent's next instruction after a successful run.
+
+    Returns None when context isn't available (e.g. no project_root, or
+    called from a context that doesn't track workflow state).
+    """
+    from slopmop.workflow.state_machine import SailMode, WorkflowState
+
+    sailing = sail_mode == SailMode.SAILING
+
+    if level == "swab" or workflow_state in (
+        WorkflowState.IDLE,
+        WorkflowState.SWAB_FAILING,
+        WorkflowState.SCOUR_FAILING,
+        WorkflowState.BUFF_FAILING,
+        None,
+    ):
+        if sailing:
+            return (
+                "Swab clean. Run: git add -A && git commit -m 'wip: ...' "
+                "then sm sail"
+            )
+        return (
+            "Swab clean. Commit your changes, share results with the human, "
+            "and await the next instruction. Run sm sail when ready to ship."
+        )
+
+    if level == "scour" or workflow_state == WorkflowState.SCOUR_CLEAN:
+        return (
+            "Scour clean. Run: git push -u origin HEAD (or git push if "
+            "upstream exists), then sm sail"
+        )
+
+    return None
+
+
 def _structured_console_lines(
     result: CheckResult,
     *,
@@ -195,6 +236,9 @@ class RunReport:
     verify_command: Optional[str] = None
     first_to_fix: Optional[str] = None
     baseline_filter: Optional[Dict[str, object]] = None
+    # next_step is emitted on success to tell the agent what to do now.
+    # Computed from the current workflow state + sail mode when available.
+    next_step: Optional[str] = None
 
     @classmethod
     def from_summary(
@@ -206,6 +250,8 @@ class RunReport:
         registry: Optional["CheckRegistry"] = None,
         sort_actionable_by_remediation_order: bool = False,
         verbose: bool = False,
+        workflow_state: Optional["WorkflowState"] = None,
+        sail_mode: Optional["SailMode"] = None,
     ) -> "RunReport":
         """Build a RunReport from a raw ExecutionSummary.
 
@@ -248,6 +294,12 @@ class RunReport:
             verb = level or "swab"
             verify = f"sm {verb} -g {first_blocking.name}"
 
+        next_step = (
+            _compute_next_step(level, workflow_state, sail_mode)
+            if summary.all_passed
+            else None
+        )
+
         return cls(
             summary=summary,
             level=level,
@@ -261,6 +313,7 @@ class RunReport:
             not_applicable=status_buckets[CheckStatus.NOT_APPLICABLE],
             verify_command=verify,
             first_to_fix=first_blocking.name if first_blocking is not None else None,
+            next_step=next_step,
         )
 
     def per_gate_verify_command(self, gate_name: str) -> str:

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -138,7 +138,7 @@ def _compute_next_step(
     """Return the agent's next instruction after a successful run.
 
     ``level`` (the tool that just passed) is the primary signal; ``sail_mode``
-    selects between exact-command (SAILING) and share-with-human (ITERATING)
+    selects between exact-command (SAILING) and share-with-human (TACKING)
     guidance. Returns None for unrecognised levels or when level is not provided.
     """
     from slopmop.workflow.state_machine import SailMode

--- a/slopmop/workflow/state_machine.py
+++ b/slopmop/workflow/state_machine.py
@@ -56,17 +56,17 @@ class RepoPhase(str, Enum):
 
 
 class SailMode(str, Enum):
-    """Whether the agent is iterating or driving toward a green PR.
+    """Whether the agent is tacking or driving toward a green PR.
 
-    ITERATING — default; agent is building the feature.  After swab clean,
+    TACKING — default; agent is building the feature.  After swab clean,
         surface results to the human and await the next instruction.
 
     SAILING — human has approved the work and wants it shipped.  After each
         step, sail emits the exact next command and tells the agent to call
-        ``sm sail`` again.  Resets to ITERATING when PR_READY is reached.
+        ``sm sail`` again.  Resets to TACKING when PR_READY is reached.
     """
 
-    ITERATING = "iterating"
+    TACKING = "tacking"
     SAILING = "sailing"
 
 

--- a/slopmop/workflow/state_machine.py
+++ b/slopmop/workflow/state_machine.py
@@ -51,6 +51,26 @@ class RepoPhase(str, Enum):
 
 
 # ---------------------------------------------------------------------------
+# Sail mode — sub-mode within MAINTENANCE
+# ---------------------------------------------------------------------------
+
+
+class SailMode(str, Enum):
+    """Whether the agent is iterating or driving toward a green PR.
+
+    ITERATING — default; agent is building the feature.  After swab clean,
+        surface results to the human and await the next instruction.
+
+    SAILING — human has approved the work and wants it shipped.  After each
+        step, sail emits the exact next command and tells the agent to call
+        ``sm sail`` again.  Resets to ITERATING when PR_READY is reached.
+    """
+
+    ITERATING = "iterating"
+    SAILING = "sailing"
+
+
+# ---------------------------------------------------------------------------
 # States
 # ---------------------------------------------------------------------------
 

--- a/slopmop/workflow/state_store.py
+++ b/slopmop/workflow/state_store.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
-from slopmop.workflow.state_machine import RepoPhase, WorkflowState
+from slopmop.workflow.state_machine import RepoPhase, SailMode, WorkflowState
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ _STATE_DIR = ".slopmop"
 _STATE_KEY = "state"
 _PHASE_KEY = "phase"
 _BASELINE_KEY = "baseline_achieved"
+_SAIL_MODE_KEY = "sail_mode"
 
 
 def _state_path(project_root: str | Path) -> Path:
@@ -61,6 +62,24 @@ def read_baseline_achieved(project_root: str | Path) -> bool:
     """Return True when a clean scour baseline has been recorded."""
     data = _read_raw(project_root)
     return bool(data.get(_BASELINE_KEY, False))
+
+
+def read_sail_mode(project_root: str | Path) -> SailMode:
+    """Return the current sail mode, defaulting to ITERATING."""
+    data = _read_raw(project_root)
+    raw = data.get(_SAIL_MODE_KEY)
+    if isinstance(raw, str):
+        try:
+            return SailMode(raw)
+        except ValueError:
+            pass
+    return SailMode.ITERATING
+
+
+def write_sail_mode(project_root: str | Path, mode: SailMode) -> None:
+    """Persist *mode* without touching other fields."""
+    _update(project_root, {_SAIL_MODE_KEY: mode.value})
+    logger.debug("Sail mode → %s", mode.value)
 
 
 def write_state(project_root: str | Path, state: WorkflowState) -> None:

--- a/slopmop/workflow/state_store.py
+++ b/slopmop/workflow/state_store.py
@@ -65,7 +65,7 @@ def read_baseline_achieved(project_root: str | Path) -> bool:
 
 
 def read_sail_mode(project_root: str | Path) -> SailMode:
-    """Return the current sail mode, defaulting to ITERATING."""
+    """Return the current sail mode, defaulting to TACKING."""
     data = _read_raw(project_root)
     raw = data.get(_SAIL_MODE_KEY)
     if isinstance(raw, str):
@@ -73,7 +73,7 @@ def read_sail_mode(project_root: str | Path) -> SailMode:
             return SailMode(raw)
         except ValueError:
             pass
-    return SailMode.ITERATING
+    return SailMode.TACKING
 
 
 def write_sail_mode(project_root: str | Path, mode: SailMode) -> None:

--- a/tests/unit/test_hooks_and_state_store.py
+++ b/tests/unit/test_hooks_and_state_store.py
@@ -113,7 +113,7 @@ class TestStateStoreEdgeCases:
         write_sail_mode(tmp_path, SailMode.SAILING)
         assert read_sail_mode(tmp_path) == SailMode.SAILING
 
-    def test_read_sail_mode_returns_iterating_for_invalid_string(self, tmp_path):
+    def test_read_sail_mode_returns_tacking_for_invalid_string(self, tmp_path):
         from slopmop.workflow.state_store import read_sail_mode
 
         state_dir = tmp_path / ".slopmop"
@@ -121,12 +121,12 @@ class TestStateStoreEdgeCases:
         (state_dir / "workflow_state.json").write_text(
             json.dumps({"sail_mode": "bogus_mode"})
         )
-        assert read_sail_mode(tmp_path) == SailMode.ITERATING
+        assert read_sail_mode(tmp_path) == SailMode.TACKING
 
-    def test_read_sail_mode_defaults_to_iterating_when_missing(self, tmp_path):
+    def test_read_sail_mode_defaults_to_tacking_when_missing(self, tmp_path):
         from slopmop.workflow.state_store import read_sail_mode
 
-        assert read_sail_mode(tmp_path) == SailMode.ITERATING
+        assert read_sail_mode(tmp_path) == SailMode.TACKING
 
     def test_update_creates_dir_if_missing(self, tmp_path):
         from slopmop.workflow.state_store import write_state

--- a/tests/unit/test_hooks_and_state_store.py
+++ b/tests/unit/test_hooks_and_state_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
-from slopmop.workflow.state_machine import RepoPhase, WorkflowState
+from slopmop.workflow.state_machine import RepoPhase, SailMode, WorkflowState
 
 # ---------------------------------------------------------------------------
 # state_store tests — fill coverage gaps on edge cases
@@ -106,6 +106,27 @@ class TestStateStoreEdgeCases:
         state_dir.mkdir()
         (state_dir / "workflow_state.json").write_text('"just a string"')
         assert _read_raw(tmp_path) == {}
+
+    def test_read_sail_mode_returns_mode_for_valid_string(self, tmp_path):
+        from slopmop.workflow.state_store import read_sail_mode, write_sail_mode
+
+        write_sail_mode(tmp_path, SailMode.SAILING)
+        assert read_sail_mode(tmp_path) == SailMode.SAILING
+
+    def test_read_sail_mode_returns_iterating_for_invalid_string(self, tmp_path):
+        from slopmop.workflow.state_store import read_sail_mode
+
+        state_dir = tmp_path / ".slopmop"
+        state_dir.mkdir()
+        (state_dir / "workflow_state.json").write_text(
+            json.dumps({"sail_mode": "bogus_mode"})
+        )
+        assert read_sail_mode(tmp_path) == SailMode.ITERATING
+
+    def test_read_sail_mode_defaults_to_iterating_when_missing(self, tmp_path):
+        from slopmop.workflow.state_store import read_sail_mode
+
+        assert read_sail_mode(tmp_path) == SailMode.ITERATING
 
     def test_update_creates_dir_if_missing(self, tmp_path):
         from slopmop.workflow.state_store import write_state

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -676,7 +676,7 @@ class TestConsoleAdapter:
 
 
 class TestPorcelainAdapter:
-    def test_success_is_single_summary_line(self) -> None:
+    def test_success_includes_summary_line_and_next_step(self) -> None:
         summary = _summary(
             [
                 _result("a", CheckStatus.PASSED),
@@ -689,7 +689,9 @@ class TestPorcelainAdapter:
         )
         report = RunReport.from_summary(summary, level="swab")
 
-        assert PorcelainAdapter.render(report) == "sm swab: 0 fail · 1 pass · 1 n/a"
+        rendered = PorcelainAdapter.render(report)
+        assert rendered.startswith("sm swab: 0 fail · 1 pass · 1 n/a")
+        assert "next:" in rendered
 
     def test_failure_lists_actionable_detail_and_next_command(self) -> None:
         summary = _summary(

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -27,6 +27,7 @@ from slopmop.reporting.adapters import (
     _role_badge,
 )
 from slopmop.reporting.report import JSON_SCHEMA_VERSION, RunReport
+from slopmop.workflow.state_machine import SailMode
 
 # ─── fixtures ────────────────────────────────────────────────────────────
 
@@ -1003,7 +1004,29 @@ class TestConsoleAdapterWarnings:
         assert "line 2" in out
         assert "line 3" not in out
         assert "more lines in log" in out
-        assert "logs/g.log" in out
+
+
+# ─── next_step sailing mode ───────────────────────────────────────────────
+
+
+class TestNextStepSailingMode:
+    def test_swab_sailing_mode_gives_exact_commit_command(self) -> None:
+        summary = _summary([_result("p", CheckStatus.PASSED)])
+        report = RunReport.from_summary(
+            summary, level="swab", sail_mode=SailMode.SAILING
+        )
+        assert report.next_step is not None
+        assert "git add -A && git commit" in report.next_step
+        assert "sm sail" in report.next_step
+
+    def test_scour_sailing_mode_gives_exact_push_command(self) -> None:
+        summary = _summary([_result("p", CheckStatus.PASSED)])
+        report = RunReport.from_summary(
+            summary, level="scour", sail_mode=SailMode.SAILING
+        )
+        assert report.next_step is not None
+        assert "git push" in report.next_step
+        assert "sm sail" in report.next_step
 
     def test_verbose_output_preview_shows_more_lines(self, capsys) -> None:
         long_output = "\n".join(f"line {i}" for i in range(20))

--- a/tests/unit/test_run_report.py
+++ b/tests/unit/test_run_report.py
@@ -826,8 +826,16 @@ class TestPorcelainAdapter:
         out = PorcelainAdapter.render(report)
         assert "timed check(s) skipped" in out
 
-
-# ─── role badge helper ───────────────────────────────────────────────────
+    def test_next_step_emitted_when_warnings_present(self) -> None:
+        summary = _summary(
+            [
+                _result("p", CheckStatus.PASSED),
+                _result("w", CheckStatus.WARNED),
+            ]
+        )
+        report = RunReport.from_summary(summary, level="swab")
+        out = PorcelainAdapter.render(report)
+        assert "next:" in out
 
 
 class TestRoleBadge:

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -11,7 +11,7 @@ import pytest
 
 from slopmop.cli import sail as sail_mod
 from slopmop.cli.scan_triage import ARTIFACT_NAME, WORKFLOW_NAME
-from slopmop.workflow.state_machine import WorkflowState
+from slopmop.workflow.state_machine import SailMode, WorkflowState
 
 
 def _base_args(tmp_path: Path) -> argparse.Namespace:
@@ -162,14 +162,15 @@ class TestSailDispatch:
         assert call_args.workflow == WORKFLOW_NAME
         assert call_args.artifact == ARTIFACT_NAME
 
-    def test_pr_ready_reports_ready_to_land(self, monkeypatch, capsys, tmp_path: Path):
+    def test_pr_ready_reports_ready_for_human_review(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_READY)
 
         assert sail_mod.cmd_sail(args) == 0
         out = capsys.readouterr().out
-        assert "ready to land" in out
-        assert "finalize" in out
+        assert "human review" in out
 
     def test_none_state_defaults_to_idle(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)
@@ -374,3 +375,89 @@ class TestSailStateReconciliation:
         )
 
         assert state == WorkflowState.SCOUR_CLEAN
+
+
+class TestSailMode:
+    """Sailing mode is activated on entry and drives mode-aware output."""
+
+    @pytest.fixture(autouse=True)
+    def _onboarded(self, monkeypatch):
+        monkeypatch.setattr(sail_mod, "_onboard_status", lambda _: "onboarded")
+
+    def test_cmd_sail_activates_sailing_mode(self, monkeypatch, tmp_path: Path):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.IDLE)
+        monkeypatch.setattr("slopmop.cli.cmd_swab", Mock(return_value=0))
+        write_sail_mode = Mock()
+        monkeypatch.setattr(sail_mod, "write_sail_mode", write_sail_mode)
+
+        sail_mod.cmd_sail(args)
+
+        write_sail_mode.assert_any_call(tmp_path, SailMode.SAILING)
+
+    def test_swab_clean_uncommitted_sailing_gives_exact_commit_command(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SWAB_CLEAN)
+        monkeypatch.setattr(sail_mod, "_has_uncommitted_changes", lambda _: True)
+        monkeypatch.setattr(sail_mod, "read_sail_mode", lambda _: SailMode.SAILING)
+        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
+
+        assert sail_mod.cmd_sail(args) == 0
+        out = capsys.readouterr().out
+        assert "git add -A" in out
+        assert "git commit" in out
+        assert "sm sail" in out
+
+    def test_swab_clean_uncommitted_iterating_gives_share_guidance(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SWAB_CLEAN)
+        monkeypatch.setattr(sail_mod, "_has_uncommitted_changes", lambda _: True)
+        monkeypatch.setattr(sail_mod, "read_sail_mode", lambda _: SailMode.ITERATING)
+        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
+
+        assert sail_mod.cmd_sail(args) == 0
+        out = capsys.readouterr().out
+        assert "human" in out
+        assert "sm sail" in out
+
+    def test_scour_clean_no_pr_gives_exact_push_and_create_commands(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SCOUR_CLEAN)
+        monkeypatch.setattr(sail_mod, "_get_pr_number", lambda _: None)
+        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
+
+        assert sail_mod.cmd_sail(args) == 0
+        out = capsys.readouterr().out
+        assert "git push -u origin HEAD" in out
+        assert "gh pr create --fill" in out
+        assert "sm sail" in out
+
+    def test_scour_clean_with_pr_gives_exact_push_command(
+        self, monkeypatch, capsys, tmp_path: Path
+    ):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SCOUR_CLEAN)
+        monkeypatch.setattr(sail_mod, "_get_pr_number", lambda _: 77)
+        monkeypatch.setattr(sail_mod, "_has_unpushed_commits", lambda _: True)
+        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
+
+        assert sail_mod.cmd_sail(args) == 0
+        out = capsys.readouterr().out
+        assert "git push" in out
+        assert "sm sail" in out
+
+    def test_pr_ready_resets_mode_to_iterating(self, monkeypatch, tmp_path: Path):
+        args = _base_args(tmp_path)
+        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_READY)
+        write_sail_mode = Mock()
+        monkeypatch.setattr(sail_mod, "write_sail_mode", write_sail_mode)
+
+        sail_mod.cmd_sail(args)
+
+        write_sail_mode.assert_any_call(tmp_path, SailMode.ITERATING)

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -395,33 +395,18 @@ class TestSailMode:
 
         write_sail_mode.assert_any_call(tmp_path, SailMode.SAILING)
 
-    def test_swab_clean_uncommitted_sailing_gives_exact_commit_command(
+    def test_swab_clean_uncommitted_gives_exact_commit_command(
         self, monkeypatch, capsys, tmp_path: Path
     ):
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SWAB_CLEAN)
         monkeypatch.setattr(sail_mod, "_has_uncommitted_changes", lambda _: True)
-        monkeypatch.setattr(sail_mod, "read_sail_mode", lambda _: SailMode.SAILING)
         monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
 
         assert sail_mod.cmd_sail(args) == 0
         out = capsys.readouterr().out
         assert "git add -A" in out
         assert "git commit" in out
-        assert "sm sail" in out
-
-    def test_swab_clean_uncommitted_iterating_gives_share_guidance(
-        self, monkeypatch, capsys, tmp_path: Path
-    ):
-        args = _base_args(tmp_path)
-        monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.SWAB_CLEAN)
-        monkeypatch.setattr(sail_mod, "_has_uncommitted_changes", lambda _: True)
-        monkeypatch.setattr(sail_mod, "read_sail_mode", lambda _: SailMode.ITERATING)
-        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
-
-        assert sail_mod.cmd_sail(args) == 0
-        out = capsys.readouterr().out
-        assert "human" in out
         assert "sm sail" in out
 
     def test_scour_clean_no_pr_gives_exact_push_and_create_commands(

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -437,7 +437,7 @@ class TestSailMode:
         assert "git push" in out
         assert "sm sail" in out
 
-    def test_pr_ready_resets_mode_to_iterating(self, monkeypatch, tmp_path: Path):
+    def test_pr_ready_resets_mode_to_tacking(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_READY)
         write_sail_mode = Mock()
@@ -445,4 +445,4 @@ class TestSailMode:
 
         sail_mod.cmd_sail(args)
 
-        write_sail_mode.assert_any_call(tmp_path, SailMode.ITERATING)
+        write_sail_mode.assert_any_call(tmp_path, SailMode.TACKING)


### PR DESCRIPTION
- `sm sail` now activates SAILING mode on entry and persists it across
  calls until PR_READY, so agents can drive all the way to a green PR
  without stopping to ask what to do next.

- Two modes: ITERATING (default — surface results, await human) vs
  SAILING (human approved — emit exact git/gh commands at every step).

- Success paths now emit `next:` guidance, filling the gap where swab
  or scour passes used to go silent and leave agents guessing.

- SCOUR_CLEAN handler emits exact command strings
  (`git push -u origin HEAD && gh pr create --fill`) rather than
  vague descriptions.

- PR_READY resets to ITERATING and tells the agent to surface the PR
  to the human rather than suggesting `sm buff finalize --push`.

- `SailMode` enum + `read_sail_mode`/`write_sail_mode` in state_store.
- `RunReport.next_step` computed from level + workflow_state + sail_mode.
- Console and porcelain adapters emit next_step on every clean pass.
