### PR TITLE
chore: bump version to 1.6.0 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "1.5.0"
+version = "1.6.0"
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}


### PR DESCRIPTION
Release 1.5.0 -> 1.6.0.

This PR was created by the Release workflow. After checks pass, the workflow merges it into main; the protected main-branch push then runs the publish path.