### PR TITLE
fix: clear barnacle backlog (#220 #230 #232 #233 #241) + gang intercept noise

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -23,9 +23,9 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "2.0 just shipped, so I swept the readme and docs for anything still talking like it's the old version and fixed the stale bits",
-    "direction": "Wrapping up the doc cleanup, then back to the leftover CI-status fix waiting to go up",
-    "last_update": "2026-05-31T00:00:00Z"
+    "status": "Cleared the whole backlog of tool-friction reports, plus knocked out a stray bit of noise where a safety check was printing a harmless-but-confusing error on every command",
+    "direction": "Backlog's empty. Next is getting these fixes reviewed and into a release so they actually reach people's machines",
+    "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {
     "active": true,

--- a/commands/sm-wake-angry-drunk-captain.md
+++ b/commands/sm-wake-angry-drunk-captain.md
@@ -25,15 +25,21 @@ required. Invoke the verb without them and it reads the standing order back to
 you and refuses — that friction is the point. If you can't fill every line, you
 don't have an emergency, you have unfinished work. Go back to `sm sail`.
 
-A valid summons writes `.slopmop/last_captain_summons.md`, lays the case in
-front of the captain, then **blocks on a prompt and waits for a human to type
-orders**. You cannot satisfy this verb alone — a human must be at the keyboard.
-The orders are recorded to the summons file and the workflow halts with a
-non-zero exit. Carry out the captain's orders; do not keep looping.
+A valid summons writes `.slopmop/last_captain_summons.md` and halts the loop
+with a non-zero exit. It does **not** read your terminal — an agent's stdin is
+a pipe, never a live human, so forcing a prompt would make this verb unreachable
+in the exact stuck-in-a-loop case it exists for. Instead it speaks the same
+JSON-envelope contract as every other verb:
 
-If no human is at the wheel (non-interactive terminal), the verb refuses with
-`🥃 NO CAPTAIN AT THE WHEEL` and decides nothing. Run it where the captain can
-answer.
+- `data.relay_to_human` — the captain's question, laid out for the human, ending
+  on a direct ask. Show this to the user **verbatim**.
+- `data.agent_directive` — the instruction back to you: **your turn is over.**
+  Display `relay_to_human`, then stop and wait. Do not run another verb. Do not
+  continue the loop.
+
+The human answers in the chat; their reply is the captain's orders. Carry them
+out — and do not wake him again. You cannot satisfy this verb alone; that is the
+point.
 
 **Prerequisite:** `sm` must be installed. If `command not found`, suggest:
 ```bash

--- a/skills/slopmop/SKILL.md
+++ b/skills/slopmop/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Trigger when you would normally reach for pytest, gh, mypy, black, or other
   raw repo tooling. Redirect to `sm swab`, `sm scour`, `sm buff`, `sm sail`,
   `sm refit`, or `sm doctor` so remediation follows the established rails.
-  Also trigger when you find a repo with sm installed but no .sb_config.json
-  — use `sm init --non-interactive` before entering the loop.
+  Also trigger when asked to "install" or "set up" slop-mop in a repo, or
+  when you find a repo with sm installed but no .sb_config.json — follow the
+  install handoff (sm agent install → sm init → sm refit) before the loop.
   Also trigger when filing issues about slop-mop friction — use
   `sm barnacle file` / `/sm-barnacle`, never `gh issue create`.
   Also trigger when the maintenance loop is exhausted and only a human
@@ -18,6 +19,27 @@ description: >-
 
 Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **maintenance** (steady-state development). Refit remediates all existing slop and installs permanent guards; the swab/scour/buff loop then keeps the repo clean as you work.
 
+## Setting up slop-mop in a repo (the install handoff)
+
+When the user says "install slop-mop", "set up slop-mop in this repo", or
+similar, do **not** improvise ad-hoc setup. It is an ordered handoff — each
+step is a real CLI surface (`sm -h` lists them). Run them in order, skipping
+any that are already done:
+
+1. **CLI present?** If `sm` is "command not found", install the utility:
+   `pipx install slopmop[all]`.
+2. **Repo-local agent instructions?** Install them so every agent in this repo
+   follows the rails: `sm agent install` (add `--target copilot|cursor|claude`
+   as needed).
+3. **Config?** If there's no `.sb_config.json`, generate one tuned to the
+   detected stack: `sm init --non-interactive`.
+4. **Onboard the existing code:** `sm refit --start` → `sm refit --iterate` →
+   `sm refit --finish`, then enter the maintenance loop.
+
+"Install slop-mop in the repo" means all of the above, not just step 1. If you
+are unsure which steps remain, `sm sail` reads the repo state and tells you the
+next move.
+
 ## When to use
 
 - **Initial setup (step -1)**: Run `sm init --non-interactive` when the repo has
@@ -28,7 +50,7 @@ Slop-mop (`sm`) has two primary modes: **refit** (one-time onboarding) and **mai
 - **During implementation**: Run `sm swab` after every meaningful code change. Keep running until clean.
 - **Before PR**: Run `sm scour` for a comprehensive sweep.
 - **After CI/review**: Run `sm buff <PR_NUMBER>` to convert feedback into next steps.
-- **Loop exhausted (last resort)**: Run `sm wake-angry-drunk-captain` only when barnacles are filed, gates are green or truly unfixable, and the one move left is a human judgment call no verb can make. It demands structured proof and then blocks for a human to type orders. See below.
+- **Loop exhausted (last resort)**: Run `sm wake-angry-drunk-captain` only when barnacles are filed, gates are green or truly unfixable, and the one move left is a human judgment call no verb can make. It demands structured proof, then ends your turn and hands you the captain's question to relay to the human. See below.
 
 ## When the loop is exhausted: wake the captain
 
@@ -48,7 +70,7 @@ sm wake-angry-drunk-captain \
   --option "approach A" --option "approach B"
 ```
 
-A valid summons blocks on a prompt and **waits for a human to type orders** — you cannot complete it alone. If no human is at the wheel, it refuses and decides nothing. When orders come, carry them out; do not keep looping. Full detail: `/sm-wake-angry-drunk-captain`.
+A valid summons doesn't resolve into more agent work. The verb writes `.slopmop/last_captain_summons.md`, then returns an envelope whose `data.relay_to_human` is the captain's question and whose `data.agent_directive` says, plainly: **your turn is over.** Show the user `relay_to_human` verbatim, then stop and wait — the human's next message is the captain's orders. You cannot complete this verb alone; that is the point. Carry out the orders when they come; do not keep looping. Full detail: `/sm-wake-angry-drunk-captain`.
 
 ## The maintenance loop
 

--- a/slopmop/agent_install/templates/_shared/core.md
+++ b/slopmop/agent_install/templates/_shared/core.md
@@ -96,6 +96,25 @@ Or just run `sm sail` repeatedly — it reads the workflow state and dispatches 
 
 Use `sm sail` for forward motion; use individual verbs (`sm swab -g <gate>`, `sm buff resolve`, etc.) for surgical work.
 
+### Setting up slop-mop in a repo (the install handoff)
+
+When asked to "install" or "set up" slop-mop in this repo, do **not** improvise
+ad-hoc setup. It is an ordered handoff — each step is a real `sm` verb (see
+`sm -h`). Run them in order, skipping any already done:
+
+1. **CLI present?** If `sm` is "command not found", install the utility:
+   `pipx install slopmop[all]`.
+2. **Repo-local agent instructions?** `sm agent install` (add
+   `--target copilot|cursor|claude` as needed) so every agent here follows the
+   rails.
+3. **Config?** No `.sb_config.json` yet → `sm init --non-interactive` to
+   generate one tuned to the detected stack.
+4. **Onboard the existing code:** run the refit sequence below, then enter the
+   maintenance loop.
+
+"Install slop-mop in the repo" means all of the above, not just step 1. Unsure
+which steps remain? `sm sail` reads the repo state and names the next move.
+
 ### Refit (step 0 — before entering the loop)
 
 Refit is a nearly necessary first step for any repository adopting slop-mop. It is not part of the maintenance loop — it is how you earn the right to enter it.

--- a/slopmop/checks/javascript/lint_format.py
+++ b/slopmop/checks/javascript/lint_format.py
@@ -763,9 +763,27 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
                         level=FindingLevel.ERROR,
                     )
                 )
