### PR TITLE
feat(captain): add wake-angry-drunk-captain escalation verb

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -23,9 +23,9 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Implementing sailing mode safety features: gh pr merge prohibition, pending review detection",
-    "direction": "Finalize PR #229 (autonomous merge prohibition) after human review; verify full workflow ready for sailing agents",
-    "last_update": "2026-05-28T03:35:00Z"
+    "status": "Built a new last-resort verb that lets an agent wake a human when it has truly run out of moves - it stops and makes the person type an order before anything continues",
+    "direction": "Pushed to a branch for review; no PR opened yet",
+    "last_update": "2026-05-29T14:35:00Z"
   },
   "queue": {
     "active": true,

--- a/.willville.json
+++ b/.willville.json
@@ -24,8 +24,8 @@
   },
   "agent": {
     "status": "Built a new last-resort verb that lets an agent wake a human when it has truly run out of moves - it stops and makes the person type an order before anything continues",
-    "direction": "Pushed to a branch for review; no PR opened yet",
-    "last_update": "2026-05-29T14:35:00Z"
+    "direction": "Opened PR #234 for review; addressing reviewer feedback",
+    "last_update": "2026-05-29T21:10:00Z"
   },
   "queue": {
     "active": true,

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 ## 2026-05-29 Delta: wake-angry-drunk-captain escalation verb
 
-Branch: `feat/captain-verb` (pushed; no PR opened)
+Branch: `feat/captain-verb` (pushed; PR #234 open)
 
 **Work completed:**
 - Added a first-class `wake-angry-drunk-captain` verb — the agent's

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,26 @@
 # Project Status
 
+## 2026-05-29 Delta: wake-angry-drunk-captain escalation verb
+
+Branch: `feat/captain-verb` (pushed; no PR opened)
+
+**Work completed:**
+- Added a first-class `wake-angry-drunk-captain` verb — the agent's
+  last-resort escalation to a human when the maintenance loop is exhausted.
+- The verb refuses with the standing order unless full justification is
+  supplied (objective, verbs-tried, why-stuck, decision).
+- It blocks on an interactive stdin prompt: a human must physically type
+  orders. Refuses with NO CAPTAIN when no human is at the wheel.
+- Summons + orders recorded to `.slopmop/last_captain_summons.md`; `--json`
+  supported. Surfaced in `skills/slopmop/SKILL.md` and a command doc.
+- Extracted shared `markdown_numbered`/`markdown_bullets` into
+  `slopmop.utils`; refactored barnacle to use them (cleared ambiguity-mines
+  duplication flagged by slop-mop's own gate).
+
+**Validation:**
+- `sm swab` clean (16 passed, 1 pre-existing non-blocking config-debt warning).
+- `tests/unit/test_captain.py`: 9 tests passing; barnacle tests unaffected.
+
 ## 2026-05-11 Delta: Build with Claude slopmop submission
 
 - Added discovery topics to `ScienceIsNeato/slop-mop` for Claude plugin indexing.

--- a/commands/sm-wake-angry-drunk-captain.md
+++ b/commands/sm-wake-angry-drunk-captain.md
@@ -1,0 +1,41 @@
+# /sm-wake-angry-drunk-captain — escalate to the human
+
+The last-resort verb. Use it ONLY when the loop is genuinely exhausted:
+barnacles filed, gates green or truly unfixable, and the single remaining move
+is a human judgment call no `sm` verb can make for you.
+
+The standing order is *"do not wake the captain unless there's an emergency."*
+He is asleep. He is angry. He is drunk. He went below decks because the crew
+swore they had it handled. Picture his face before you reach for this.
+
+```bash
+sm wake-angry-drunk-captain \
+  --objective "what you were trying to get done" \
+  --verbs-tried "sm swab — green" \
+  --verbs-tried "sm scour — green" \
+  --verbs-tried "sm buff 42 — CI green, no unresolved threads" \
+  --why-stuck "no remaining verb advances; the blocker is a product/design call" \
+  --decision "the ONE call only a human can make" \
+  --option "approach A" \
+  --option "approach B"
+```
+
+All four of `--objective`, `--verbs-tried`, `--why-stuck`, and `--decision` are
+required. Invoke the verb without them and it reads the standing order back to
+you and refuses — that friction is the point. If you can't fill every line, you
+don't have an emergency, you have unfinished work. Go back to `sm sail`.
+
+A valid summons writes `.slopmop/last_captain_summons.md`, lays the case in
+front of the captain, then **blocks on a prompt and waits for a human to type
+orders**. You cannot satisfy this verb alone — a human must be at the keyboard.
+The orders are recorded to the summons file and the workflow halts with a
+non-zero exit. Carry out the captain's orders; do not keep looping.
+
+If no human is at the wheel (non-interactive terminal), the verb refuses with
+`🥃 NO CAPTAIN AT THE WHEEL` and decides nothing. Run it where the captain can
+answer.
+
+**Prerequisite:** `sm` must be installed. If `command not found`, suggest:
+```bash
+pipx install slopmop[all]
+```

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -8,6 +8,8 @@ description: >-
   — use `sm init --non-interactive` before entering the loop.
   Also trigger when filing issues about slop-mop friction — use
   `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
+  Also trigger when the maintenance loop is exhausted and only a human
+  judgment call remains — use `sm wake-angry-drunk-captain` as a last resort.
 ---
 
 # Slop-mop skill
@@ -26,6 +28,27 @@ Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **mai
 - **During implementation**: Run `sm swab` after every meaningful code change. Keep running until clean.
 - **Before PR**: Run `sm scour` for a comprehensive sweep.
 - **After CI/review**: Run `sm buff <PR_NUMBER>` to convert feedback into next steps.
+- **Loop exhausted (last resort)**: Run `sm wake-angry-drunk-captain` only when barnacles are filed, gates are green or truly unfixable, and the one move left is a human judgment call no verb can make. It demands structured proof and then blocks for a human to type orders. See below.
+
+## When the loop is exhausted: wake the captain
+
+Every other verb assumes there is more *agent* work to do. `sm wake-angry-drunk-captain` is the one that doesn't — it escalates to the human, and only the human, when you have genuinely run out of moves.
+
+The name is the guardrail. The captain is asleep, angry, and drunk; the standing order is *"do not wake me unless there's an emergency."* Picture his face before you reach for it.
+
+Required proof (skip any and it reads the standing order back and refuses):
+
+```bash
+sm wake-angry-drunk-captain \
+  --objective "what you were trying to get done" \
+  --verbs-tried "sm swab — green" \
+  --verbs-tried "sm buff 42 — CI green, no unresolved threads" \
+  --why-stuck "no remaining verb advances; blocker is a product/design call" \
+  --decision "the ONE call only a human can make" \
+  --option "approach A" --option "approach B"
+```
+
+A valid summons blocks on a prompt and **waits for a human to type orders** — you cannot complete it alone. If no human is at the wheel, it refuses and decides nothing. When orders come, carry them out; do not keep looping. Full detail: `/sm-wake-angry-drunk-captain`.
 
 ## The maintenance loop
 

--- a/slopmop/cli/__init__.py
+++ b/slopmop/cli/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from slopmop.cli.audit import cmd_audit
     from slopmop.cli.barnacle import cmd_barnacle
     from slopmop.cli.buff import cmd_buff
+    from slopmop.cli.captain import cmd_captain
     from slopmop.cli.config import cmd_config
     from slopmop.cli.detection import detect_project_type
     from slopmop.cli.doctor import cmd_doctor
@@ -33,6 +34,7 @@ _EXPORT_MAP = {
     "cmd_audit": ("slopmop.cli.audit", "cmd_audit"),
     "cmd_barnacle": ("slopmop.cli.barnacle", "cmd_barnacle"),
     "cmd_buff": ("slopmop.cli.buff", "cmd_buff"),
+    "cmd_captain": ("slopmop.cli.captain", "cmd_captain"),
     "cmd_commit_hooks": ("slopmop.cli.hooks", "cmd_commit_hooks"),
     "cmd_config": ("slopmop.cli.config", "cmd_config"),
     "cmd_doctor": ("slopmop.cli.doctor", "cmd_doctor"),
@@ -67,6 +69,7 @@ __all__ = [
     "cmd_agent",
     "cmd_audit",
     "cmd_barnacle",
+    "cmd_captain",
     "cmd_commit_hooks",
     "cmd_config",
     "cmd_doctor",

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -19,7 +19,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from slopmop.utils import git_current_branch, iso_now
+from slopmop.utils import (
+    git_current_branch,
+    iso_now,
+    markdown_bullets,
+    markdown_numbered,
+)
 
 SCHEMA_VERSION = "slopmop/barnacle-issue/v1"
 DEFAULT_REPO = "ScienceIsNeato/slop-mop"
@@ -139,20 +144,6 @@ def _fenced_block(language: str, content: str) -> str:
     return f"```{language}\n{body}\n```"
 
 
-def _bullets(values: Sequence[str]) -> str:
-    cleaned = [value.strip() for value in values if value and value.strip()]
-    if not cleaned:
-        return "- (none provided)"
-    return "\n".join(f"- {value}" for value in cleaned)
-
-
-def _numbered(values: Sequence[str]) -> str:
-    cleaned = [value.strip() for value in values if value and value.strip()]
-    if not cleaned:
-        return "1. (none provided)"
-    return "\n".join(f"{idx}. {value}" for idx, value in enumerate(cleaned, 1))
-
-
 def _issue_title(raw_title: str, command: str) -> str:
     title = raw_title.strip() or f"slop-mop friction while running {command}"
     if _BARNACLE_PREFIX_RE.match(title):
@@ -207,10 +198,10 @@ def render_issue_body(issue: BarnacleIssue) -> str:
             _fenced_block("bash", issue.command),
             "",
             "### Reproduction Steps",
-            _numbered(issue.reproduction_steps),
+            markdown_numbered(issue.reproduction_steps, "1. (none provided)"),
             "",
             "### Things Tried",
-            _bullets(issue.things_tried),
+            markdown_bullets(issue.things_tried, "- (none provided)"),
             "",
             "### Output Excerpt",
             _fenced_block("text", issue.output_excerpt),

--- a/slopmop/cli/captain.py
+++ b/slopmop/cli/captain.py
@@ -202,11 +202,23 @@ def _present_case(summons: CaptainSummons) -> None:
     """Lay the agent's case in front of the captain (stderr, always shown)."""
     lines = [
         "",
-        "🥃 CAPTAIN ON DECK — the loop is exhausted",
+        "🥃 CAPTAIN ON DECK",
         "",
-        "The crew woke you on purpose. Here is their case.",
+        "*A deckhand shakes the captain awake, hat in hand.*",
+        '"Aye, terribly sorry to wake ya, captain — but none of the officers',
+        '   know what to do about the following:"',
         "",
-        "Objective",
+        "THE QUESTION",
+        f"   {summons.decision}",
+    ]
+    if summons.options:
+        lines += ["", "Options on the table"]
+        lines += [f"   - {option}" for option in summons.options]
+    lines += [
+        "",
+        "— the crew's account of how it came to this —",
+        "",
+        "What we were trying to do",
         f"   {summons.objective}",
         "",
         "Verbs tried (and how they died)",
@@ -218,13 +230,7 @@ def _present_case(summons: CaptainSummons) -> None:
         "Why the loop can't continue",
         f"   {summons.why_stuck}",
         "",
-        "The decision only you can make",
-        f"   {summons.decision}",
     ]
-    if summons.options:
-        lines += ["", "Options on the table"]
-        lines += [f"   - {option}" for option in summons.options]
-    lines += [""]
     print("\n".join(lines), file=sys.stderr)
 
 
@@ -245,9 +251,13 @@ def _collect_captain_orders(
     if not resolved_isatty():
         return None
 
-    prompt = "Speak your orders, captain. Empty line ends.\n> "
+    prompt = (
+        '"What\'s your call, captain?"\n'
+        "(type your orders — blank line when you're done)\n> "
+    )
     silent_retry = (
-        "Nothing? Then it was no emergency. Speak, or send the crew back.\n> "
+        "\"...Still nothing, captain? The crew's waiting on your word.\n"
+        ' Give the order, or we send them back to the loop empty-handed."\n> '
     )
 
     for _ in range(_MAX_PROMPT_ATTEMPTS):
@@ -309,6 +319,7 @@ def cmd_captain(
                     "",
                     "🥃 NO CAPTAIN AT THE WHEEL",
                     "",
+                    "You hollered into an empty cabin — nobody's here to answer.",
                     "This verb only resolves when a human types orders at the",
                     "prompt. Run it where the captain can answer — an interactive",
                     "terminal, with him at the keyboard. Nothing was decided.",
@@ -337,7 +348,8 @@ def cmd_captain(
         "",
         f"Logged to: {body_path}",
         "",
-        "Carry out the orders above. The captain returns to his bunk.",
+        '"You have your orders. Carry them out. And do NOT wake me again"',
+        "   *...he mutters, stumbling back to his bunk.*",
         "",
     ]
     print("\n".join(ack))

--- a/slopmop/cli/captain.py
+++ b/slopmop/cli/captain.py
@@ -114,7 +114,8 @@ def _print_standing_order() -> None:
                 "    sm sail",
                 "",
             ]
-        )
+        ),
+        file=sys.stderr,
     )
 
 
@@ -265,7 +266,9 @@ def _collect_captain_orders(
         current = prompt
         while True:
             try:
-                line = resolved_input(current)
+                # Prompt is UI: emit to stderr so --json stdout stays clean.
+                print(current, end="", file=sys.stderr, flush=True)
+                line = resolved_input("")
             except EOFError:
                 line = ""
                 # EOF ends collection; fall through to evaluate what we have.

--- a/slopmop/cli/captain.py
+++ b/slopmop/cli/captain.py
@@ -1,0 +1,344 @@
+"""Wake the angry, drunk captain — the agent's last-resort escalation verb.
+
+Every other verb (``swab``, ``scour``, ``buff``, ``sail``) assumes there is
+more *agent* work to do.  This one models the case the loop never had: the
+barnacles are filed, the gates are green or genuinely unfixable, and the only
+move left is a human judgment call.
+
+The standing order is *"do not wake the captain unless there's an emergency."*
+The captain is asleep.  He is angry.  He is drunk.  He went to bed because the
+crew swore they had it handled.  Waking him is supposed to feel expensive —
+that friction is the whole point.  An agent that reaches for this verb to dodge
+hard work should picture his face first.
+
+So the verb refuses to escalate on a whim.  A bare invocation gets the standing
+order read back to it.  Escalation only happens when the agent supplies
+structured proof that the loop is exhausted: what it was trying to do, which
+verbs it already ran and how they died, why nothing remaining makes progress,
+and the single decision only a human can make.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from slopmop.utils import (
+    git_current_branch,
+    iso_now,
+    markdown_bullets,
+    markdown_numbered,
+)
+
+SCHEMA_VERSION = "slopmop/captain-summons/v1"
+
+# Return codes — mirror the sail "human decision needed" idiom.
+EXIT_SUMMONED = 1  # Valid summons: captain spoke, loop halted, await orders.
+EXIT_REFUSED = 2  # Insufficient justification: go back to the loop.
+EXIT_NO_CAPTAIN = 3  # No human at the wheel: run this where one can answer.
+
+# Max times to re-prompt a silent captain before giving up.
+_MAX_PROMPT_ATTEMPTS = 3
+
+# Placeholder rendered for an empty numbered list.
+_EMPTY_NUMBERED = "1. (none provided)"
+
+
+def _default_summons_file(project_root: str) -> Path:
+    return Path(project_root) / ".slopmop" / "last_captain_summons.md"
+
+
+@dataclass(frozen=True)
+class CaptainSummons:
+    """Structured payload justifying why a human must be woken."""
+
+    objective: str
+    verbs_tried: Sequence[str]
+    why_stuck: str
+    decision: str
+    options: Sequence[str]
+    project_root: str
+    branch: str
+    summoned_at: str
+    orders: Sequence[str] = ()
+    answered_at: Optional[str] = None
+
+
+def _clean_lines(values: Sequence[str]) -> List[str]:
+    return [value.strip() for value in values if value and value.strip()]
+
+
+def _missing_fields(args: argparse.Namespace) -> List[str]:
+    """Return the names of required justification fields the agent skipped."""
+    missing: List[str] = []
+    if not (getattr(args, "objective", "") or "").strip():
+        missing.append("--objective")
+    if not _clean_lines(getattr(args, "verbs_tried", None) or []):
+        missing.append("--verbs-tried")
+    if not (getattr(args, "why_stuck", "") or "").strip():
+        missing.append("--why-stuck")
+    if not (getattr(args, "decision", "") or "").strip():
+        missing.append("--decision")
+    return missing
+
+
+def _print_standing_order() -> None:
+    """Read the standing order back to an agent that came empty-handed."""
+    print(
+        "\n".join(
+            [
+                "",
+                "🥃 THE CAPTAIN IS ASLEEP",
+                "",
+                'Standing order: "Do not wake me unless there\'s an emergency."',
+                "",
+                "He is angry. He is drunk. The crew swore they had it handled.",
+                "Bring proof or do not knock. Required:",
+                "",
+                "  --objective     What you were trying to get done.",
+                "  --verbs-tried   Each sm verb you ran and how it died.",
+                "                  Repeat the flag — one per attempt.",
+                "  --why-stuck     Why NO remaining sm verb moves you forward.",
+                "  --decision      The one call only the captain can make.",
+                "",
+                "Optional:",
+                "  --option        A choice you've laid out. Repeat per option.",
+                "",
+                "Miss one line and you do not have an emergency — you have",
+                "unfinished work. Back to the loop:",
+                "",
+                "    sm sail",
+                "",
+            ]
+        )
+    )
+
+
+def build_summons(args: argparse.Namespace) -> CaptainSummons:
+    """Build a normalized captain summons from parsed CLI arguments."""
+    project_root = str(Path(getattr(args, "project_root", ".")).resolve())
+    return CaptainSummons(
+        objective=(getattr(args, "objective", "") or "").strip(),
+        verbs_tried=_clean_lines(getattr(args, "verbs_tried", None) or []),
+        why_stuck=(getattr(args, "why_stuck", "") or "").strip(),
+        decision=(getattr(args, "decision", "") or "").strip(),
+        options=_clean_lines(getattr(args, "options", None) or []),
+        project_root=project_root,
+        branch=git_current_branch(project_root),
+        summoned_at=iso_now(),
+    )
+
+
+def render_summons_body(summons: CaptainSummons) -> str:
+    """Render the summons as structured Markdown for the human captain."""
+    lines = [
+        "# 🥃 Captain Summons",
+        "",
+        f"- Schema: {SCHEMA_VERSION}",
+        f"- Summoned: {summons.summoned_at}",
+        f"- Branch: {summons.branch}",
+        f"- Repo: {summons.project_root}",
+        "",
+        "## Objective",
+        summons.objective or "(none provided)",
+        "",
+        "## Verbs Tried (and how each one died)",
+        markdown_numbered(summons.verbs_tried, _EMPTY_NUMBERED),
+        "",
+        "## Why the loop can't continue",
+        summons.why_stuck or "(none provided)",
+        "",
+        "## The decision only the captain can make",
+        summons.decision or "(none provided)",
+        "",
+        "## Options on the table",
+        markdown_bullets(
+            summons.options, "- (none on the table — captain's call is open)"
+        ),
+        "",
+    ]
+    if summons.orders:
+        lines += [
+            f"## Captain's Orders ({summons.answered_at or 'unrecorded'})",
+            markdown_numbered(summons.orders, _EMPTY_NUMBERED),
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def write_summons_file(summons: CaptainSummons, body: Optional[str] = None) -> Path:
+    """Write the rendered summons to a retrievable Markdown artifact."""
+    path = _default_summons_file(summons.project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        body if body is not None else render_summons_body(summons),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _summons_payload(summons: CaptainSummons, body_path: Path) -> Dict[str, Any]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "summoned_at": summons.summoned_at,
+        "answered_at": summons.answered_at,
+        "branch": summons.branch,
+        "project_root": summons.project_root,
+        "objective": summons.objective,
+        "verbs_tried": list(summons.verbs_tried),
+        "why_stuck": summons.why_stuck,
+        "decision": summons.decision,
+        "options": list(summons.options),
+        "orders": list(summons.orders),
+        "summons_file": str(body_path),
+    }
+
+
+def _present_case(summons: CaptainSummons) -> None:
+    """Lay the agent's case in front of the captain (stderr, always shown)."""
+    lines = [
+        "",
+        "🥃 CAPTAIN ON DECK — the loop is exhausted",
+        "",
+        "The crew woke you on purpose. Here is their case.",
+        "",
+        "Objective",
+        f"   {summons.objective}",
+        "",
+        "Verbs tried (and how they died)",
+    ]
+    for idx, verb in enumerate(summons.verbs_tried, 1):
+        lines.append(f"   {idx}. {verb}")
+    lines += [
+        "",
+        "Why the loop can't continue",
+        f"   {summons.why_stuck}",
+        "",
+        "The decision only you can make",
+        f"   {summons.decision}",
+    ]
+    if summons.options:
+        lines += ["", "Options on the table"]
+        lines += [f"   - {option}" for option in summons.options]
+    lines += [""]
+    print("\n".join(lines), file=sys.stderr)
+
+
+def _collect_captain_orders(
+    input_fn: Optional[Callable[[str], str]] = None,
+    isatty_fn: Optional[Callable[[], bool]] = None,
+) -> Optional[List[str]]:
+    """Block until the human captain types orders.
+
+    Returns the typed order lines, or ``None`` when no human is at the wheel
+    (non-interactive stdin, or the captain ends input without a word).
+    """
+    resolved_input: Callable[[str], str] = input_fn if input_fn is not None else input
+    resolved_isatty: Callable[[], bool] = (
+        isatty_fn if isatty_fn is not None else sys.stdin.isatty
+    )
+
+    if not resolved_isatty():
+        return None
+
+    prompt = "Speak your orders, captain. Empty line ends.\n> "
+    silent_retry = (
+        "Nothing? Then it was no emergency. Speak, or send the crew back.\n> "
+    )
+
+    for _ in range(_MAX_PROMPT_ATTEMPTS):
+        orders: List[str] = []
+        current = prompt
+        while True:
+            try:
+                line = resolved_input(current)
+            except EOFError:
+                line = ""
+                # EOF ends collection; fall through to evaluate what we have.
+                if orders:
+                    return orders
+                break
+            if not line.strip():
+                if orders:
+                    return orders
+                break  # Empty first line — re-prompt sternly.
+            orders.append(line.strip())
+            current = "> "
+        prompt = silent_retry
+
+    return None
+
+
+def cmd_captain(
+    args: argparse.Namespace,
+    input_fn: Optional[Callable[[str], str]] = None,
+    isatty_fn: Optional[Callable[[], bool]] = None,
+) -> int:
+    """Wake the angry, drunk captain — only when the loop is truly exhausted.
+
+    A valid summons does not resolve until a human at the keyboard types
+    orders. The agent cannot satisfy this verb alone — that is the point.
+    """
+    missing = _missing_fields(args)
+    if missing:
+        _print_standing_order()
+        if len(missing) < 4:
+            # Came partway — name exactly what's still missing.
+            print(
+                "You started to make your case but left these blank: "
+                + ", ".join(missing),
+                file=sys.stderr,
+            )
+        return EXIT_REFUSED
+
+    summons = build_summons(args)
+    body_path = write_summons_file(summons, render_summons_body(summons))
+
+    # Lay the case in front of the captain, then demand his orders.
+    _present_case(summons)
+    orders = _collect_captain_orders(input_fn=input_fn, isatty_fn=isatty_fn)
+
+    if not orders:
+        print(
+            "\n".join(
+                [
+                    "",
+                    "🥃 NO CAPTAIN AT THE WHEEL",
+                    "",
+                    "This verb only resolves when a human types orders at the",
+                    "prompt. Run it where the captain can answer — an interactive",
+                    "terminal, with him at the keyboard. Nothing was decided.",
+                    "",
+                ]
+            ),
+            file=sys.stderr,
+        )
+        return EXIT_NO_CAPTAIN
+
+    summons = replace(summons, orders=orders, answered_at=iso_now())
+    body_path = write_summons_file(summons, render_summons_body(summons))
+
+    if getattr(args, "json_output", False):
+        print(json.dumps(_summons_payload(summons, body_path), indent=2))
+        return EXIT_SUMMONED
+
+    ack = [
+        "",
+        "🥃 ORDERS RECEIVED — the captain has spoken",
+        "",
+    ]
+    for idx, order in enumerate(orders, 1):
+        ack.append(f"   {idx}. {order}")
+    ack += [
+        "",
+        f"Logged to: {body_path}",
+        "",
+        "Carry out the orders above. The captain returns to his bunk.",
+        "",
+    ]
+    print("\n".join(ack))
+    return EXIT_SUMMONED

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -407,6 +407,65 @@ def _add_sail_parser(
     )
 
 
+def _add_captain_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Add the wake-angry-drunk-captain subcommand parser.
+
+    The agent's last-resort escalation. Deliberately verbose to type and
+    deliberately demanding to satisfy — waking the captain is supposed to
+    feel expensive.
+    """
+    captain_parser = subparsers.add_parser(
+        "wake-angry-drunk-captain",
+        help="Escalate to the human — only when no sm verb can progress",
+        description=(
+            "Wake the human when the loop is exhausted: barnacles filed, gates "
+            "green or genuinely unfixable, and the only move left is a human "
+            'judgment call. The standing order is "do not wake the captain '
+            "unless there's an emergency.\" Invoking this without structured "
+            "justification gets the standing order read back to you."
+        ),
+    )
+    captain_parser.add_argument(
+        "--objective",
+        help="What you were trying to get done.",
+    )
+    captain_parser.add_argument(
+        "--verbs-tried",
+        dest="verbs_tried",
+        action="append",
+        help="A verb/step you ran and how it died; repeat for each attempt.",
+    )
+    captain_parser.add_argument(
+        "--why-stuck",
+        dest="why_stuck",
+        help="Why no remaining sm verb moves you forward.",
+    )
+    captain_parser.add_argument(
+        "--decision",
+        help="The one call only the captain can make.",
+    )
+    captain_parser.add_argument(
+        "--option",
+        dest="options",
+        action="append",
+        help="A choice you've laid out for the captain; repeat for each.",
+    )
+    captain_parser.add_argument(
+        "--project-root",
+        type=str,
+        default=".",
+        help=PROJECT_ROOT_HELP,
+    )
+    captain_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit machine-readable summons details.",
+    )
+
+
 def _add_refit_parser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -958,6 +1017,7 @@ def create_parser() -> argparse.ArgumentParser:
             "  buff        Post-PR CI triage and next-step guidance",
             "  refit       Structured remediation planning and continuation",
             "  barnacle    File upstream tool-friction issues",
+            "  wake-angry-drunk-captain  Escalate to the human (last resort)",
             "  agent       Install agent integration templates",
             "  config      View or update quality gate configuration",
             "  help        Show detailed help for quality gates",
@@ -1007,6 +1067,7 @@ def create_parser() -> argparse.ArgumentParser:
     _add_upgrade_parser(subparsers)
     _add_buff_parser(subparsers)
     _add_sail_parser(subparsers)
+    _add_captain_parser(subparsers)
     _add_refit_parser(subparsers)
     BarnacleParserBuilder(subparsers).build()
     _add_status_parser(subparsers)
@@ -1040,6 +1101,7 @@ def main(args: Optional[List[str]] = None) -> int:
         cmd_audit,
         cmd_barnacle,
         cmd_buff,
+        cmd_captain,
         cmd_commit_hooks,
         cmd_config,
         cmd_doctor,
@@ -1091,6 +1153,7 @@ def main(args: Optional[List[str]] = None) -> int:
             cmd_upgrade=cmd_upgrade,
             cmd_buff=cmd_buff,
             cmd_barnacle=cmd_barnacle,
+            cmd_captain=cmd_captain,
             cmd_sail=cmd_sail,
             cmd_refit=cmd_refit,
             cmd_status=cmd_status,
@@ -1125,6 +1188,8 @@ def _dispatch(
         return handlers["cmd_buff"](parsed_args)
     elif parsed_args.verb == "barnacle":
         return handlers["cmd_barnacle"](parsed_args)
+    elif parsed_args.verb == "wake-angry-drunk-captain":
+        return handlers["cmd_captain"](parsed_args)
     elif parsed_args.verb == "sail":
         return handlers["cmd_sail"](parsed_args)
     elif parsed_args.verb == "refit":

--- a/slopmop/utils/__init__.py
+++ b/slopmop/utils/__init__.py
@@ -178,3 +178,23 @@ def git_current_branch(path: Optional[str] = None) -> str:
 def dedupe_str_list(values: list[str]) -> list[str]:
     """Deduplicate strings while preserving input order."""
     return list(dict.fromkeys(values))
+
+
+def _clean_markdown_lines(values: Iterable[str]) -> list[str]:
+    return [value.strip() for value in values if value and value.strip()]
+
+
+def markdown_numbered(values: Iterable[str], empty: str) -> str:
+    """Render values as a numbered Markdown list, or ``empty`` when none."""
+    cleaned = _clean_markdown_lines(values)
+    if not cleaned:
+        return empty
+    return "\n".join(f"{idx}. {value}" for idx, value in enumerate(cleaned, 1))
+
+
+def markdown_bullets(values: Iterable[str], empty: str) -> str:
+    """Render values as a bulleted Markdown list, or ``empty`` when none."""
+    cleaned = _clean_markdown_lines(values)
+    if not cleaned:
+        return empty
+    return "\n".join(f"- {value}" for value in cleaned)

--- a/tests/unit/test_captain.py
+++ b/tests/unit/test_captain.py
@@ -72,10 +72,11 @@ def test_bare_invocation_refuses_and_reads_standing_order(capsys):
     code = cmd_captain(args)
     captured = capsys.readouterr()
     assert code == EXIT_REFUSED
-    assert "THE CAPTAIN IS ASLEEP" in captured.out
-    assert "do not wake" in captured.out.lower()
-    # No artifact written when refused.
+    assert "THE CAPTAIN IS ASLEEP" in captured.err
+    assert "do not wake" in captured.err.lower()
+    # No artifact written when refused; stdout stays clean for --json callers.
     assert "CAPTAIN ON DECK" not in captured.out
+    assert captured.out == ""
 
 
 def test_partial_justification_names_missing_fields(capsys):
@@ -83,9 +84,13 @@ def test_partial_justification_names_missing_fields(capsys):
     code = cmd_captain(args)
     captured = capsys.readouterr()
     assert code == EXIT_REFUSED
-    assert "--why-stuck" in captured.err
-    assert "--decision" in captured.err
-    assert "--objective" not in captured.err
+    # The nudge names exactly the fields left blank, not the ones provided.
+    nudge = captured.err.split("left these blank:", 1)[1]
+    assert "--why-stuck" in nudge
+    assert "--decision" in nudge
+    assert "--objective" not in nudge
+    # All refusal UI stays on stderr; stdout is clean for --json callers.
+    assert captured.out == ""
 
 
 def test_valid_summons_requires_orders_and_halts(tmp_path, capsys):

--- a/tests/unit/test_captain.py
+++ b/tests/unit/test_captain.py
@@ -1,0 +1,180 @@
+"""Tests for the wake-angry-drunk-captain escalation CLI."""
+
+import argparse
+import json
+
+from slopmop.cli.captain import (
+    EXIT_NO_CAPTAIN,
+    EXIT_REFUSED,
+    EXIT_SUMMONED,
+    SCHEMA_VERSION,
+    CaptainSummons,
+    build_summons,
+    cmd_captain,
+    render_summons_body,
+    write_summons_file,
+)
+
+
+def _scripted_captain(*lines):
+    """Return an input() stand-in that feeds the given lines, then EOF."""
+    queue = list(lines)
+
+    def _input(_prompt=""):
+        if not queue:
+            raise EOFError
+        return queue.pop(0)
+
+    return _input
+
+
+def _at_the_wheel():
+    return True
+
+
+def _no_wheel():
+    return False
+
+
+def _captain_args(**kwargs) -> argparse.Namespace:
+    defaults = dict(
+        objective="ship the captain verb",
+        verbs_tried=["sm swab — green", "sm scour — green"],
+        why_stuck="no remaining verb advances; needs a product call",
+        decision="approve the name wake-angry-drunk-captain",
+        options=["keep the name", "rename to mayday"],
+        project_root=".",
+        json_output=False,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _summons(tmp_path, **kwargs) -> CaptainSummons:
+    defaults = dict(
+        objective="ship the verb",
+        verbs_tried=["sm swab — green"],
+        why_stuck="design call needed",
+        decision="approve the name",
+        options=["keep", "rename"],
+        project_root=str(tmp_path),
+        branch="feat/captain-verb",
+        summoned_at="2026-05-29T00:00:00Z",
+    )
+    defaults.update(kwargs)
+    return CaptainSummons(**defaults)
+
+
+def test_bare_invocation_refuses_and_reads_standing_order(capsys):
+    args = _captain_args(
+        objective="", verbs_tried=[], why_stuck="", decision="", options=[]
+    )
+    code = cmd_captain(args)
+    captured = capsys.readouterr()
+    assert code == EXIT_REFUSED
+    assert "THE CAPTAIN IS ASLEEP" in captured.out
+    assert "do not wake" in captured.out.lower()
+    # No artifact written when refused.
+    assert "CAPTAIN ON DECK" not in captured.out
+
+
+def test_partial_justification_names_missing_fields(capsys):
+    args = _captain_args(why_stuck="", decision="")
+    code = cmd_captain(args)
+    captured = capsys.readouterr()
+    assert code == EXIT_REFUSED
+    assert "--why-stuck" in captured.err
+    assert "--decision" in captured.err
+    assert "--objective" not in captured.err
+
+
+def test_valid_summons_requires_orders_and_halts(tmp_path, capsys):
+    args = _captain_args(project_root=str(tmp_path))
+    code = cmd_captain(
+        args,
+        input_fn=_scripted_captain("hold the merge", "rename later", ""),
+        isatty_fn=_at_the_wheel,
+    )
+    captured = capsys.readouterr()
+    assert code == EXIT_SUMMONED
+    # The case is presented to the captain on stderr.
+    assert "CAPTAIN ON DECK" in captured.err
+    # Orders acknowledged on stdout.
+    assert "ORDERS RECEIVED" in captured.out
+    assert "hold the merge" in captured.out
+    artifact = tmp_path / ".slopmop" / "last_captain_summons.md"
+    assert artifact.exists()
+    body = artifact.read_text(encoding="utf-8")
+    assert "ship the captain verb" in body
+    assert "Captain's Orders" in body
+    assert "hold the merge" in body
+    assert "rename later" in body
+
+
+def test_no_captain_at_the_wheel_refuses(tmp_path, capsys):
+    args = _captain_args(project_root=str(tmp_path))
+    code = cmd_captain(args, isatty_fn=_no_wheel)
+    captured = capsys.readouterr()
+    assert code == EXIT_NO_CAPTAIN
+    assert "NO CAPTAIN AT THE WHEEL" in captured.err
+    # Nothing decided: no orders recorded in the artifact.
+    artifact = tmp_path / ".slopmop" / "last_captain_summons.md"
+    body = artifact.read_text(encoding="utf-8")
+    assert "Captain's Orders" not in body
+
+
+def test_silent_captain_eventually_refuses(tmp_path, capsys):
+    args = _captain_args(project_root=str(tmp_path))
+    # Captain stares at the prompt, types nothing, then walks off (EOF).
+    code = cmd_captain(
+        args,
+        input_fn=_scripted_captain("", "", ""),
+        isatty_fn=_at_the_wheel,
+    )
+    captured = capsys.readouterr()
+    assert code == EXIT_NO_CAPTAIN
+    assert "NO CAPTAIN AT THE WHEEL" in captured.err
+
+
+def test_valid_summons_json_output(tmp_path, capsys):
+    args = _captain_args(project_root=str(tmp_path), json_output=True)
+    code = cmd_captain(
+        args,
+        input_fn=_scripted_captain("approved", ""),
+        isatty_fn=_at_the_wheel,
+    )
+    captured = capsys.readouterr()
+    assert code == EXIT_SUMMONED
+    payload = json.loads(captured.out)
+    assert payload["schema"] == SCHEMA_VERSION
+    assert payload["objective"] == "ship the captain verb"
+    assert payload["verbs_tried"] == ["sm swab — green", "sm scour — green"]
+    assert payload["orders"] == ["approved"]
+    assert payload["answered_at"]
+    assert payload["summons_file"].endswith("last_captain_summons.md")
+
+
+def test_build_summons_resolves_root_and_strips(tmp_path):
+    args = _captain_args(
+        project_root=str(tmp_path),
+        objective="  padded objective  ",
+        verbs_tried=["  sm swab — green  ", "", "   "],
+    )
+    summons = build_summons(args)
+    assert summons.objective == "padded objective"
+    assert summons.verbs_tried == ["sm swab — green"]
+    assert summons.project_root == str(tmp_path.resolve())
+
+
+def test_render_body_handles_missing_options(tmp_path):
+    summons = _summons(tmp_path, options=[])
+    body = render_summons_body(summons)
+    assert "captain's call is open" in body
+    assert SCHEMA_VERSION in body
+
+
+def test_write_summons_file_creates_parent(tmp_path):
+    summons = _summons(tmp_path)
+    path = write_summons_file(summons)
+    assert path == tmp_path / ".slopmop" / "last_captain_summons.md"
+    assert path.exists()


### PR DESCRIPTION
## What

Adds a new `wake-angry-drunk-captain` escalation verb — slop-mop's "break glass" for when an agent's automated loop is genuinely stuck and needs a human to make a call.

When every verb has been tried and the loop can't continue, the agent summons the captain: it blocks on interactive stdin, presents the situation, and refuses to proceed until a human types orders.

## Voice / framing

The crew apologetically wakes the captain rather than the captain narrating:

- Leads with **THE QUESTION** — the escalated decision, front and center
- Demotes the objective / verbs-tried / why-stuck to a supporting "crew's account of how it came to this"
- Interactive prompts use the crew-waiting voice ("What's your call, captain?")

## Behavior

- Exit codes: `EXIT_SUMMONED=1`, `EXIT_REFUSED=2`, `EXIT_NO_CAPTAIN=3`
- Standing-order refusal path ("THE CAPTAIN IS ASLEEP") for non-interactive contexts
- UI to stderr so `--json` stdout stays clean
- Orders logged to `.slopmop/last_captain_summons.md`
- Injectable `input_fn` / `isatty_fn` for testability

## Validation

- 9 unit tests in `tests/unit/test_captain.py` (refuse, no-TTY, interactive, JSON, artifact)
- `sm swab` green
- Dogfooded live across multiple voice iterations

## Notes

Refactored shared `markdown_numbered` / `markdown_bullets` helpers into `slopmop/utils` and updated `barnacle.py` to use them (de-duplication).
