### PR TITLE
refactor+fix: shared JSONC parser + always-label barnacles (#244/#245 follow-ups)

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -23,8 +23,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Type checker was burying people under errors coming from other people's untyped libraries, with no way to quiet them short of switching the whole check off. Now it respects a project's own settings so they can hush just the noisy bits",
-    "direction": "Getting this reviewed and shipped alongside the other friction fixes",
+    "status": "Tidying up two things at once: one shared way to read config files with comments (we had three slightly-broken copies), and making sure friction reports always get tagged so they don't get lost",
+    "direction": "Wrapping these up; one unrelated security alert on a borrowed library is in the way and needs a call on how to handle it",
     "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ security = [
     "pyasn1>=0.6.3",  # GHSA-jr27-m4p2-rc6r
     "requests>=2.33.0",  # GHSA-gc5v-m9x4-r6x2
     "python-multipart>=0.0.27",  # GHSA-pp6c-gr5w-3c5g via semgrep/mcp
+    "pyjwt>=2.13.0",  # PYSEC-2026-175, PYSEC-2026-177, PYSEC-2026-179 via semgrep/mcp
     "starlette>=1.0.1",  # PYSEC-2026-161 via mcp/sse-starlette
     "semgrep>=1.140.0",
     "pip-audit>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ cryptography>=46.0.7
 pyasn1>=0.6.3
 requests>=2.33.0
 python-multipart>=0.0.27
+pyjwt>=2.13.0
 starlette>=1.0.1
 semgrep>=1.140.0
 pip-audit>=2.0.0

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 import time
 from typing import Any, Dict, List, Optional, cast
 
@@ -17,6 +16,7 @@ from slopmop.checks.base import (
 from slopmop.checks.mixins import JavaScriptCheckMixin
 from slopmop.constants import NPM_INSTALL_FAILED
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
+from slopmop.utils.jsonc import loads_jsonc
 
 
 class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
@@ -247,9 +247,9 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
             try:
                 with open(cfg_path) as f:
                     text = f.read()
-                # Strip // line comments (JSONC) before parsing
-                stripped = re.sub(r"//[^\n]*", "", text)
-                parsed: Any = json.loads(stripped)
+                # knip configs are JSONC (comments + trailing commas); parse
+                # with the shared string-aware stripper.
+                parsed: Any = loads_jsonc(text)
                 if isinstance(parsed, dict):
                     return cast(Dict[str, Any], parsed)
             except (json.JSONDecodeError, OSError):

--- a/slopmop/checks/python/type_checking.py
+++ b/slopmop/checks/python/type_checking.py
@@ -40,6 +40,7 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.mixins import PythonCheckMixin
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
+from slopmop.utils.jsonc import loads_jsonc
 
 # pyright rules we enforce for type completeness
 TYPE_COMPLETENESS_RULES: Dict[str, str] = {
@@ -138,66 +139,6 @@ def _detect_venv_path(project_root: str) -> Tuple[Optional[str], Optional[str]]:
         return venv_parent, venv_name
 
     return None, None
-
-
-def _strip_jsonc(text: str) -> str:
-    """Make a JSONC document parseable by ``json.loads``.
-
-    pyright config files are JSONC: they may contain ``//`` line comments,
-    ``/* */`` block comments, and trailing commas — all of which ``json.loads``
-    rejects. Strip them so a project's pyrightconfig.json is honored instead of
-    silently failing to parse (which would discard its rule overrides).
-
-    A naive regex can't do this: pyright glob values like ``"src/**"`` and
-    ``"packages/*/dist"`` contain ``/*`` and ``*/``, and a path could contain
-    ``//`` — a regex would treat those as comment markers and swallow the rule
-    keys in between. So this scans character by character, never touching the
-    contents of a (double-quoted, escape-aware) JSON string.
-    """
-    out: List[str] = []
-    i = 0
-    n = len(text)
-    in_string = False
-    while i < n:
-        ch = text[i]
-        if in_string:
-            out.append(ch)
-            if ch == "\\" and i + 1 < n:  # keep escaped char verbatim
-                out.append(text[i + 1])
-                i += 2
-                continue
-            if ch == '"':
-                in_string = False
-            i += 1
-            continue
-        if ch == '"':
-            in_string = True
-            out.append(ch)
-            i += 1
-            continue
-        if ch == "/" and i + 1 < n and text[i + 1] == "/":  # line comment
-            i += 2
-            while i < n and text[i] != "\n":
-                i += 1
-            continue
-        if ch == "/" and i + 1 < n and text[i + 1] == "*":  # block comment
-            i += 2
-            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
-                i += 1
-            i += 2
-            continue
-        if ch in "}]":  # drop a trailing comma already emitted before this
-            k = len(out) - 1
-            while k >= 0 and out[k] in " \t\r\n":
-                k -= 1
-            if k >= 0 and out[k] == ",":
-                del out[k]
-            out.append(ch)
-            i += 1
-            continue
-        out.append(ch)
-        i += 1
-    return "".join(out)
 
 
 def _detect_source_dirs(project_root: str) -> List[str]:
@@ -359,7 +300,7 @@ class PythonTypeCheckingCheck(BaseCheck, PythonCheckMixin):
             return {}
         try:
             text = path.read_text(encoding="utf-8")
-            data: Any = json.loads(_strip_jsonc(text))
+            data: Any = loads_jsonc(text)
         except (json.JSONDecodeError, OSError):
             return {}
         return cast(Dict[str, Any], data) if isinstance(data, dict) else {}

--- a/slopmop/cli/barnacle.py
+++ b/slopmop/cli/barnacle.py
@@ -43,6 +43,9 @@ _MISSING_LABEL_MARKERS = (
     "couldn't find",
     "unable to resolve",
 )
+# Used when auto-creating the label in a repo that doesn't have it yet.
+_BARNACLE_LABEL_COLOR = "5319e7"
+_BARNACLE_LABEL_DESCRIPTION = "Slop-mop tool-friction report from real usage"
 
 
 @dataclass(frozen=True)
@@ -262,10 +265,46 @@ def _is_missing_barnacle_label(stderr: str) -> bool:
     return any(marker in text for marker in _MISSING_LABEL_MARKERS)
 
 
+def _ensure_barnacle_label(repo: str) -> bool:
+    """Best-effort create the ``barnacle`` label in ``repo``.
+
+    Returns True if the label exists afterwards (created or already present).
+    ``gh label create --force`` upserts, so a pre-existing label is fine.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "label",
+                "create",
+                "barnacle",
+                "--repo",
+                repo,
+                "--color",
+                _BARNACLE_LABEL_COLOR,
+                "--description",
+                _BARNACLE_LABEL_DESCRIPTION,
+                "--force",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
 def create_barnacle_issue(
     issue: BarnacleIssue, body_file: Optional[str] = None, body: Optional[str] = None
 ) -> Tuple[subprocess.CompletedProcess[str], Path]:
-    """Create the GitHub issue, retrying without the barnacle label if needed."""
+    """Create the GitHub issue, ensuring the barnacle label is applied.
+
+    If the repo is missing the ``barnacle`` label, create it and retry *with*
+    the label — dropping it silently is how barnacles end up unlabeled and
+    invisible to ``--label barnacle`` triage. Only if the label can't be
+    created do we fall back to filing without it, and we warn when we do.
+    """
     issue_body_path = write_issue_body_file(issue, body_file, body)
     try:
         result = subprocess.run(
@@ -281,6 +320,25 @@ def create_barnacle_issue(
     if not missing_label or "barnacle" not in issue.labels:
         return result, issue_body_path
 
+    # The repo lacks the `barnacle` label. Create it and retry with the label
+    # so the barnacle stays discoverable.
+    if _ensure_barnacle_label(issue.repo):
+        retry = subprocess.run(
+            _issue_create_command(issue, issue.labels, issue_body_path),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if retry.returncode == 0 or not _is_missing_barnacle_label(retry.stderr):
+            return retry, issue_body_path
+
+    # Last resort: file without the barnacle label rather than not at all, but
+    # make the gap visible so a human can re-tag it.
+    print(
+        "⚠️  Could not apply the 'barnacle' label; filing without it. "
+        "Create the label and re-tag this issue so it shows up in triage.",
+        file=sys.stderr,
+    )
     fallback_labels = tuple(label for label in issue.labels if label != "barnacle")
     return (
         subprocess.run(

--- a/slopmop/utils/jsonc.py
+++ b/slopmop/utils/jsonc.py
@@ -1,0 +1,76 @@
+"""Shared JSONC parsing for config files (pyright, knip, ...).
+
+Several gates read config files that are JSON-with-comments: pyright's
+``pyrightconfig.json`` and knip's ``knip.jsonc`` both allow ``//`` line
+comments, ``/* */`` block comments, and trailing commas — none of which
+``json.loads`` accepts. Each gate used to strip those with its own regex, and
+those regexes kept reintroducing the same bug: a naive ``//`` or ``/* */``
+regex doesn't respect string boundaries, so glob values like ``"src/**"`` or a
+path containing ``//`` get treated as comment markers and silently corrupt the
+document. This module is the single, string-aware implementation everyone
+shares so that bug class stays fixed in one place.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+
+def strip_jsonc(text: str) -> str:
+    """Return ``text`` with JSONC comments and trailing commas removed.
+
+    Handles ``//`` line comments, ``/* */`` block comments, and trailing commas
+    before ``}``/``]``. Scans character by character and never inspects the
+    contents of a double-quoted, escape-aware JSON string, so values such as
+    ``"src/**"``, ``"packages/*/dist"``, or ``"http://example"`` survive intact.
+    """
+    out: List[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:  # keep escaped char verbatim
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":  # line comment
+            i += 2
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":  # block comment
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        if ch in "}]":  # drop a trailing comma already emitted before this
+            k = len(out) - 1
+            while k >= 0 and out[k] in " \t\r\n":
+                k -= 1
+            if k >= 0 and out[k] == ",":
+                del out[k]
+            out.append(ch)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def loads_jsonc(text: str) -> Any:
+    """Parse a JSONC document (comments + trailing commas tolerated)."""
+    return json.loads(strip_jsonc(text))

--- a/tests/unit/test_barnacle.py
+++ b/tests/unit/test_barnacle.py
@@ -190,24 +190,62 @@ class TestCreateBarnacleIssue:
         assert "barnacle" in command
         assert "bug" in command
 
-    def test_retries_without_barnacle_label_when_missing(self, tmp_path):
+    def test_creates_label_and_retries_with_it_when_missing(self, tmp_path):
+        """Missing barnacle label → create the label, retry WITH it (#244/#245)."""
         missing = subprocess.CompletedProcess(
             args=["gh"], returncode=1, stdout="", stderr="label barnacle not found"
+        )
+        label_created = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="", stderr=""
         )
         success = subprocess.CompletedProcess(
             args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
         )
         with patch(
-            "slopmop.cli.barnacle.subprocess.run", side_effect=[missing, success]
+            "slopmop.cli.barnacle.subprocess.run",
+            side_effect=[missing, label_created, success],
         ) as run:
             result, _body_path = create_barnacle_issue(
                 _issue(project_root=str(tmp_path))
             )
 
         assert result.returncode == 0
-        fallback_command = run.call_args_list[1].args[0]
+        # Second call creates the label.
+        label_command = run.call_args_list[1].args[0]
+        assert label_command[:3] == ["gh", "label", "create"]
+        assert "barnacle" in label_command
+        # Third call re-files the issue WITH the barnacle label intact.
+        retry_command = run.call_args_list[2].args[0]
+        assert retry_command[:3] == ["gh", "issue", "create"]
+        assert "barnacle" in retry_command
+        assert "bug" in retry_command
+
+    def test_files_without_label_as_last_resort_when_label_create_fails(
+        self, tmp_path, capsys
+    ):
+        """If the label can't be created, file without it but warn loudly."""
+        missing = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="label barnacle not found"
+        )
+        label_failed = subprocess.CompletedProcess(
+            args=["gh"], returncode=1, stdout="", stderr="permission denied"
+        )
+        success = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="https://example.test/1\n", stderr=""
+        )
+        with patch(
+            "slopmop.cli.barnacle.subprocess.run",
+            side_effect=[missing, label_failed, success],
+        ) as run:
+            result, _body_path = create_barnacle_issue(
+                _issue(project_root=str(tmp_path))
+            )
+
+        assert result.returncode == 0
+        fallback_command = run.call_args_list[2].args[0]
         assert "barnacle" not in fallback_command
         assert "bug" in fallback_command
+        assert "could not apply the 'barnacle' label" in capsys.readouterr().err.lower()
 
     def test_does_not_retry_for_non_label_error_mentioning_barnacle(self, tmp_path):
         failed = subprocess.CompletedProcess(

--- a/tests/unit/test_jsonc.py
+++ b/tests/unit/test_jsonc.py
@@ -1,0 +1,51 @@
+"""Tests for the shared string-aware JSONC parser."""
+
+from slopmop.utils.jsonc import loads_jsonc, strip_jsonc
+
+
+class TestStripJsonc:
+    def test_strips_line_comments(self):
+        assert loads_jsonc('{"a": 1} // trailing\n') == {"a": 1}
+
+    def test_strips_block_comments(self):
+        assert loads_jsonc('{/* c */ "a": 1}') == {"a": 1}
+
+    def test_strips_multiline_block_comments(self):
+        assert loads_jsonc('{\n/* one\n two */\n"a": 1}') == {"a": 1}
+
+    def test_strips_trailing_comma_in_object(self):
+        assert loads_jsonc('{"a": 1,}') == {"a": 1}
+
+    def test_strips_trailing_comma_in_array(self):
+        assert loads_jsonc('{"a": [1, 2,]}') == {"a": [1, 2]}
+
+    def test_strips_trailing_comma_with_whitespace_and_comment(self):
+        assert loads_jsonc('{"a": 1, // note\n}') == {"a": 1}
+
+    def test_preserves_slashes_inside_strings(self):
+        # // and /* */ inside string values must NOT be treated as comments.
+        cfg = loads_jsonc(
+            '{"url": "http://example.com", "glob": "src/**", "p": "packages/*/dist"}'
+        )
+        assert cfg["url"] == "http://example.com"
+        assert cfg["glob"] == "src/**"
+        assert cfg["p"] == "packages/*/dist"
+
+    def test_does_not_strip_comma_inside_string(self):
+        assert loads_jsonc('{"a": "x, ]"}') == {"a": "x, ]"}
+
+    def test_preserves_escaped_quote_in_string(self):
+        assert loads_jsonc('{"a": "she said \\"hi\\""}') == {"a": 'she said "hi"'}
+
+    def test_plain_json_is_unchanged(self):
+        assert strip_jsonc('{"a": 1}') == '{"a": 1}'
+
+    def test_glob_pair_does_not_swallow_keys_between_them(self):
+        # Regression: a regex stripper would match from the /* in "src/**" to
+        # the */ in "packages/*/dist" and eat the key between them.
+        text = (
+            '{\n  "include": ["src/**"],\n'
+            '  "secret": "kept",\n'
+            '  "exclude": ["packages/*/dist"]\n}'
+        )
+        assert loads_jsonc(text)["secret"] == "kept"


### PR DESCRIPTION
Two follow-ups from the #244/#245 review, plus one bundled security pin needed to keep scour green.

## 1. Shared string-aware JSONC parser

The #245 review surfaced three escalating bugs in an ad-hoc pyright-config comment stripper (block comments, then string-boundary corruption, then logic). The same fragile regex approach also lived in the knip-config reader. New `slopmop/utils/jsonc.py` provides one hardened, **string-aware** `strip_jsonc`/`loads_jsonc` (handles `//`, `/* */`, trailing commas; never touches contents of quoted strings like `"src/**"` or `"http://x"`). Wired into both the pyright (`type_checking.py`) and knip (`dead_code.py`) readers; removed the now-unused `re` imports.

> Out of scope: `dart/bogus_tests.py` has a `_strip_comments` too, but it operates on **Dart source**, not JSON — a JSON-oriented util would be wrong there, so it's left alone.

## 2. Barnacles always get labeled

`#244` and `#245` came in **unlabeled**. Root cause: when a repo lacks the `barnacle` label, the filer silently dropped the label and filed the issue without it — exactly how friction reports become invisible to `--label barnacle` triage. The filer now **creates the label and retries with it**, only filing without as a last resort (and warning loudly when it does).

## 3. (bundled) pyjwt security pin

pip-audit flagged `pyjwt 2.12.1` (transitive via semgrep/mcp) for PYSEC-2026-175/177/179 — a pre-existing, advisory-driven `dependency-risk` failure unrelated to the above, but it blocks the shared scour gate. Pinned `pyjwt>=2.13.0` the same way the neighboring transitive deps (python-multipart, starlette) are handled.

Closes #244
Closes #245

## Test plan

- [x] `sm scour` clean (18 passed, 1 pre-existing non-blocking config-debt warning)
- [x] New `tests/unit/test_jsonc.py` covers comment/trailing-comma stripping and string-boundary preservation (the exact glob case that broke the regex)
- [x] Barnacle tests updated: label-create-and-retry path, plus last-resort warning path
- [ ] CI green

> Note: #244 and #245 are already closed (their fixes merged in #246/#247); the `Closes` keywords here are belt-and-suspenders for the label/follow-up work and harmless if already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)