-            count = (
-                len(findings) if findings else len(result.output.strip().split("\n"))
-            )
+            if not findings:
+                # ESLint exited non-zero but produced no per-file diagnostics:
+                # e.g. a config/plugin error printed to stderr, an empty "[]"
+                # JSON body, or all messages filtered out. Surface the raw
+                # output so the failure is diagnosable inline — otherwise the
+                # gate reports an opaque "N lint issue(s)" with no location and
+                # the only way to find the cause is a rerun (which may pass from
+                # cache once the working tree changes).
+                raw = result.output.strip()
+                findings.append(
+                    Finding(
+                        message=(
+                            "ESLint exited non-zero but reported no per-file "
+                            "diagnostics. Raw output:\n" + raw[:500]
+                            if raw
+                            else "ESLint exited non-zero with no output."
+                        ),
+                        level=FindingLevel.ERROR,
+                    )
+                )
+            count = len(findings)
             return f"{count} lint issue(s)", findings
         return None, []
 

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -39,6 +39,23 @@ from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 _SCANNER_NOT_INSTALLED = "{name} (not installed)"
 _GIT_SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+
+# A scanner that fails to even start (its Python module isn't importable in the
+# interpreter we shell out to) is a tooling/environment problem, NOT a security
+# finding. Reporting "No module named detect_secrets" as SLOP DETECTED tells a
+# user they have a leaked secret when they have a broken install. These markers
+# identify a process that never ran a scan.
+_SCANNER_STARTUP_FAILURE_MARKERS = (
+    "No module named",
+    "ModuleNotFoundError",
+)
+
+
+def _scanner_failed_to_start(output: str) -> bool:
+    """Return True when scanner output shows it never ran (import/startup error)."""
+    return any(marker in output for marker in _SCANNER_STARTUP_FAILURE_MARKERS)
+
+
 _HEX_HIGH_ENTROPY_STRING = "Hex High Entropy String"
 
 # Canonical remediations for common bandit test IDs.  These are the fixes
@@ -868,10 +885,25 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin):
             except json.JSONDecodeError:
                 return SecuritySubResult("detect-secrets", True, "Scan completed")
 
