### PR TITLE
Safety: Prohibit autonomous gh pr merge

### DIFF
--- a/.cursor-plugin/skills/sm-barnacle.md
+++ b/.cursor-plugin/skills/sm-barnacle.md
@@ -1,0 +1,42 @@
+---
+name: sm-barnacle
+description: >-
+  Report slop-mop tool friction. Triggers when sm itself gives invalid
+  guidance, blocks valid work, produces confusing output, or breaks install
+  flow. Never use gh issue create for slop-mop bugs — use sm barnacle file.
+---
+
+# sm barnacle — report slopmop friction
+
+Use when `sm` itself is broken — not when your repo has lint failures.
+
+```bash
+sm barnacle file \
+  --title "short summary of the slop-mop friction" \
+  --command "sm <verb> [flags]" \
+  --expected "what should have happened" \
+  --actual "what happened instead" \
+  --repro-step "how to reproduce it" \
+  --tried "what you already tried" \
+  --workflow swab \
+  --blocker-type blocking \
+  --json
+```
+
+Use `--dry-run` when GitHub auth is unavailable. The generated issue body is
+written to `.slopmop/last_barnacle_issue.md`.
+
+## Hard rule
+
+- **NEVER** use `gh issue create` for slop-mop friction.
+  `sm barnacle file` targets the right repo, adds the correct labels,
+  and captures platform/version metadata automatically.
+- File the barnacle, then continue only if the friction is non-blocking.
+
+## Prerequisite
+
+`sm` must be installed. If `command not found`:
+
+```bash
+pipx install slopmop[all]
+```

--- a/.cursor-plugin/skills/sm-init.md
+++ b/.cursor-plugin/skills/sm-init.md
@@ -1,0 +1,36 @@
+---
+name: sm-init
+description: >-
+  Configure slopmop for this repo. Triggers when you find a repo with sm
+  installed but no .sb_config.json, or after upgrading slopmop. Run before
+  sm refit or the maintenance loop.
+---
+
+# sm init — initial repo setup
+
+Run `sm init --non-interactive` when the repo has `sm` installed but no
+`.sb_config.json`. It auto-detects the stack and writes a tuned config.
+
+After init, run `sm sail` to enter the loop.
+
+## Prerequisite
+
+`sm` must be installed. If `command not found`:
+
+```bash
+pipx install slopmop[all]
+```
+
+## Usage
+
+```bash
+sm init --non-interactive   # agent context: skip prompts
+sm init                     # interactive: prompts for test dirs, thresholds
+```
+
+Re-run after `pip install --upgrade slopmop` to pick up new gates.
+
+## Hard rule
+
+- Run `sm init` **before** `sm refit` or `sm swab` in a fresh repo.
+  Without a `.sb_config.json`, gates cannot run.

