### PR TITLE
docs: refresh README and DOCS for v2.0.0 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slopmop",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.willville.json
+++ b/.willville.json
@@ -23,8 +23,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Answered a reviewer worry on the machine-format PR by adding a guard that keeps the verb catalog honest about what each command can actually do",
-    "direction": "Getting the machine-format PR green and merged",
+    "status": "2.0 just shipped, so I swept the readme and docs for anything still talking like it's the old version and fixed the stale bits",
+    "direction": "Wrapping up the doc cleanup, then back to the leftover CI-status fix waiting to go up",
     "last_update": "2026-05-31T00:00:00Z"
   },
   "queue": {

--- a/DOCS/COMPATIBILITY.md
+++ b/DOCS/COMPATIBILITY.md
@@ -51,7 +51,7 @@ When a minor release changes behavior:
 
 ## Config and Output Compatibility
 
-For 1.x releases:
+Within a major release line:
 
 - committed config templates may gain new optional settings between minor
   releases

--- a/DOCS/MACHINE_INTERFACE.md
+++ b/DOCS/MACHINE_INTERFACE.md
@@ -185,7 +185,7 @@ sm capabilities
   "status": "info",
   "exit_code": 0,
   "data": {
-    "version": "1.6.0",
+    "version": "2.0.0",
     "verbs": [
       { "name": "swab", "summary": "…", "level": "core",
         "formats": ["human", "json", "porcelain", "sarif"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is purposefully opinionated, as structure begets adherence to best practices.
 
 ## Project Status
 
-slop-mop has reached 1.0.0. The current public policy surface for release and
+slop-mop has reached 2.0.0. The current public policy surface for release and
 stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)
@@ -98,9 +98,10 @@ It reads the current workflow state and runs the next obvious slop-mop verb.
 ## Use with Claude
 
 Slop-mop ships as a Claude plugin: a skill that auto-triggers on remediation
-prompts, plus six slash commands (`/sm-refit`, `/sm-sail`, `/sm-swab`,
-`/sm-scour`, `/sm-buff`, `/sm-barnacle`). Install once and `sm` is available in
-every repo — no per-repo `sm agent install` required.
+prompts, plus eight slash commands (`/sm-init`, `/sm-refit`, `/sm-sail`,
+`/sm-swab`, `/sm-scour`, `/sm-buff`, `/sm-barnacle`,
+`/sm-wake-angry-drunk-captain`). Install once and `sm` is available in every
+repo — no per-repo `sm agent install` required.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ScienceIsNeato/slop-mop/main/assets/claude-skill-demo.gif" alt="Demo: sm scour flagging a bogus test, an uncovered function, and a silenced gate in one run" width="780"/>


### PR DESCRIPTION
## Summary
Post-2.0.0 staleness sweep of the README and `DOCS/`. Fixes the spots that still talk like the 1.x line is current.

- **README**: "reached 1.0.0" → 2.0.0; corrected the slash-command list from "six" to the **eight** that actually ship in `commands/` (adds `/sm-init` and `/sm-wake-angry-drunk-captain`).
- **`.claude-plugin/plugin.json`**: version `1.1.0` → `2.0.0` to match the package (`pyproject.toml`).
- **`DOCS/COMPATIBILITY.md`**: generalized the "For 1.x releases" config/output policy heading to "Within a major release line" now that 2.x exists.
- **`DOCS/MACHINE_INTERFACE.md`**: bumped the illustrative `capabilities` envelope `version` example `1.6.0` → `2.0.0`.

## Notes
- The README's uppercase `DOCS/` links were verified correct (git tracks `DOCS/`; the lowercase `docs/` is only a macOS case-insensitive-FS artifact). No broken links.
- The other 11 `DOCS/` files + `AGENTS.md` were audited and are clean — historical version refs in MIGRATIONS.md and the `slopmop/v1`/`v2` markers in MACHINE_INTERFACE.md are intentional migration context, not stale.

## Test plan
- [x] `sm swab` green (pre-commit)
- [ ] CI green