+        # The scan command exited non-zero. Distinguish a scanner that never
+        # ran (module not importable in this interpreter — a tooling failure)
+        # from a scan that ran and genuinely failed. The former must not be
+        # reported as a security finding: that's a false "SLOP DETECTED" for a
+        # broken install, not a leaked secret.
+        output = result.output or ""
+        if _scanner_failed_to_start(output):
+            return SecuritySubResult(
+                "detect-secrets",
+                True,
+                "detect-secrets could not run (module not importable) — "
+                "skipped. Reinstall with: pipx install --force 'slopmop[all]'",
+                warned=True,
+            )
+
         return SecuritySubResult(
             "detect-secrets",
             False,
-            result.output[-300:] if result.output else "Scan failed",
+            output[-300:] if output else "Scan failed",
         )
 
     def _filter_known_secrets(

--- a/slopmop/cli/captain.py
+++ b/slopmop/cli/captain.py
@@ -23,12 +23,13 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from slopmop.reporting.envelope import (
     Diagnostic,
+    NextStep,
     Status,
     build_envelope,
 )
@@ -46,15 +47,24 @@ COMMAND = "wake-angry-drunk-captain"
 SCHEMA_VERSION = "slopmop/captain-summons/v1"
 
 # Return codes — mirror the sail "human decision needed" idiom.
-EXIT_SUMMONED = 1  # Valid summons: captain spoke, loop halted, await orders.
+EXIT_SUMMONED = 1  # Valid summons: turn is over, await the human's reply.
 EXIT_REFUSED = 2  # Insufficient justification: go back to the loop.
-EXIT_NO_CAPTAIN = 3  # No human at the wheel: run this where one can answer.
-
-# Max times to re-prompt a silent captain before giving up.
-_MAX_PROMPT_ATTEMPTS = 3
 
 # Placeholder rendered for an empty numbered list.
 _EMPTY_NUMBERED = "1. (none provided)"
+
+# The verbatim directive handed to the agent on a valid summons. The whole
+# point of this verb is that the agent cannot resolve it alone: it surfaces
+# the captain's question to the human and ends its turn. Reading stdin is
+# pointless — an agent's stdin is a pipe, never a live human — so instead the
+# verb hands back an explicit "your turn is over" instruction and the exact
+# words to relay, the same JSON-envelope contract every other verb speaks.
+AGENT_DIRECTIVE = (
+    "YOUR TURN IS OVER. Show the user the text in `relay_to_human` exactly as "
+    "written — verbatim, nothing added, nothing summarized, nothing after it — "
+    "then STOP and wait for the human's reply. Do not run any sm verb. Do not "
+    "continue the loop. The human's next message carries the captain's orders."
+)
 
 
 def _default_summons_file(project_root: str) -> Path:
@@ -73,8 +83,6 @@ class CaptainSummons:
     project_root: str
     branch: str
     summoned_at: str
-    orders: Sequence[str] = ()
-    answered_at: Optional[str] = None
 
 
 def _clean_lines(values: Sequence[str]) -> List[str]:
@@ -171,12 +179,6 @@ def render_summons_body(summons: CaptainSummons) -> str:
         ),
         "",
     ]
-    if summons.orders:
-        lines += [
-            f"## Captain's Orders ({summons.answered_at or 'unrecorded'})",
-            markdown_numbered(summons.orders, _EMPTY_NUMBERED),
-            "",
-        ]
     return "\n".join(lines)
 
 
@@ -193,8 +195,9 @@ def write_summons_file(summons: CaptainSummons, body: Optional[str] = None) -> P
 
 def _summons_payload(summons: CaptainSummons, body_path: Path) -> Dict[str, Any]:
     return {
+        "outcome": "summoned",
+        "turn_over": True,
         "summoned_at": summons.summoned_at,
-        "answered_at": summons.answered_at,
         "branch": summons.branch,
         "project_root": summons.project_root,
         "objective": summons.objective,
@@ -202,15 +205,20 @@ def _summons_payload(summons: CaptainSummons, body_path: Path) -> Dict[str, Any]
         "why_stuck": summons.why_stuck,
         "decision": summons.decision,
         "options": list(summons.options),
-        "orders": list(summons.orders),
         "summons_file": str(body_path),
+        "agent_directive": AGENT_DIRECTIVE,
+        "relay_to_human": build_relay_message(summons),
     }
 
 
-def _present_case(summons: CaptainSummons) -> None:
-    """Lay the agent's case in front of the captain (stderr, always shown)."""
+def build_relay_message(summons: CaptainSummons) -> str:
+    """Render the exact words the agent must relay to the human, verbatim.
+
+    This is the captain's question laid in front of the human, ending on a
+    direct ask. The agent does not paraphrase it — it shows this text and
+    ends its turn, and the human answers in the chat.
+    """
     lines = [
-        "",
         "🥃 CAPTAIN ON DECK",
         "",
         "*A deckhand shakes the captain awake, hat in hand.*",
@@ -239,70 +247,19 @@ def _present_case(summons: CaptainSummons) -> None:
         "Why the loop can't continue",
         f"   {summons.why_stuck}",
         "",
+        "*The captain squints at you, swaying, and waits.*",
+        '"Well? What\'s your call?"',
     ]
-    print("\n".join(lines), file=sys.stderr)
+    return "\n".join(lines)
 
 
-def _collect_captain_orders(
-    input_fn: Optional[Callable[[str], str]] = None,
-    isatty_fn: Optional[Callable[[], bool]] = None,
-) -> Optional[List[str]]:
-    """Block until the human captain types orders.
-
-    Returns the typed order lines, or ``None`` when no human is at the wheel
-    (non-interactive stdin, or the captain ends input without a word).
-    """
-    resolved_input: Callable[[str], str] = input_fn if input_fn is not None else input
-    resolved_isatty: Callable[[], bool] = (
-        isatty_fn if isatty_fn is not None else sys.stdin.isatty
-    )
-
-    if not resolved_isatty():
-        return None
-
-    prompt = (
-        '"What\'s your call, captain?"\n'
-        "(type your orders — blank line when you're done)\n> "
-    )
-    silent_retry = (
-        "\"...Still nothing, captain? The crew's waiting on your word.\n"
-        ' Give the order, or we send them back to the loop empty-handed."\n> '
-    )
-
-    for _ in range(_MAX_PROMPT_ATTEMPTS):
-        orders: List[str] = []
-        current = prompt
-        while True:
-            try:
-                # Prompt is UI: emit to stderr so --json stdout stays clean.
-                print(current, end="", file=sys.stderr, flush=True)
-                line = resolved_input("")
-            except EOFError:
-                line = ""
-                # EOF ends collection; fall through to evaluate what we have.
-                if orders:
-                    return orders
-                break
-            if not line.strip():
-                if orders:
-                    return orders
-                break  # Empty first line — re-prompt sternly.
-            orders.append(line.strip())
-            current = "> "
-        prompt = silent_retry
-
-    return None
-
-
-def cmd_captain(
-    args: argparse.Namespace,
-    input_fn: Optional[Callable[[str], str]] = None,
-    isatty_fn: Optional[Callable[[], bool]] = None,
-) -> int:
+def cmd_captain(args: argparse.Namespace) -> int:
     """Wake the angry, drunk captain — only when the loop is truly exhausted.
 
-    A valid summons does not resolve until a human at the keyboard types
-    orders. The agent cannot satisfy this verb alone — that is the point.
+    A valid summons does not resolve into more agent work: the verb hands the
+    agent the captain's question and an explicit "your turn is over" directive,
+    then halts. The agent relays the question to the human and waits. The agent
+    cannot satisfy this verb alone — that is the point.
     """
     json_output = bool(getattr(args, "json_output", False))
 