--- a/.willville.json
+++ b/.willville.json
@@ -23,9 +23,9 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "PR #224 — --no-tty flag + Windows KBI fix, waiting on CI",
-    "direction": "Two small quality-of-life fixes: agents can share output with humans, Windows tests no longer flake on teardown",
-    "last_update": "2026-05-26T05:45:00Z"
+    "status": "Implementing sailing mode safety features: gh pr merge prohibition, pending review detection",
+    "direction": "Finalize PR #229 (autonomous merge prohibition) after human review; verify full workflow ready for sailing agents",
+    "last_update": "2026-05-28T03:35:00Z"
   },
   "queue": {
     "active": true,

--- a/commands/sm-init.md
+++ b/commands/sm-init.md
@@ -1,0 +1,20 @@
+# /sm-init — configure slopmop for this repo
+
+Run when you find a repo with `sm` installed but no `.sb_config.json` — or
+after upgrading slopmop to pick up new gates.
+
+1. Run `sm init --non-interactive` from the project root.
+2. It auto-detects the stack (Python, JS, Go, Rust, iOS…) and writes a tuned
+   `.sb_config.json`.
+3. Then run `sm sail` — it reads the config and enters the loop.
+
+Re-run after `pip install --upgrade slopmop` to pick up new gates, or after
+adding a language to the repo.
+
+`--non-interactive` skips prompts; use it in agent contexts. Without it, init
+asks about test directories and coverage thresholds.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Trigger when you would normally reach for pytest, gh, mypy, black, or other
   raw repo tooling. Redirect to `sm swab`, `sm scour`, `sm buff`, `sm sail`,
   `sm refit`, or `sm doctor` so remediation follows the established rails.
+  Also trigger when you find a repo with sm installed but no .sb_config.json
+  — use `sm init --non-interactive` before entering the loop.
   Also trigger when filing issues about slop-mop friction — use
   `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
 ---
@@ -16,6 +18,9 @@ Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **mai
 
 ## When to use
 
+- **Initial setup (step -1)**: Run `sm init --non-interactive` when the repo has
+  `sm` installed but no `.sb_config.json`. This generates a config tuned to the
+  detected stack. Run it before refit or the maintenance loop.
 - **Default action**: Run `sm sail` when you're not sure what's next — it reads workflow state and does the right thing.
 - **Refit (step 0)**: Run `sm refit --start` to generate a remediation plan, then `sm refit --iterate` until complete, then `sm refit --finish` to enter maintenance.
 - **During implementation**: Run `sm swab` after every meaningful code change. Keep running until clean.

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -21,6 +21,7 @@ when your impulse is the left column, run the right column instead.
 | `gh pr review --approve` after addressing threads | `sm buff verify <PR#>` first                 |
 | `gh pr merge`                                     | **Wait for human decision.** Sail stops at PR_READY. Share the PR with human, await their merge call. |
 | `gh issue create` for slop-mop tool friction      | `sm barnacle file`                           |
+| No `.sb_config.json` in repo (first setup)        | `sm init --non-interactive`                  |
 | "not sure what to do next"                        | `sm sail`                                    |
 | "why won't sm / this gate run?"                   | `sm doctor`                                  |
 | Stale `.slopmop/sm.lock`, broken state dir        | `sm doctor --fix`                            |
@@ -47,6 +48,21 @@ when your impulse is the left column, run the right column instead.
   `sm gang press` installs system-wide command intercepts that conscript forbidden
   tools into sm equivalents automatically, blocking bypass attempts.
   (`press` = Royal Navy term for forcible conscription; `sm gang discharge` removes them.)
+
+### Excluding paths from all gates
+
+Built-in global excludes (always active, no config needed):
+`node_modules`, `venv`, `__pycache__`, `dist`, `build`, `htmlcov`, `cursor-rules`, `logs`,
+and all dot-prefixed directories (`.git`, `.venv`, `.next`, `.gradle`, etc.)
+
+For project-specific directories not in that list, add them **once** at the top level of `.sb_config.json`:
+
+```json
+"exclude_paths": ["Pods", "vendor", "target", "local"]
+```
+
+This applies to every gate. Do **not** reach for per-gate `extra_exclude_paths` unless you
+need a gate-specific exception. `sm init` auto-populates common ones for detected project types.
 
 ### The loop
 

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -19,6 +19,7 @@ when your impulse is the left column, run the right column instead.
 | Reading CI logs to find the failing test          | `sm buff inspect <PR#>`                      |
 | `gh api ... resolveReviewThread`                  | `sm buff resolve <PR#> <THREAD_ID> -m "..."` |
 | `gh pr review --approve` after addressing threads | `sm buff verify <PR#>` first                 |
+| `gh pr merge`                                     | **Wait for human decision.** Sail stops at PR_READY. Share the PR with human, await their merge call. |
 | `gh issue create` for slop-mop tool friction      | `sm barnacle file`                           |
 | "not sure what to do next"                        | `sm sail`                                    |
 | "why won't sm / this gate run?"                   | `sm doctor`                                  |
@@ -36,6 +37,8 @@ when your impulse is the left column, run the right column instead.
   remediation plan — it knows which check failed and what you need to
   do next, not just that something is red.
 - **NEVER** open or update a PR without `sm scour` passing first.
+- **NEVER** merge a PR autonomously.  `sm sail` reaches PR_READY and stops.
+  The human makes the final merge decision.  This is a safety wall.
 - **NEVER** file slop-mop tool-friction issues with raw `gh issue create`.
   `sm barnacle file` adds the correct labels, issue shape, and source context.
 - **NEVER** bypass or silence a failing check.  If a gate is wrong,

--- a/slopmop/agent_install/templates/claude/.claude/commands/sm-init.md
+++ b/slopmop/agent_install/templates/claude/.claude/commands/sm-init.md
@@ -1,0 +1,20 @@
+# /sm-init — configure slopmop for this repo
+
+Run when you find a repo with `sm` installed but no `.sb_config.json` — or
+after upgrading slopmop to pick up new gates.
+
+1. Run `sm init --non-interactive` from the project root.
+2. It auto-detects the stack (Python, JS, Go, Rust, iOS…) and writes a tuned
+   `.sb_config.json`.
+3. Then run `sm sail` — it reads the config and enters the loop.
+
+Re-run after `pip install --upgrade slopmop` to pick up new gates, or after
+adding a language to the repo.
+
+`--non-interactive` skips prompts; use it in agent contexts. Without it, init
+asks about test directories and coverage thresholds.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/slopmop/agent_install/templates/cursor/.cursor/rules/slopmop-barnacle.mdc
+++ b/slopmop/agent_install/templates/cursor/.cursor/rules/slopmop-barnacle.mdc
@@ -1,0 +1,6 @@
+---
+description: Report slop-mop tool friction — when sm itself blocks valid work, file a barnacle instead of routing around it
+alwaysApply: true
+---
+
+{{CORE}}

--- a/slopmop/agent_install/templates/cursor/.cursor/rules/slopmop-init.mdc
+++ b/slopmop/agent_install/templates/cursor/.cursor/rules/slopmop-init.mdc
@@ -1,0 +1,6 @@
+---
+description: Slop-mop initial project setup — bootstrap a repo that has sm installed but no .sb_config.json
+alwaysApply: true
+---
+
+{{CORE}}

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -317,10 +317,85 @@ class PRCommentsCheck(BaseCheck):
             pass
         return "", ""
 
+    def _wait_for_bugbot_completion(
+        self, project_root: str, pr_number: int, owner: str, repo: str, max_wait: int = 300
+    ) -> None:
+        """Wait for Cursor Bugbot to finish posting review comments.
+
+        On the web (CI), Bugbot may still be in progress when scour runs.
+        This method polls for active Bugbot check runs and waits for completion.
+        """
+        check_run_query = """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              checkRuns(first: 10) {
+                nodes {
+                  name
+                  status
+                  conclusion
+                }
+              }
+            }
+          }
+        }
+        """
+
+        start_time = time.time()
+        while time.time() - start_time < max_wait:
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "api",
+                        "graphql",
+                        "-F",
+                        f"owner={owner}",
+                        "-F",
+                        f"name={repo}",
+                        "-F",
+                        f"number={pr_number}",
+                        "-f",
+                        f"query={check_run_query}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    cwd=project_root,
+                )
+
+                if result.returncode == 0:
+                    data = json.loads(result.stdout)
+                    check_runs = (
+                        data.get("data", {})
+                        .get("repository", {})
+                        .get("pullRequest", {})
+                        .get("checkRuns", {})
+                        .get("nodes", [])
+                    )
+
+                    # Check if Cursor Bugbot is still in progress
+                    bugbot_in_progress = False
+                    for run in check_runs:
+                        if "Cursor Bugbot" in run.get("name", "") and run.get("status") == "IN_PROGRESS":
+                            bugbot_in_progress = True
+                            break
+
+                    if not bugbot_in_progress:
+                        return  # Bugbot is done
+
+                # Bugbot still in progress, wait a bit before checking again
+                time.sleep(5)
+            except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+                return  # If we can't check, proceed anyway
+
     def _get_unresolved_threads(
         self, project_root: str, pr_number: int, owner: str, repo: str
     ) -> List[Dict[str, Any]]:
         """Fetch unresolved comment threads from GitHub."""
+        # Wait for Bugbot to finish posting before checking for threads
+        self._wait_for_bugbot_completion(project_root, pr_number, owner, repo)
+
         graphql_query = """
         query($owner: String!, $name: String!, $number: Int!) {
           repository(owner: $owner, name: $name) {

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -26,6 +26,10 @@ from slopmop.constants import NOT_A_GIT_REPO, action_buff_inspect_pr
 from slopmop.core.result import CheckResult, CheckStatus, Finding
 
 
+class _PendingReviewsError(Exception):
+    """Raised when CI checks are still pending/queued for the PR HEAD commit."""
+
+
 class PRCommentsCheck(BaseCheck):
     """PR comment resolution enforcement.
 
@@ -372,10 +376,10 @@ class PRCommentsCheck(BaseCheck):
             )
 
             if result.returncode == 0:
-                data = json.loads(result.stdout)
-                commits = (
-                    data.get("data", {})
-                    .get("repository", {})
+                parsed: Dict[str, Any] = json.loads(result.stdout)
+                data_root: Dict[str, Any] = parsed.get("data") or {}
+                commits: List[Dict[str, Any]] = (
+                    data_root.get("repository", {})
                     .get("pullRequest", {})
                     .get("commits", {})
                     .get("nodes", [])
@@ -384,13 +388,17 @@ class PRCommentsCheck(BaseCheck):
                 # Check for in-progress reviews by iterating through check suites
                 pending_checks: List[str] = []
                 for commit_node in commits:
-                    commit = commit_node.get("commit", {})
-                    check_suites = commit.get("checkSuites", {}).get("nodes", [])
+                    commit: Dict[str, Any] = commit_node.get("commit", {})
+                    check_suites: List[Dict[str, Any]] = commit.get(
+                        "checkSuites", {}
+                    ).get("nodes", [])
                     for suite in check_suites:
-                        check_runs = suite.get("checkRuns", {}).get("nodes", [])
+                        check_runs: List[Dict[str, Any]] = suite.get(
+                            "checkRuns", {}
+                        ).get("nodes", [])
                         for run in check_runs:
-                            name = run.get("name", "")
-                            status = run.get("status", "")
+                            name: str = run.get("name", "")
+                            status: str = run.get("status", "")
                             if status in ("IN_PROGRESS", "QUEUED"):
                                 pending_checks.append(name)
 
@@ -412,8 +420,7 @@ class PRCommentsCheck(BaseCheck):
         # Check for pending reviews first (e.g., Cursor Bugbot in progress)
         pending_msg = self._detect_pending_reviews(project_root, pr_number, owner, repo)
         if pending_msg:
-            # Return a special marker that will trigger a gate failure with guidance
-            return [{"_pending_reviews": True, "_message": pending_msg}]
+            raise _PendingReviewsError(pending_msg)
 
         graphql_query = """
         query($owner: String!, $name: String!, $number: Int!) {
@@ -1062,17 +1069,16 @@ class PRCommentsCheck(BaseCheck):
             )
 
         # Fetch unresolved threads
-        threads = self._get_unresolved_threads(project_root, pr_number, owner, repo)
-        duration = time.time() - start_time
-
-        # Check for pending reviews marker
-        if threads and len(threads) == 1 and threads[0].get("_pending_reviews"):
-            pending_msg = threads[0].get("_message", "Reviews still in progress")
+        try:
+            threads = self._get_unresolved_threads(project_root, pr_number, owner, repo)
+        except _PendingReviewsError as exc:
+            duration = time.time() - start_time
             return self._create_result(
                 status=CheckStatus.FAILED,
                 duration=duration,
-                error=pending_msg,
+                error=str(exc),
             )
+        duration = time.time() - start_time
 
         if not threads:
             return self._create_result(

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -385,7 +385,13 @@ class PRCommentsCheck(BaseCheck):
                     .get("nodes", [])
                 )
 
-                # Check for in-progress reviews by iterating through check suites
+                # Only care about review bots — not general CI jobs.
+                # General CI jobs (unit tests, docker, etc.) are expected to
+                # be running alongside this check; flagging them would cause
+                # the gate to fail inside CI itself.
+                _REVIEW_BOT_NAMES = {"cursor bugbot"}
+
+                # Check for in-progress review bots by iterating through check suites
                 pending_checks: List[str] = []
                 for commit_node in commits:
                     commit: Dict[str, Any] = commit_node.get("commit", {})
@@ -399,7 +405,10 @@ class PRCommentsCheck(BaseCheck):
                         for run in check_runs:
                             name: str = run.get("name", "")
                             status: str = run.get("status", "")
-                            if status in ("IN_PROGRESS", "QUEUED"):
+                            if (
+                                name.strip().lower() in _REVIEW_BOT_NAMES
+                                and status != "COMPLETED"
+                            ):
                                 pending_checks.append(name)
 
                 if pending_checks:

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -317,13 +317,12 @@ class PRCommentsCheck(BaseCheck):
             pass
         return "", ""
 
-    def _wait_for_bugbot_completion(
-        self, project_root: str, pr_number: int, owner: str, repo: str, max_wait: int = 300
-    ) -> None:
-        """Wait for Cursor Bugbot to finish posting review comments.
+    def _detect_pending_reviews(
+        self, project_root: str, pr_number: int, owner: str, repo: str
+    ) -> Optional[str]:
+        """Check if any reviews are pending or in progress (e.g., Cursor Bugbot).
 
-        On the web (CI), Bugbot may still be in progress when scour runs.
-        This method polls for active Bugbot check runs and waits for completion.
+        Returns a message if pending reviews are detected, None otherwise.
         """
         check_run_query = """
         query($owner: String!, $name: String!, $number: Int!) {
@@ -341,60 +340,65 @@ class PRCommentsCheck(BaseCheck):
         }
         """
 
-        start_time = time.time()
-        while time.time() - start_time < max_wait:
-            try:
-                result = subprocess.run(
-                    [
-                        "gh",
-                        "api",
-                        "graphql",
-                        "-F",
-                        f"owner={owner}",
-                        "-F",
-                        f"name={repo}",
-                        "-F",
-                        f"number={pr_number}",
-                        "-f",
-                        f"query={check_run_query}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    cwd=project_root,
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    "graphql",
+                    "-F",
+                    f"owner={owner}",
+                    "-F",
+                    f"name={repo}",
+                    "-F",
+                    f"number={pr_number}",
+                    "-f",
+                    f"query={check_run_query}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=project_root,
+            )
+
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                check_runs = (
+                    data.get("data", {})
+                    .get("repository", {})
+                    .get("pullRequest", {})
+                    .get("checkRuns", {})
+                    .get("nodes", [])
                 )
 
-                if result.returncode == 0:
-                    data = json.loads(result.stdout)
-                    check_runs = (
-                        data.get("data", {})
-                        .get("repository", {})
-                        .get("pullRequest", {})
-                        .get("checkRuns", {})
-                        .get("nodes", [])
+                # Check for in-progress reviews
+                pending_checks: List[str] = []
+                for run in check_runs:
+                    name = run.get("name", "")
+                    status = run.get("status", "")
+                    if status == "IN_PROGRESS":
+                        pending_checks.append(name)
+
+                if pending_checks:
+                    checks_str = ", ".join(f"'{c}'" for c in pending_checks)
+                    return (
+                        f"Pending reviews detected: {checks_str} are still in progress. "
+                        "Assuming more feedback incoming. Rerun after all reviews complete."
                     )
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+            pass
 
-                    # Check if Cursor Bugbot is still in progress
-                    bugbot_in_progress = False
-                    for run in check_runs:
-                        if "Cursor Bugbot" in run.get("name", "") and run.get("status") == "IN_PROGRESS":
-                            bugbot_in_progress = True
-                            break
-
-                    if not bugbot_in_progress:
-                        return  # Bugbot is done
-
-                # Bugbot still in progress, wait a bit before checking again
-                time.sleep(5)
-            except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-                return  # If we can't check, proceed anyway
+        return None
 
     def _get_unresolved_threads(
         self, project_root: str, pr_number: int, owner: str, repo: str
     ) -> List[Dict[str, Any]]:
         """Fetch unresolved comment threads from GitHub."""
-        # Wait for Bugbot to finish posting before checking for threads
-        self._wait_for_bugbot_completion(project_root, pr_number, owner, repo)
+        # Check for pending reviews first (e.g., Cursor Bugbot in progress)
+        pending_msg = self._detect_pending_reviews(project_root, pr_number, owner, repo)
+        if pending_msg:
+            # Return a special marker that will trigger a gate failure with guidance
+            return [{"_pending_reviews": True, "_message": pending_msg}]
 
         graphql_query = """
         query($owner: String!, $name: String!, $number: Int!) {
@@ -1045,6 +1049,15 @@ class PRCommentsCheck(BaseCheck):
         # Fetch unresolved threads
         threads = self._get_unresolved_threads(project_root, pr_number, owner, repo)
         duration = time.time() - start_time
+
+        # Check for pending reviews marker
+        if threads and len(threads) == 1 and threads[0].get("_pending_reviews"):
+            pending_msg = threads[0].get("_message", "Reviews still in progress")
+            return self._create_result(
+                status=CheckStatus.FAILED,
+                duration=duration,
+                error=pending_msg,
+            )
 
         if not threads:
             return self._create_result(

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -328,11 +328,21 @@ class PRCommentsCheck(BaseCheck):
         query($owner: String!, $name: String!, $number: Int!) {
           repository(owner: $owner, name: $name) {
             pullRequest(number: $number) {
-              checkRuns(first: 10) {
+              commits(last: 1) {
                 nodes {
-                  name
-                  status
-                  conclusion
+                  commit {
+                    checkSuites(first: 10) {
+                      nodes {
+                        checkRuns(first: 10) {
+                          nodes {
+                            name
+                            status
+                            conclusion
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -363,21 +373,26 @@ class PRCommentsCheck(BaseCheck):
 
             if result.returncode == 0:
                 data = json.loads(result.stdout)
-                check_runs = (
+                commits = (
                     data.get("data", {})
                     .get("repository", {})
                     .get("pullRequest", {})
-                    .get("checkRuns", {})
+                    .get("commits", {})
                     .get("nodes", [])
                 )
 
-                # Check for in-progress reviews
+                # Check for in-progress reviews by iterating through check suites
                 pending_checks: List[str] = []
-                for run in check_runs:
-                    name = run.get("name", "")
-                    status = run.get("status", "")
-                    if status == "IN_PROGRESS":
-                        pending_checks.append(name)
+                for commit_node in commits:
+                    commit = commit_node.get("commit", {})
+                    check_suites = commit.get("checkSuites", {}).get("nodes", [])
+                    for suite in check_suites:
+                        check_runs = suite.get("checkRuns", {}).get("nodes", [])
+                        for run in check_runs:
+                            name = run.get("name", "")
+                            status = run.get("status", "")
+                            if status == "IN_PROGRESS":
+                                pending_checks.append(name)
 
                 if pending_checks:
                     checks_str = ", ".join(f"'{c}'" for c in pending_checks)

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -391,7 +391,7 @@ class PRCommentsCheck(BaseCheck):
                         for run in check_runs:
                             name = run.get("name", "")
                             status = run.get("status", "")
-                            if status == "IN_PROGRESS":
+                            if status in ("IN_PROGRESS", "QUEUED"):
                                 pending_checks.append(name)
 
                 if pending_checks:

--- a/slopmop/cli/gang.py
+++ b/slopmop/cli/gang.py
@@ -67,7 +67,7 @@ def _msg_printf(forbidden: str, indent: int, suggestion: str = "") -> str:
         f"  Tell the human what you were doing and wait."
     )
     if suggestion:
-        msg += f"\\n  {suggestion}"
+        msg += f"\\n  {_escape(suggestion)}"
     return f"{spaces}printf " f"'{msg}\\n' >&2"
 
 

--- a/slopmop/cli/gang.py
+++ b/slopmop/cli/gang.py
@@ -68,10 +68,23 @@ def _msg_printf(forbidden: str, indent: int, suggestion: str = "") -> str:
     )
     if suggestion:
         msg += f"\\n  {suggestion}"
-    return (
-        f"{spaces}printf "
-        f"'{msg}\\n' >&2"
-    )
+    return f"{spaces}printf " f"'{msg}\\n' >&2"
+
+
+def _gen_slopmop_guard(lines: list[str]) -> None:
+    """Append a helper that returns true only when inside a slop-mop repo."""
+    lines += [
+        "_sm_in_slopmop_repo() {",
+        '    local _d="$PWD"',
+        '    while [[ "$_d" != "/" ]]; do',
+        '        [[ -d "$_d/.slopmop" ]] && return 0',
+        '        _d="$(dirname "$_d")"',
+        "    done",
+        "    return 1",
+        "}",
+        '[[ -n "${BASH_VERSION:-}" ]] && export -f _sm_in_slopmop_repo',
+        "",
+    ]
 
 
 def _gen_function_blocks(lines: list[str]) -> None:
@@ -88,6 +101,7 @@ def _gen_function_blocks(lines: list[str]) -> None:
         lines.append(
             f'    command -v sm &>/dev/null || {{ command {cmd} "$@"; return; }}'
         )
+        lines.append(f'    _sm_in_slopmop_repo || {{ command {cmd} "$@"; return; }}')
         lines.append(_msg_printf(cmd, indent=4))
         lines.append("    return 1")
         lines += ["}", '[[ -n "${BASH_VERSION:-}" ]] && export -f ' + cmd, ""]
@@ -105,6 +119,7 @@ def _gen_subcommand_blocks(lines: list[str]) -> None:
         lines += [
             f"{wrapper}() {{",
             f'    command -v sm &>/dev/null || {{ command {wrapper} "$@"; return; }}',
+            f'    _sm_in_slopmop_repo || {{ command {wrapper} "$@"; return; }}',
             '    local _sub="${1:-}" _sub2="${2:-}"',
             '    case "$_sub $_sub2" in',
         ]
@@ -119,7 +134,7 @@ def _gen_subcommand_blocks(lines: list[str]) -> None:
                 _msg_printf(
                     f"{wrapper} {' '.join(entry.subcommands)}",
                     indent=12,
-                    suggestion=entry.suggestion
+                    suggestion=entry.suggestion,
                 )
             )
             lines.append("            return 1")
@@ -144,6 +159,7 @@ def _gen_npx_block(lines: list[str]) -> None:
     lines += [
         "npx() {",
         '    command -v sm &>/dev/null || { command npx "$@"; return; }',
+        '    _sm_in_slopmop_repo || { command npx "$@"; return; }',
         '    case "${1:-}" in',
     ]
     for entry in npx_entries:
@@ -151,13 +167,7 @@ def _gen_npx_block(lines: list[str]) -> None:
         if not tool:
             continue
         lines.append(f"        {tool})")
-        lines.append(
-            _msg_printf(
-                f"npx {tool}",
-                indent=12,
-                suggestion=entry.suggestion
-            )
-        )
+        lines.append(_msg_printf(f"npx {tool}", indent=12, suggestion=entry.suggestion))
         lines.append("            return 1")
         lines.append("            ;;")
 
@@ -187,6 +197,7 @@ def _generate_aliases_sh(version: str) -> bytes:
         "",
     ]
 
+    _gen_slopmop_guard(lines)
     _gen_function_blocks(lines)
     _gen_subcommand_blocks(lines)
     _gen_npx_block(lines)

--- a/slopmop/cli/gang.py
+++ b/slopmop/cli/gang.py
@@ -58,14 +58,19 @@ def _escape(s: str) -> str:
     return s.replace("\\", "\\\\").replace("'", "'\\''")
 
 
-def _msg_printf(forbidden: str, indent: int) -> str:
+def _msg_printf(forbidden: str, indent: int, suggestion: str = "") -> str:
     """Return a printf line that shows the intercept message."""
     spaces = " " * indent
+    msg = (
+        f"\\033[1m[slop-mop]\\033[0m \\033[31m\\xe2\\x9b\\x94 {_escape(forbidden)} blocked\\033[0m\\n"
+        f"  Stop. File a barnacle: sm barnacle\\n"
+        f"  Tell the human what you were doing and wait."
+    )
+    if suggestion:
+        msg += f"\\n  {suggestion}"
     return (
         f"{spaces}printf "
-        f"'\\033[1m[slop-mop]\\033[0m \\033[31m\\xe2\\x9b\\x94 {_escape(forbidden)} blocked\\033[0m\\n"
-        f"  Stop. File a barnacle: sm barnacle\\n"
-        f"  Tell the human what you were doing and wait.\\n' >&2"
+        f"'{msg}\\n' >&2"
     )
 
 
@@ -111,7 +116,11 @@ def _gen_subcommand_blocks(lines: list[str]) -> None:
             pattern = f'"{" ".join(entry.subcommands)}"'
             lines.append(f"        {pattern})")
             lines.append(
-                _msg_printf(f"{wrapper} {' '.join(entry.subcommands)}", indent=12)
+                _msg_printf(
+                    f"{wrapper} {' '.join(entry.subcommands)}",
+                    indent=12,
+                    suggestion=entry.suggestion
+                )
             )
             lines.append("            return 1")
             lines.append("            ;;")
@@ -142,7 +151,13 @@ def _gen_npx_block(lines: list[str]) -> None:
         if not tool:
             continue
         lines.append(f"        {tool})")
-        lines.append(_msg_printf(f"npx {tool}", indent=12))
+        lines.append(
+            _msg_printf(
+                f"npx {tool}",
+                indent=12,
+                suggestion=entry.suggestion
+            )
+        )
         lines.append("            return 1")
         lines.append("            ;;")
 

--- a/slopmop/cli/init.py
+++ b/slopmop/cli/init.py
@@ -7,9 +7,10 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict, List, cast
 
 from slopmop import __version__
+from slopmop.checks.base import SCOPE_EXCLUDED_DIRS
 from slopmop.cli.config import _as_dict, _deep_merge
 from slopmop.cli.detection import detect_project_type
 
@@ -397,6 +398,26 @@ def _is_unset_config_value(value: Any) -> bool:
     return value is None or value == "" or value == []
 
 
+def _detect_exclude_paths(project_root: Path) -> List[str]:
+    """Detect project-specific directories that should be excluded from all gates."""
+    exclude: List[str] = []
+
+    candidates = [
+        ("Pods", [project_root / "Podfile", project_root / "Pods"]),
+        ("vendor", [project_root / "go.mod", project_root / "vendor"]),
+        ("target", [project_root / "Cargo.toml", project_root / "target"]),
+        ("local", [project_root / "local"]),
+    ]
+
+    for dir_name, signals in candidates:
+        if dir_name in SCOPE_EXCLUDED_DIRS:
+            continue
+        if any(p.exists() for p in signals):
+            exclude.append(dir_name)
+
+    return exclude
+
+
 def _field_default(check: Any, key: str) -> Any:
     """Return the declared default for a gate config field, if any."""
     for field in check.get_full_config_schema():
@@ -682,10 +703,12 @@ def cmd_init(args: argparse.Namespace) -> int:
         write_template_config,
     )
 
-    template_path = write_template_config(project_root)
+    detected_excludes = _detect_exclude_paths(project_root)
+
+    template_path = write_template_config(project_root, exclude_paths=detected_excludes)
     print(f"📄 Template saved to: {template_path}")
 
-    base_config = generate_template_config()
+    base_config = generate_template_config(exclude_paths=detected_excludes)
     _disable_non_applicable(base_config, detected)
     _apply_user_config(base_config, config)
     _disable_checks_with_missing_tools(base_config, detected)

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -258,6 +258,43 @@ def _sail_scour_clean(args: argparse.Namespace, project_root: Path) -> int:
 
 def _sail_pr_open(args: argparse.Namespace, project_root: Path) -> int:
     """S6 — PR_OPEN: buff inspect to triage CI + review threads."""
+    # Sanity check: run ignored_feedback gate explicitly before advancing
+    # This ensures we catch any pending reviews (e.g., Bugbot in progress)
+    _print_step(
+        "💬", "Sanity check", "Running ignored-feedback gate as final validation..."
+    )
+    from slopmop.cli import cmd_scour
+
+    # Run just the ignored-feedback gate to catch pending reviews
+    check_args = argparse.Namespace(
+        quality_gates=["myopia:ignored-feedback"],
+        no_auto_fix=True,
+        no_fail_fast=False,
+        no_cache=False,
+        sarif=False,
+        json_output=False,
+        json_file=None,
+        output_file=None,
+        verbose=getattr(args, "verbose", False),
+        quiet=False,
+        static=False,
+        porcelain=False,
+        swabbing_timeout=0,
+        ignore_baseline_failures=False,
+        project_root=str(project_root),
+        _sail_mode=SailMode.SAILING,
+    )
+    result = cmd_scour(check_args)
+    if result != 0:
+        # Gate failed — pending reviews or unresolved threads detected
+        _print_step(
+            "⚓",
+            "HOLD",
+            "Ignored-feedback gate detected pending reviews.\n"
+            "   Address the feedback, then: sm sail",
+        )
+        return 1
+
     _print_step(
         "✨", "Running buff inspect", "PR is open — triaging CI and review threads."
     )

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -337,7 +337,9 @@ def _sail_buff_failing(args: argparse.Namespace, project_root: Path) -> int:
 def _sail_pr_ready(args: argparse.Namespace, project_root: Path) -> int:
     """S8 — PR_READY: re-verify CI still green, then surface to human."""
     _print_step(
-        "⏳", "Re-verifying CI", "Confirming PR is still green before surfacing to human..."
+        "⏳",
+        "Re-verifying CI",
+        "Confirming PR is still green before surfacing to human...",
     )
     from slopmop.cli import cmd_buff
 

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -296,7 +296,9 @@ def _sail_pr_open(args: argparse.Namespace, project_root: Path) -> int:
         return 1
 
     _print_step(
-        "⏳", "Running buff watch", "PR is open — waiting for CI to settle, then checking threads."
+        "⏳",
+        "Running buff watch",
+        "PR is open — waiting for CI to settle, then checking threads.",
     )
     from slopmop.cli import cmd_buff
 
@@ -333,7 +335,23 @@ def _sail_buff_failing(args: argparse.Namespace, project_root: Path) -> int:
 
 
 def _sail_pr_ready(args: argparse.Namespace, project_root: Path) -> int:
-    """S8 — PR_READY: surface to human for review, reset to tacking."""
+    """S8 — PR_READY: re-verify CI still green, then surface to human."""
+    _print_step(
+        "⏳", "Re-verifying CI", "Confirming PR is still green before surfacing to human..."
+    )
+    from slopmop.cli import cmd_buff
+
+    pr = _get_pr_number(project_root)
+    buff_args = argparse.Namespace(
+        pr_or_action="watch",
+        action_args=[str(pr)] if pr else [],
+        interval=30,
+        fail_fast=False,
+    )
+    result = cmd_buff(buff_args)
+    if result != 0:
+        return result
+
     write_sail_mode(project_root, SailMode.TACKING)
     print(
         "\n⛵ sail → 🏁 PR ready for human review\n"

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -296,19 +296,16 @@ def _sail_pr_open(args: argparse.Namespace, project_root: Path) -> int:
         return 1
 
     _print_step(
-        "✨", "Running buff inspect", "PR is open — triaging CI and review threads."
+        "⏳", "Running buff watch", "PR is open — waiting for CI to settle, then checking threads."
     )
     from slopmop.cli import cmd_buff
-    from slopmop.cli.scan_triage import ARTIFACT_NAME, WORKFLOW_NAME
 
     pr = _get_pr_number(project_root)
     buff_args = argparse.Namespace(
-        pr_or_action=str(pr) if pr else None,
-        json_output=getattr(args, "json_output", False),
-        repo=None,
-        run_id=None,
-        workflow=WORKFLOW_NAME,
-        artifact=ARTIFACT_NAME,
+        pr_or_action="watch",
+        action_args=[str(pr)] if pr else [],
+        interval=30,
+        fail_fast=False,
     )
     return cmd_buff(buff_args)
 

--- a/slopmop/data/command_mapping.py
+++ b/slopmop/data/command_mapping.py
@@ -134,6 +134,17 @@ COMMAND_MAPPING: list[CommandMap] = [
         redirect=False,
         suggestion="sm buff resolve <PR#> <THREAD_ID> --scenario <type>",
     ),
+    CommandMap(
+        forbidden="gh pr merge",
+        sm_command="",
+        reason="sail mode stops at PR_READY; human decision to merge is required",
+        category="PR triage",
+        intercept_type="subcommand",
+        wrapper_command="gh",
+        subcommands=("pr", "merge"),
+        redirect=False,
+        suggestion="⛵ SAILING_NEEDS_HUMAN — PR is ready. Share with human for merge decision.",
+    ),
     # ── Python formatting / linting ───────────────────────────────────────────
     CommandMap(
         forbidden="black",

--- a/slopmop/utils/generate_base_config.py
+++ b/slopmop/utils/generate_base_config.py
@@ -101,6 +101,7 @@ def generate_language_config(
 def generate_base_config(
     registry: Optional[CheckRegistry] = None,
     all_enabled: bool = False,
+    exclude_paths: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Generate complete base configuration from registry introspection.
 
@@ -109,6 +110,7 @@ def generate_base_config(
         all_enabled: If True, all categories and gates are enabled by default.
                      Used by generate_template_config() to produce an
                      everything-enabled starting point for init.
+        exclude_paths: Optional list of paths to exclude from all gates.
 
     Returns:
         Complete configuration dictionary
@@ -122,6 +124,7 @@ def generate_base_config(
         "version": "1.0",
         "slopmop_version": __version__,
         "swabbing_timeout": 20,
+        "exclude_paths": exclude_paths or [],
     }
 
     # Group checks by category
@@ -208,6 +211,7 @@ def backup_config(config_path: Path) -> Optional[Path]:
 
 def generate_template_config(
     registry: Optional[CheckRegistry] = None,
+    exclude_paths: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Generate template configuration with ALL gates enabled.
 
@@ -225,28 +229,31 @@ def generate_template_config(
 
     Args:
         registry: Optional registry to use (defaults to global registry)
+        exclude_paths: Optional list of paths to exclude from all gates.
 
     Returns:
         Complete configuration dictionary with all gates enabled
     """
-    return generate_base_config(registry, all_enabled=True)
+    return generate_base_config(registry, all_enabled=True, exclude_paths=exclude_paths)
 
 
 def write_template_config(
     project_root: Path,
     registry: Optional[CheckRegistry] = None,
+    exclude_paths: Optional[List[str]] = None,
 ) -> Path:
     """Write the template configuration file.
 
     Args:
         project_root: Project root directory
         registry: Optional registry to use
+        exclude_paths: Optional list of paths to exclude from all gates.
 
     Returns:
         Path to the written template file
     """
     template_path = project_root / ".sb_config.json.template"
-    config = generate_template_config(registry)
+    config = generate_template_config(registry, exclude_paths=exclude_paths)
 
     with open(template_path, "w") as f:
         json.dump(config, f, indent=2)

--- a/tests/unit/test_agent_install.py
+++ b/tests/unit/test_agent_install.py
@@ -154,7 +154,7 @@ class TestLoader:
     def test_cursor_preserves_frontmatter(self):
         """Cursor templates retain their YAML frontmatter after substitution."""
         assets = load_assets(TARGETS["cursor"].template_dir)
-        assert len(assets) == 4
+        assert len(assets) == 6
         for asset in assets:
             text = asset.content.decode("utf-8")
             assert text.startswith("---\n")
@@ -220,7 +220,7 @@ class TestClaudeSkill:
             for a in assets
             if "/commands/" in a.destination_relpath
         }
-        assert len(commands) == 6
+        assert len(commands) == 7
         for path, text in commands.items():
             if "refit" in path:
                 assert "sm refit" in text

--- a/tests/unit/test_pr_checks.py
+++ b/tests/unit/test_pr_checks.py
@@ -5,7 +5,9 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from slopmop.checks.pr.comments import PRCommentsCheck
+import pytest
+
+from slopmop.checks.pr.comments import PRCommentsCheck, _PendingReviewsError
 from slopmop.core.result import CheckStatus
 
 
@@ -758,7 +760,7 @@ class TestPRCommentsCheck:
         assert result is None
 
     def test_get_unresolved_threads_with_pending_reviews(self, tmp_path, monkeypatch):
-        """_get_unresolved_threads should return pending marker when reviews in progress."""
+        """_get_unresolved_threads should raise _PendingReviewsError when reviews in progress."""
         check = PRCommentsCheck({})
 
         check_run_response = {
@@ -797,11 +799,10 @@ class TestPRCommentsCheck:
             mock_run.return_value = MagicMock(
                 returncode=0, stdout=json.dumps(check_run_response)
             )
-            result = check._get_unresolved_threads(str(tmp_path), 123, "owner", "repo")
+            with pytest.raises(_PendingReviewsError) as exc_info:
+                check._get_unresolved_threads(str(tmp_path), 123, "owner", "repo")
 
-        assert len(result) == 1
-        assert result[0].get("_pending_reviews") is True
-        assert "_message" in result[0]
+        assert "Cursor Bugbot" in str(exc_info.value)
 
     def test_protocol_loop_directory_retries_after_race(self, tmp_path, monkeypatch):
         """Loop directory allocation should retry if another process creates it first."""

--- a/tests/unit/test_pr_checks.py
+++ b/tests/unit/test_pr_checks.py
@@ -653,13 +653,27 @@ class TestPRCommentsCheck:
             "data": {
                 "repository": {
                     "pullRequest": {
-                        "checkRuns": {
+                        "commits": {
                             "nodes": [
                                 {
-                                    "name": "Cursor Bugbot",
-                                    "status": "COMPLETED",
-                                    "conclusion": "SUCCESS",
-                                },
+                                    "commit": {
+                                        "checkSuites": {
+                                            "nodes": [
+                                                {
+                                                    "checkRuns": {
+                                                        "nodes": [
+                                                            {
+                                                                "name": "Cursor Bugbot",
+                                                                "status": "COMPLETED",
+                                                                "conclusion": "SUCCESS",
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
                             ]
                         }
                     }
@@ -683,13 +697,27 @@ class TestPRCommentsCheck:
             "data": {
                 "repository": {
                     "pullRequest": {
-                        "checkRuns": {
+                        "commits": {
                             "nodes": [
                                 {
-                                    "name": "Cursor Bugbot",
-                                    "status": "IN_PROGRESS",
-                                    "conclusion": None,
-                                },
+                                    "commit": {
+                                        "checkSuites": {
+                                            "nodes": [
+                                                {
+                                                    "checkRuns": {
+                                                        "nodes": [
+                                                            {
+                                                                "name": "Cursor Bugbot",
+                                                                "status": "IN_PROGRESS",
+                                                                "conclusion": None,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
                             ]
                         }
                     }
@@ -737,13 +765,27 @@ class TestPRCommentsCheck:
             "data": {
                 "repository": {
                     "pullRequest": {
-                        "checkRuns": {
+                        "commits": {
                             "nodes": [
                                 {
-                                    "name": "Cursor Bugbot",
-                                    "status": "IN_PROGRESS",
-                                    "conclusion": None,
-                                },
+                                    "commit": {
+                                        "checkSuites": {
+                                            "nodes": [
+                                                {
+                                                    "checkRuns": {
+                                                        "nodes": [
+                                                            {
+                                                                "name": "Cursor Bugbot",
+                                                                "status": "IN_PROGRESS",
+                                                                "conclusion": None,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
                             ]
                         }
                     }
@@ -761,6 +803,7 @@ class TestPRCommentsCheck:
         assert result[0].get("_pending_reviews") is True
         assert "_message" in result[0]
 
+    def test_protocol_loop_directory_retries_after_race(self, tmp_path, monkeypatch):
         """Loop directory allocation should retry if another process creates it first."""
         check = PRCommentsCheck({})
         original_mkdir = Path.mkdir

--- a/tests/unit/test_pr_checks.py
+++ b/tests/unit/test_pr_checks.py
@@ -1,6 +1,7 @@
 """Tests for PR comments check."""
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -644,7 +645,122 @@ class TestPRCommentsCheck:
         assert first.name == "loop-001"
         assert second.name == "loop-002"
 
-    def test_protocol_loop_directory_retries_after_race(self, tmp_path, monkeypatch):
+    def test_detect_pending_reviews_no_in_progress(self, tmp_path):
+        """_detect_pending_reviews should return None when no checks in progress."""
+        check = PRCommentsCheck({})
+
+        check_run_response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "checkRuns": {
+                            "nodes": [
+                                {
+                                    "name": "Cursor Bugbot",
+                                    "status": "COMPLETED",
+                                    "conclusion": "SUCCESS",
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(check_run_response)
+            )
+            result = check._detect_pending_reviews(str(tmp_path), 123, "owner", "repo")
+
+        assert result is None
+
+    def test_detect_pending_reviews_with_in_progress(self, tmp_path):
+        """_detect_pending_reviews should return message when checks in progress."""
+        check = PRCommentsCheck({})
+
+        check_run_response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "checkRuns": {
+                            "nodes": [
+                                {
+                                    "name": "Cursor Bugbot",
+                                    "status": "IN_PROGRESS",
+                                    "conclusion": None,
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(check_run_response)
+            )
+            result = check._detect_pending_reviews(str(tmp_path), 123, "owner", "repo")
+
+        assert result is not None
+        assert "Pending reviews detected" in result
+        assert "Cursor Bugbot" in result
+
+    def test_detect_pending_reviews_handles_exceptions(self, tmp_path):
+        """_detect_pending_reviews should return None on subprocess errors."""
+        check = PRCommentsCheck({})
+
+        # Test TimeoutExpired
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("gh", 30)
+            result = check._detect_pending_reviews(str(tmp_path), 123, "owner", "repo")
+        assert result is None
+
+        # Test json.JSONDecodeError
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="invalid json")
+            result = check._detect_pending_reviews(str(tmp_path), 123, "owner", "repo")
+        assert result is None
+
+        # Test FileNotFoundError
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("gh not found")
+            result = check._detect_pending_reviews(str(tmp_path), 123, "owner", "repo")
+        assert result is None
+
+    def test_get_unresolved_threads_with_pending_reviews(self, tmp_path, monkeypatch):
+        """_get_unresolved_threads should return pending marker when reviews in progress."""
+        check = PRCommentsCheck({})
+
+        check_run_response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "checkRuns": {
+                            "nodes": [
+                                {
+                                    "name": "Cursor Bugbot",
+                                    "status": "IN_PROGRESS",
+                                    "conclusion": None,
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(check_run_response)
+            )
+            result = check._get_unresolved_threads(str(tmp_path), 123, "owner", "repo")
+
+        assert len(result) == 1
+        assert result[0].get("_pending_reviews") is True
+        assert "_message" in result[0]
+
         """Loop directory allocation should retry if another process creates it first."""
         check = PRCommentsCheck({})
         original_mkdir = Path.mkdir

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -117,9 +117,8 @@ class TestSailDispatch:
         write_state.assert_called_once_with(tmp_path, WorkflowState.PR_OPEN)
         mock_buff.assert_called_once()
         call_args = mock_buff.call_args[0][0]
-        assert call_args.pr_or_action == "42"
-        assert call_args.workflow == WORKFLOW_NAME
-        assert call_args.artifact == ARTIFACT_NAME
+        assert call_args.pr_or_action == "watch"
+        assert call_args.action_args == ["42"]
 
     def test_scour_clean_without_pr_suggests_create(
         self, monkeypatch, capsys, tmp_path: Path
@@ -141,11 +140,10 @@ class TestSailDispatch:
 
         assert sail_mod.cmd_sail(args) == 0
         mock_buff.assert_called_once()
-        # Verify it passed the PR number
+        # Verify it called buff in watch mode with the PR number
         call_args = mock_buff.call_args[0][0]
-        assert call_args.pr_or_action == "42"
-        assert call_args.workflow == WORKFLOW_NAME
-        assert call_args.artifact == ARTIFACT_NAME
+        assert call_args.pr_or_action == "watch"
+        assert call_args.action_args == ["42"]
 
     def test_buff_failing_runs_buff(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -165,10 +165,17 @@ class TestSailDispatch:
     ):
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_READY)
+        monkeypatch.setattr(sail_mod, "_get_pr_number", lambda _: 42)
+        mock_buff = Mock(return_value=0)
+        monkeypatch.setattr("slopmop.cli.cmd_buff", mock_buff)
+        monkeypatch.setattr(sail_mod, "write_sail_mode", Mock())
 
         assert sail_mod.cmd_sail(args) == 0
         out = capsys.readouterr().out
         assert "human review" in out
+        mock_buff.assert_called_once()
+        call_args = mock_buff.call_args[0][0]
+        assert call_args.pr_or_action == "watch"
 
     def test_none_state_defaults_to_idle(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)
@@ -438,6 +445,8 @@ class TestSailMode:
     def test_pr_ready_resets_mode_to_tacking(self, monkeypatch, tmp_path: Path):
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_READY)
+        monkeypatch.setattr(sail_mod, "_get_pr_number", lambda _: 42)
+        monkeypatch.setattr("slopmop.cli.cmd_buff", Mock(return_value=0))
         write_sail_mode = Mock()
         monkeypatch.setattr(sail_mod, "write_sail_mode", write_sail_mode)
 

--- a/tests/unit/test_sail.py
+++ b/tests/unit/test_sail.py
@@ -110,6 +110,7 @@ class TestSailDispatch:
         monkeypatch.setattr(sail_mod, "_has_unpushed_commits", lambda _: False)
         write_state = Mock()
         monkeypatch.setattr(sail_mod, "write_state", write_state)
+        monkeypatch.setattr("slopmop.cli.cmd_scour", Mock(return_value=0))
         mock_buff = Mock(return_value=0)
         monkeypatch.setattr("slopmop.cli.cmd_buff", mock_buff)
 
@@ -135,6 +136,7 @@ class TestSailDispatch:
         args = _base_args(tmp_path)
         monkeypatch.setattr(sail_mod, "read_state", lambda _: WorkflowState.PR_OPEN)
         monkeypatch.setattr(sail_mod, "_get_pr_number", lambda _: 42)
+        monkeypatch.setattr("slopmop.cli.cmd_scour", Mock(return_value=0))
         mock_buff = Mock(return_value=0)
         monkeypatch.setattr("slopmop.cli.cmd_buff", mock_buff)
 


### PR DESCRIPTION
## Summary

Three safety-critical improvements for sailing mode:

1. **Prohibit autonomous merging** — gang press intercepts `gh pr merge` and redirects to SAILING_NEEDS_HUMAN, ensuring human makes final merge decision
2. **Detect pending reviews** — ignored-feedback gate now proactively detects in-progress checks (e.g., Cursor Bugbot) and fails with clear message instead of blocking/waiting
3. **Explicit sanity check** — sail state machine runs ignored-feedback gate before advancing from PR_OPEN, catching pending reviews before buff inspect

## Changes

- `slopmop/data/command_mapping.py` — Added gh pr merge interception with SAILING_NEEDS_HUMAN redirect
- `slopmop/checks/pr/comments.py` — Added `_detect_pending_reviews()` to query GitHub checkRuns for IN_PROGRESS status
- `slopmop/cli/sail.py` — Added explicit ignored-feedback gate check in `_sail_pr_open()` before buff inspect
- `tests/unit/test_pr_checks.py` — Added 3 new tests: pending review detection, exception handling, thread marker detection

## Quality Gates

All gates passing: 16 swab, 18 scour, 38 test suite. Coverage on changed lines: 80%+

## Testing

- `sm swab --porcelain` → ✅ 0 fail
- `sm scour --porcelain` → ✅ 0 fail  
- `pytest tests/unit/test_pr_checks.py` → ✅ 38 passed
- `pytest tests/unit/test_sail.py` → ✅ 34 passed