@@ -350,64 +307,13 @@ def cmd_captain(
 
     summons = build_summons(args)
     body_path = write_summons_file(summons, render_summons_body(summons))
-
-    # Lay the case in front of the captain, then demand his orders.
-    _present_case(summons)
-    orders = _collect_captain_orders(input_fn=input_fn, isatty_fn=isatty_fn)
-
-    if not orders:
-        reason = (
-            "No human at the wheel — nobody answered the prompt. This verb only "
-            "resolves when a human types orders at an interactive terminal. "
-            "Nothing was decided."
-        )
-        if json_output:
-            print(
-                json.dumps(
-                    build_envelope(
-                        command=COMMAND,
-                        status=Status.ERROR,
-                        exit_code=EXIT_NO_CAPTAIN,
-                        data={"outcome": "no_captain", "reason": reason},
-                        diagnostics=[
-                            Diagnostic(
-                                code="captain.no_human",
-                                level="error",
-                                message=reason,
-                                suggested_command=(
-                                    "sm wake-angry-drunk-captain  "
-                                    "# rerun in an interactive terminal"
-                                ),
-                            )
-                        ],
-                    ),
-                    indent=2,
-                )
-            )
-            return EXIT_NO_CAPTAIN
-        print(
-            "\n".join(
-                [
-                    "",
-                    "🥃 NO CAPTAIN AT THE WHEEL",
-                    "",
-                    "You hollered into an empty cabin — nobody's here to answer.",
-                    "This verb only resolves when a human types orders at the",
-                    "prompt. Run it where the captain can answer — an interactive",
-                    "terminal, with him at the keyboard. Nothing was decided.",
-                    "",
-                ]
-            ),
-            file=sys.stderr,
-        )
-        return EXIT_NO_CAPTAIN
-
-    summons = replace(summons, orders=orders, answered_at=iso_now())
-    body_path = write_summons_file(summons, render_summons_body(summons))
+    relay = build_relay_message(summons)
 
     if json_output:
         # A valid summons is a deliberate halt-and-await, not a failure —
         # INFO carries the non-zero exit_code that signals "loop paused".
+        # The agent reads the directive, relays `relay_to_human` verbatim,
+        # and ends its turn; the human answers in the chat.
         print(
             json.dumps(
                 build_envelope(
@@ -415,26 +321,30 @@ def cmd_captain(
                     status=Status.INFO,
                     exit_code=EXIT_SUMMONED,
                     data=_summons_payload(summons, body_path),
+                    next_steps=[
+                        NextStep(
+                            action="wait",
+                            reason=(
+                                "Your turn is over. Relay `relay_to_human` to "
+                                "the user verbatim, then wait for their reply."
+                            ),
+                        )
+                    ],
+                    diagnostics=[
+                        Diagnostic(
+                            code="captain.summoned",
+                            level="info",
+                            message=AGENT_DIRECTIVE,
+                        )
+                    ],
                 ),
                 indent=2,
             )
         )
         return EXIT_SUMMONED
 
-    ack = [
-        "",
-        "🥃 ORDERS RECEIVED — the captain has spoken",
-        "",
-    ]
-    for idx, order in enumerate(orders, 1):
-        ack.append(f"   {idx}. {order}")
-    ack += [
-        "",
-        f"Logged to: {body_path}",
-        "",
-        '"You have your orders. Carry them out. And do NOT wake me again"',
-        "   *...he mutters, stumbling back to his bunk.*",
-        "",
-    ]
-    print("\n".join(ack))
+    # Human running the verb directly: lay the case out, then stop. There is
+    # no prompt to type into — the question stands and the human answers it.
+    print(relay)
+    print(f"\nLogged to: {body_path}")
     return EXIT_SUMMONED

--- a/slopmop/cli/gang.py
+++ b/slopmop/cli/gang.py
@@ -75,6 +75,28 @@ def _msg_printf(
     return f"{spaces}printf " f"'{msg}\\n' >&2"
 
 
+def _guard_call(cmd: str, indent: int) -> str:
+    """Return the repo-guard line for a wrapper, tolerant of a missing helper.
+
+    Wrappers must only intercept inside a slop-mop repo. Normally that's
+    decided by ``_sm_in_slopmop_repo``, but that helper isn't guaranteed to be
+    present in every shell that picks up the wrapper — Claude Code (and similar
+    tools) snapshot active shell functions and can capture the ``cmd`` wrapper
+    without its private helper. Calling a missing helper prints a spurious
+    ``command not found`` to stderr on every invocation.
+
+    The ``type`` check makes the wrapper fail open: if the helper isn't
+    defined, fall straight through to the real command silently. Portable
+    across bash and zsh. Behaviour when the helper IS present is unchanged.
+    """
+    spaces = " " * indent
+    fallthrough = f'{{ command {cmd} "$@"; return; }}'
+    return (
+        f"{spaces}type _sm_in_slopmop_repo >/dev/null 2>&1 "
+        f"&& _sm_in_slopmop_repo || {fallthrough}"
+    )
+
+
 def _gen_slopmop_guard(lines: list[str]) -> None:
     """Append a helper that returns true only when inside a slop-mop repo."""
     lines += [
@@ -113,7 +135,7 @@ def _gen_function_blocks(lines: list[str]) -> None:
         lines.append(
             f'    command -v sm &>/dev/null || {{ command {cmd} "$@"; return; }}'
         )
-        lines.append(f'    _sm_in_slopmop_repo || {{ command {cmd} "$@"; return; }}')
+        lines.append(_guard_call(cmd, indent=4))
         lines.append(
             _msg_printf(
                 cmd,
@@ -138,7 +160,7 @@ def _gen_subcommand_blocks(lines: list[str]) -> None:
         lines += [
             f"{wrapper}() {{",
             f'    command -v sm &>/dev/null || {{ command {wrapper} "$@"; return; }}',
-            f'    _sm_in_slopmop_repo || {{ command {wrapper} "$@"; return; }}',
+            _guard_call(wrapper, indent=4),
             '    local _sub="${1:-}" _sub2="${2:-}"',
             '    case "$_sub $_sub2" in',
         ]
@@ -179,7 +201,7 @@ def _gen_npx_block(lines: list[str]) -> None:
     lines += [
         "npx() {",
         '    command -v sm &>/dev/null || { command npx "$@"; return; }',
-        '    _sm_in_slopmop_repo || { command npx "$@"; return; }',
+        _guard_call("npx", indent=4),
         '    case "${1:-}" in',
     ]
     for entry in npx_entries:

--- a/slopmop/cli/sail.py
+++ b/slopmop/cli/sail.py
@@ -134,10 +134,17 @@ def _reconcile_runtime_state(
 
 
 def _print_step(icon: str, heading: str, detail: str = "") -> None:
-    print(f"\n⛵ sail → {icon} {heading}")
+    # Flush immediately. stdout is block-buffered when piped (an agent's
+    # stdout always is), and sail's handlers hand off to long-running
+    # delegates like ``buff watch`` right after announcing the step. If that
+    # delegate is killed (timeout/interrupt) before the process exits
+    # normally, an unflushed buffer is lost — the invocation looks silent
+    # with no dispatch line. Flushing here guarantees the dispatch signal is
+    # durable no matter what happens next.
+    print(f"\n⛵ sail → {icon} {heading}", flush=True)
     if detail:
-        print(f"   {detail}")
-    print()
+        print(f"   {detail}", flush=True)
+    print(flush=True)
 
 
 def _swab_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -359,7 +366,8 @@ def _sail_pr_ready(args: argparse.Namespace, project_root: Path) -> int:
         "\n⛵ sail → 🏁 PR ready for human review\n"
         "   All CI green, no unresolved threads.\n"
         "   Share the PR with the human and await their decision.\n"
-        "   (Sail mode reset to tacking for the next feature.)\n"
+        "   (Sail mode reset to tacking for the next feature.)\n",
+        flush=True,
     )
     return 0
 
@@ -412,7 +420,10 @@ def cmd_sail(args: argparse.Namespace) -> int:
 
     handler = _STATE_HANDLERS.get(state)
     if handler is None:
-        print(f"⛵ sail: unknown state {state.value!r} — falling back to swab.")
+        print(
+            f"⛵ sail: unknown state {state.value!r} — falling back to swab.",
+            flush=True,
+        )
         from slopmop.cli import cmd_swab
 
         return cmd_swab(_swab_args(args))

--- a/slopmop/schemas/v3/data/wake-angry-drunk-captain.json
+++ b/slopmop/schemas/v3/data/wake-angry-drunk-captain.json
@@ -2,17 +2,18 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://slopmop.dev/schemas/v3/data/wake-angry-drunk-captain.json",
   "title": "sm wake-angry-drunk-captain data payload",
-  "description": "Result of the last-resort human-escalation verb. Two shapes selected by outcome: a 'summons' once a human captain has typed orders (the loop halts and awaits them), or an 'unresolved' record when the verb refused (insufficient justification) or found no human at the wheel. The agent knows which by the envelope status and exit_code.",
+  "description": "Result of the last-resort human-escalation verb. Two shapes selected by outcome: a 'summoned' record once the agent has supplied valid justification (the loop halts, the agent's turn is over, and it must relay the captain's question to the human and await a reply), or an 'unresolved' record when the verb refused (insufficient justification). The agent knows which by the envelope status and exit_code.",
   "oneOf": [
-    {"$ref": "#/$defs/summons"},
+    {"$ref": "#/$defs/summoned"},
     {"$ref": "#/$defs/unresolved"}
   ],
   "$defs": {
-    "summons": {
+    "summoned": {
       "type": "object",
       "required": [
+        "outcome",
+        "turn_over",
         "summoned_at",
-        "answered_at",
         "branch",
         "project_root",
         "objective",
@@ -20,18 +21,23 @@
         "why_stuck",
         "decision",
         "options",
-        "orders",
-        "summons_file"
+        "summons_file",
+        "agent_directive",
+        "relay_to_human"
       ],
       "additionalProperties": false,
       "properties": {
+        "outcome": {
+          "description": "Always 'summoned' for a valid escalation.",
+          "const": "summoned"
+        },
+        "turn_over": {
+          "description": "Always true. The agent's turn is over: relay the question to the human and wait, do not continue the loop.",
+          "const": true
+        },
         "summoned_at": {
           "description": "When the captain was woken (ISO 8601).",
           "type": "string"
-        },
-        "answered_at": {
-          "description": "When the human typed orders (ISO 8601), or null if unanswered.",
-          "type": ["string", "null"]
         },
         "branch": {"type": ["string", "null"]},
         "project_root": {"type": "string"},
@@ -57,13 +63,16 @@
           "type": "array",
           "items": {"type": "string"}
         },
-        "orders": {
-          "description": "The human's typed orders. Non-empty for a resolved summons.",
-          "type": "array",
-          "items": {"type": "string"}
-        },
         "summons_file": {
           "description": "Path to the markdown record of this summons.",
+          "type": "string"
+        },
+        "agent_directive": {
+          "description": "Explicit instruction to the agent: its turn is over; show relay_to_human verbatim and wait for the human.",
+          "type": "string"
+        },
+        "relay_to_human": {
+          "description": "The exact text the agent must show the human, verbatim — the captain's question and the crew's account, ending on a direct ask.",
           "type": "string"
         }
       }
@@ -74,8 +83,8 @@
       "additionalProperties": false,
       "properties": {
         "outcome": {
-          "description": "Why the summons did not resolve. 'refused' = insufficient justification (go back to the loop); 'no_captain' = no human at the wheel.",
-          "enum": ["refused", "no_captain"]
+          "description": "Why the summons did not resolve. 'refused' = insufficient justification (go back to the loop).",
+          "enum": ["refused"]
         },
         "reason": {
           "description": "Human-readable explanation of the outcome.",

--- a/tests/unit/test_captain.py
+++ b/tests/unit/test_captain.py
@@ -4,36 +4,17 @@ import argparse
 import json
 
 from slopmop.cli.captain import (
-    EXIT_NO_CAPTAIN,
+    AGENT_DIRECTIVE,
     EXIT_REFUSED,
     EXIT_SUMMONED,
     SCHEMA_VERSION,
     CaptainSummons,
+    build_relay_message,
     build_summons,
     cmd_captain,
     render_summons_body,
     write_summons_file,
 )
-
-
-def _scripted_captain(*lines):
-    """Return an input() stand-in that feeds the given lines, then EOF."""
-    queue = list(lines)
-
-    def _input(_prompt=""):
-        if not queue:
-            raise EOFError
-        return queue.pop(0)
-
-    return _input
-
-
-def _at_the_wheel():
-    return True
-
-
-def _no_wheel():
-    return False
 
 
 def _captain_args(**kwargs) -> argparse.Namespace:
@@ -93,61 +74,24 @@ def test_partial_justification_names_missing_fields(capsys):
     assert captured.out == ""
 
 
-def test_valid_summons_requires_orders_and_halts(tmp_path, capsys):
+def test_valid_summons_halts_and_presents_case(tmp_path, capsys):
     args = _captain_args(project_root=str(tmp_path))
-    code = cmd_captain(
-        args,
-        input_fn=_scripted_captain("hold the merge", "rename later", ""),
-        isatty_fn=_at_the_wheel,
-    )
+    code = cmd_captain(args)
     captured = capsys.readouterr()
+    # A valid summons is a deliberate halt-and-await, not a failure.
     assert code == EXIT_SUMMONED
-    # The case is presented to the captain on stderr.
-    assert "CAPTAIN ON DECK" in captured.err
-    # Orders acknowledged on stdout.
-    assert "ORDERS RECEIVED" in captured.out
-    assert "hold the merge" in captured.out
+    # The captain's question is laid out for the human on stdout.
+    assert "CAPTAIN ON DECK" in captured.out
+    assert "approve the name wake-angry-drunk-captain" in captured.out
     artifact = tmp_path / ".slopmop" / "last_captain_summons.md"
     assert artifact.exists()
     body = artifact.read_text(encoding="utf-8")
     assert "ship the captain verb" in body
-    assert "Captain's Orders" in body
-    assert "hold the merge" in body
-    assert "rename later" in body
-
-
-def test_no_captain_at_the_wheel_refuses(tmp_path, capsys):
-    args = _captain_args(project_root=str(tmp_path))
-    code = cmd_captain(args, isatty_fn=_no_wheel)
-    captured = capsys.readouterr()
-    assert code == EXIT_NO_CAPTAIN
-    assert "NO CAPTAIN AT THE WHEEL" in captured.err
-    # Nothing decided: no orders recorded in the artifact.
-    artifact = tmp_path / ".slopmop" / "last_captain_summons.md"
-    body = artifact.read_text(encoding="utf-8")
-    assert "Captain's Orders" not in body
-
-
-def test_silent_captain_eventually_refuses(tmp_path, capsys):
-    args = _captain_args(project_root=str(tmp_path))
-    # Captain stares at the prompt, types nothing, then walks off (EOF).
-    code = cmd_captain(
-        args,
-        input_fn=_scripted_captain("", "", ""),
-        isatty_fn=_at_the_wheel,
-    )
-    captured = capsys.readouterr()
-    assert code == EXIT_NO_CAPTAIN
-    assert "NO CAPTAIN AT THE WHEEL" in captured.err
 
 
 def test_valid_summons_json_output(tmp_path, capsys):
     args = _captain_args(project_root=str(tmp_path), json_output=True)
-    code = cmd_captain(
-        args,
-        input_fn=_scripted_captain("approved", ""),
-        isatty_fn=_at_the_wheel,
-    )
+    code = cmd_captain(args)
     captured = capsys.readouterr()
     assert code == EXIT_SUMMONED
     envelope = json.loads(captured.out)
@@ -157,24 +101,18 @@ def test_valid_summons_json_output(tmp_path, capsys):
     assert envelope["exit_code"] == EXIT_SUMMONED
     payload = envelope["data"]
     assert "schema" not in payload
+    assert payload["outcome"] == "summoned"
+    assert payload["turn_over"] is True
     assert payload["objective"] == "ship the captain verb"
     assert payload["verbs_tried"] == ["sm swab — green", "sm scour — green"]
-    assert payload["orders"] == ["approved"]
-    assert payload["answered_at"]
+    # The agent gets an explicit "turn over" directive and the verbatim relay.
+    assert payload["agent_directive"] == AGENT_DIRECTIVE
+    assert "CAPTAIN ON DECK" in payload["relay_to_human"]
+    assert "approve the name wake-angry-drunk-captain" in payload["relay_to_human"]
     assert payload["summons_file"].endswith("last_captain_summons.md")
-
-
-def test_no_captain_json_output(tmp_path, capsys):
-    """No human at the wheel + --json emits the no_captain error envelope."""
-    args = _captain_args(project_root=str(tmp_path), json_output=True)
-    code = cmd_captain(args, isatty_fn=_no_wheel)
-    assert code == EXIT_NO_CAPTAIN
-    envelope = json.loads(capsys.readouterr().out)
-    assert envelope["command"] == "wake-angry-drunk-captain"
-    assert envelope["status"] == "error"
-    assert envelope["exit_code"] == EXIT_NO_CAPTAIN
-    assert envelope["data"]["outcome"] == "no_captain"
-    assert envelope["diagnostics"][0]["code"] == "captain.no_human"
+    # The machine signal to halt rides on next_steps + the info diagnostic.
+    assert envelope["next_steps"][0]["action"] == "wait"
+    assert envelope["diagnostics"][0]["code"] == "captain.summoned"
 
 
 def test_build_summons_resolves_root_and_strips(tmp_path):
@@ -187,6 +125,17 @@ def test_build_summons_resolves_root_and_strips(tmp_path):
     assert summons.objective == "padded objective"
     assert summons.verbs_tried == ["sm swab — green"]
     assert summons.project_root == str(tmp_path.resolve())
+
+
+def test_relay_message_carries_question_and_account(tmp_path):
+    summons = _summons(tmp_path)
+    relay = build_relay_message(summons)
+    assert "THE QUESTION" in relay
+    assert summons.decision in relay
+    assert summons.objective in relay
+    assert summons.why_stuck in relay
+    # Ends on a direct ask to the human.
+    assert "What's your call?" in relay
 
 
 def test_render_body_handles_missing_options(tmp_path):

--- a/tests/unit/test_detect_secrets_check.py
+++ b/tests/unit/test_detect_secrets_check.py
@@ -44,6 +44,41 @@ class TestRunDetectSecrets:
         assert result.passed is True
         assert "No secrets" in result.findings
 
+    def test_detect_secrets_module_missing_is_not_a_finding(self, tmp_path):
+        """A scanner that can't import is a tooling failure, not SLOP.
+
+        Regression for the barnacle where ``No module named detect_secrets``
+        was reported as a security finding (SLOP DETECTED) instead of a
+        graceful skip — telling users they had a leaked secret when they
+        actually had a broken install.
+        """
+        check = SecurityLocalCheck({})
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.output = "/path/to/python: No module named detect_secrets\n"  # pragma: allowlist secret
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.name == "detect-secrets"
+        # Not a failure — it never ran, so it cannot be a security finding.
+        assert result.passed is True
+        assert result.warned is True
+        assert "could not run" in result.findings
+
+    def test_detect_secrets_real_scan_failure_still_fails(self, tmp_path):
+        """A genuine scan failure (not a startup error) is still reported."""
+        check = SecurityLocalCheck({})
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.output = "detect-secrets: error: unrecognized arguments: --bogus"
+
+        with patch.object(check, "_run_command", return_value=mock_result):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.name == "detect-secrets"
+        assert result.passed is False
+
     def test_detect_secrets_with_findings(self, tmp_path):
         """Test _run_detect_secrets with secrets found."""
         check = SecurityLocalCheck({})

--- a/tests/unit/test_gang.py
+++ b/tests/unit/test_gang.py
@@ -645,6 +645,30 @@ class TestIntegrationAliasesSh:
         assert "[slop-mop]" not in result.stderr
         assert "fake-gh" in result.stdout
 
+    def test_missing_repo_guard_helper_falls_through_silently(
+        self, tmp_path: Path
+    ) -> None:
+        """Wrapper without its _sm_in_slopmop_repo helper must not spam errors.
+
+        Regression: tools like Claude Code snapshot active shell functions and
+        can capture a wrapper (e.g. ``gh``) without its private helper. Calling
+        the missing helper printed ``command not found`` on every invocation.
+        The wrapper must fail open — run the real command, silently.
+        """
+        aliases = self._make_aliases(tmp_path)
+        fake_bin = self._make_fake_bin(tmp_path, ("sm", "gh"))
+        # Source, then drop the helper to simulate the snapshot picking up the
+        # wrapper alone. ``gh run watch`` would otherwise be blocked in-repo.
+        result = self._bash(
+            aliases,
+            fake_bin,
+            "unset -f _sm_in_slopmop_repo; gh run watch",
+        )
+        assert "command not found" not in result.stderr
+        assert "_sm_in_slopmop_repo" not in result.stderr
+        assert "[slop-mop]" not in result.stderr
+        assert "fake-gh" in result.stdout
+
     def test_sm_not_found_falls_through_to_real_command(self, tmp_path: Path) -> None:
         """When sm is absent from PATH, intercepts fall through to the real command."""
         import shutil

--- a/tests/unit/test_javascript_checks.py
+++ b/tests/unit/test_javascript_checks.py
@@ -603,6 +603,46 @@ class TestJavaScriptLintFormatCheck:
             "corrupted" in f.message for f in result.findings
         ), "Expected raw output snippet in finding"
 
+    def test_run_eslint_nonzero_with_empty_json_surfaces_raw_output(self, tmp_path):
+        """ESLint exiting non-zero with empty JSON must not hide the failure.
+
+        Regression for barnacle #220: when ESLint exits non-zero but emits a
+        valid-but-empty JSON body (real error printed to stderr), the gate used
+        to report an opaque "N lint issue(s)" with no location, forcing a rerun
+        to diagnose. The finding must now carry the raw output.
+        """
+        (tmp_path / "package.json").write_text('{"name": "test"}')
+        (tmp_path / "node_modules").mkdir()
+        check = JavaScriptLintFormatCheck({})
+
+        eslint_result = MagicMock()
+        eslint_result.success = False
+        eslint_result.stdout = "[]"
+        eslint_result.output = (
+            "Oops! Something went wrong! :(\n"
+            "ESLint couldn't determine the plugin uniquely."
+        )
+
+        prettier_result = MagicMock()
+        prettier_result.success = True
+        prettier_result.output = ""
+
+        with patch.object(
+            check, "_run_command", side_effect=[eslint_result, prettier_result]
+        ):
+            result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert result.findings, "Expected a finding even with empty ESLint JSON"
+        # The real error text must be surfaced, not swallowed into a generic count.
+        assert any(
+            "plugin uniquely" in f.message for f in result.findings
+        ), "Expected raw ESLint error output in finding"
+        # And it must NOT be only the contentless aggregate message.
+        assert not all(
+            "issue(s) found" in f.message for f in result.findings
+        ), "Failure was reported with no diagnosable detail"
+
     # ------------------------------------------------------------------
     # Deno project tests
     # ------------------------------------------------------------------

--- a/tests/unit/test_machine_interface_conformance.py
+++ b/tests/unit/test_machine_interface_conformance.py
@@ -381,30 +381,35 @@ def test_captain_summons_output_conforms_to_schema(
     tmp_path: "object",
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # The summons branch needs a human at the wheel, so drive cmd_captain
-    # directly with scripted I/O rather than shelling through sm.main.
-    from slopmop.cli.captain import cmd_captain
-
-    args = argparse.Namespace(
-        objective="ship it",
-        verbs_tried=["sm swab — green"],
-        why_stuck="nothing left to automate",
-        decision="merge or hold?",
-        options=["merge", "hold"],
-        project_root=str(tmp_path),
-        json_output=True,
-    )
-    orders = iter(["merge", ""])
-    rc = cmd_captain(
-        args,
-        input_fn=lambda _prompt: next(orders),
-        isatty_fn=lambda: True,
+    # A valid summons halts and hands the agent the relay payload — no stdin,
+    # so it drives straight through sm.main with full justification.
+    rc = sm.main(
+        [
+            "wake-angry-drunk-captain",
+            "--objective",
+            "ship it",
+            "--verbs-tried",
+            "sm swab — green",
+            "--why-stuck",
+            "nothing left to automate",
+            "--decision",
+            "merge or hold?",
+            "--option",
+            "merge",
+            "--option",
+            "hold",
+            "--project-root",
+            str(tmp_path),
+            "--json",
+        ]
     )
     assert rc == 1
     envelope = json.loads(capsys.readouterr().out)
     assert envelope["command"] == "wake-angry-drunk-captain"
     assert envelope["status"] == "info"
-    assert envelope["data"]["orders"] == ["merge"]
+    assert envelope["data"]["outcome"] == "summoned"
+    assert envelope["data"]["turn_over"] is True
+    assert envelope["data"]["relay_to_human"]
 
     data_schema = load_data_schema("wake-angry-drunk-captain")
     assert data_schema is not None


### PR DESCRIPTION
## Summary

Remediates the open tool-friction barnacles surfaced during live dogfooding, plus a stray shell-intercept noise bug found while filing them.

- **#241** `wake-angry-drunk-captain`: dropped the unreachable stdin/TTY prompt and switched to a v3 JSON relay. The verb now ends the agent's turn explicitly (`turn_over` + `agent_directive`) and returns a verbatim `relay_to_human` message; the human's reply carries the captain's orders. No more "rerun in an interactive terminal" dead end.
- **#233** `sail`: flush step / PR_READY / fallback output so block-buffering on a pipe plus a killed delegate can no longer swallow the result.
- **#232** detect-secrets: distinguish "scanner could not start" (non-blocking warning) from "scanner found a secret" (blocking finding).
- **#230**: added an explicit install-handoff runbook to the shared agent template and the slopmop skill.
- **#220** `sloppy-formatting.js`: when ESLint exits non-zero with no parseable per-file findings, surface the raw output instead of an opaque "N lint issue(s)" with no location (which forced a rerun that then passed from cache).

**#226** was already fixed upstream by PR #223 — verified, no code change needed; closing it here to clear the backlog.

Closes #220
Closes #226
Closes #230
Closes #232
Closes #233
Closes #241
Closes #244

## Test plan

- [x] `sm swab` green (16 gates pass, 1 pre-existing non-blocking config-debt warning)
- [x] New regression tests: eslint empty-JSON failure surfaces raw output; detect-secrets scanner-cant-start vs finding; captain summoned-envelope conformance; gang wrapper falls through silently when helper is absent
- [x] Verified gang fix live in a real bash subprocess (helper present → blocks in-repo; helper unset → silent fall-through)
- [ ] CI green

> Note: #241 (and these fixes generally) only take effect once `sm` is rebuilt/reinstalled — the installed pipx build still shows the old captain behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)