### PR TITLE
refactor(gates): move network/expensive gates from swab to scour

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -23,8 +23,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Tidying up two things at once: one shared way to read config files with comments (we had three slightly-broken copies), and making sure friction reports always get tagged so they don't get lost",
-    "direction": "Wrapping these up; one unrelated security alert on a borrowed library is in the way and needs a call on how to handle it",
+    "status": "Moved the slow and network-using checks out of the quick every-commit pass and into the thorough pre-PR pass, so the quick loop stays fast and stays offline like it's supposed to",
+    "direction": "Getting this reviewed and shipped; also flagging that my local copy of the tool is out of date",
     "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {

--- a/slopmop/checks/quality/duplicate_strings.py
+++ b/slopmop/checks/quality/duplicate_strings.py
@@ -18,6 +18,7 @@ from slopmop.checks.base import (
     ConfigField,
     Flaw,
     GateCategory,
+    GateLevel,
     ScopeInfo,
     ToolContext,
     count_source_scope,
@@ -38,7 +39,9 @@ class StringDuplicationCheck(BaseCheck):
     literals repeated across multiple files. These are candidates
     for extraction to a constants module.
 
-    Level: swab
+    Level: scour. Cross-file scanning is comparatively expensive and the
+    signal changes slowly, so it runs in the pre-PR sweep rather than on
+    every commit.
 
     Configuration:
       threshold: 2 — minimum occurrences to flag a string.
@@ -60,10 +63,11 @@ class StringDuplicationCheck(BaseCheck):
           in tools/find-duplicate-strings/.
 
     Re-check:
-      sm swab -g myopia:string-duplication.py --verbose
+      sm scour -g myopia:string-duplication.py --verbose
     """
 
     tool_context = ToolContext.NODE
+    level = GateLevel.SCOUR
     # DIAGNOSTIC not FOUNDATION — the detection tool is vendored in
     # tools/find-duplicate-strings/, not pip/npm-installable.  The
     # protocol's litmus test is "could a developer reproduce this gate

--- a/slopmop/checks/quality/duplication.py
+++ b/slopmop/checks/quality/duplication.py
@@ -24,6 +24,7 @@ from slopmop.checks.base import (
     ConfigField,
     Flaw,
     GateCategory,
+    GateLevel,
     RemediationChurn,
     ScopeInfo,
     ToolContext,
@@ -44,7 +45,10 @@ class RepeatedCodeCheck(BaseCheck):
     TypeScript, and other languages. Reports specific file pairs and
     line ranges so you know exactly what to deduplicate.
 
-    Level: swab
+    Level: scour. jscpd clone detection is comparatively expensive and the
+    signal (cross-file duplication) changes slowly, so it runs in the
+    pre-PR sweep rather than on every commit — matching the agent rails,
+    which route any duplication scanner to ``sm scour``.
 
     Configuration:
       threshold: 5 — maximum allowed duplication percentage. 5% is
@@ -63,11 +67,12 @@ class RepeatedCodeCheck(BaseCheck):
       jscpd not available: npm install -g jscpd
 
     Re-check:
-      sm swab -g laziness:repeated-code --verbose
+      sm scour -g laziness:repeated-code --verbose
     """
 
     tool_context = ToolContext.NODE
     role = CheckRole.FOUNDATION
+    level = GateLevel.SCOUR
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_LIKELY
 
     def __init__(self, config: Dict[str, Any], threshold: float = DEFAULT_THRESHOLD):

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -117,13 +117,16 @@ class SecuritySubResult:
 
 
 class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
-    """Local security scanning (no network required).
+    """Security scanning: bandit + detect-secrets + semgrep, in parallel.
 
-    Wraps bandit, semgrep, and detect-secrets in parallel.
-    Reports only HIGH/MEDIUM severity findings to reduce noise
-    while catching real security issues.
+    Reports only HIGH/MEDIUM severity findings to reduce noise while
+    catching real security issues.
 
-    Level: scour
+    Level: scour. bandit and detect-secrets are local, but semgrep runs
+    ``--config=auto``, which fetches rulesets over the network on every run.
+    A SWAB gate must be network-free (and security scanning is a pre-push
+    concern, not a per-commit one), so this runs at scour — matching the
+    agent rails, which already route bandit/detect-secrets to ``sm scour``.
 
     Configuration:
       scanners: ["bandit", "semgrep", "detect-secrets"] — all three
@@ -141,12 +144,13 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
           .secrets.baseline if it's a false positive.
 
     Re-check:
-      sm swab -g myopia:vulnerability-blindness.py --verbose
+      sm scour -g myopia:vulnerability-blindness.py --verbose
     """
 
     tool_context = ToolContext.SM_TOOL
     required_tools = ["bandit", "detect-secrets"]
     role = CheckRole.FOUNDATION
+    level = GateLevel.SCOUR
 
     @property
     def name(self) -> str:

--- a/tests/integration/test_docker_install.py
+++ b/tests/integration/test_docker_install.py
@@ -192,10 +192,12 @@ class TestHappyPath:
 
     def test_key_gates_run(self, result_all_pass: RunResult) -> None:
         result_all_pass.assert_prerequisites()
+        # All swab-level gates. vulnerability-blindness.py is intentionally not
+        # here — it's scour-only (semgrep --config=auto needs the network).
         for gate in (
             "sloppy-formatting.py",
             "untested-code.py",
-            "vulnerability-blindness.py",
+            "dead-code.py",
         ):
             assert (
                 gate in result_all_pass.output

--- a/tests/integration/test_docker_install.py
+++ b/tests/integration/test_docker_install.py
@@ -225,14 +225,24 @@ class TestAllFail:
         result_all_fail.assert_prerequisites()
         _assert_gate_failed(result_all_fail, "sloppy-formatting.js")
 
-    def test_security_gate_fails(self, result_all_fail: RunResult) -> None:
-        """vulnerability-blindness.py should fail — hardcoded DB_PASSWORD triggers bandit B105.
+    def test_security_gate_is_scour_only(self, result_all_fail: RunResult) -> None:
+        """Both security gates are scour-level — neither runs during ``sm swab``.
 
-        Note: dependency-risk.py is scour-level and does not run during ``sm swab``.
-        vulnerability-blindness.py is the swab-level security gate.
+        vulnerability-blindness.py moved to scour because semgrep ``--config=auto``
+        fetches rulesets over the network (a swab gate must be network-free), and
+        dependency-risk.py was already scour. Secret/vuln *detection* is covered
+        by unit tests; here we just guard that swab stays fast and network-free.
         """
         result_all_fail.assert_prerequisites()
-        _assert_gate_failed(result_all_fail, "vulnerability-blindness.py")
+        leaked = [
+            line
+            for line in result_all_fail.output.splitlines()
+            if "vulnerability-blindness" in line.lower() and "fail" in line.lower()
+        ]
+        assert not leaked, (
+            "vulnerability-blindness.py is scour-level and must not run during "
+            "swab:\n" + "\n".join(leaked)
+        )
 
     def test_pytest_gate_fails(self, result_all_fail: RunResult) -> None:
         """untested-code.py should not pass.
@@ -267,13 +277,22 @@ class TestMixed:
             result_mixed.exit_code == 1
         ), f"Expected exit 1 (some validate failures) on mixed branch:\n{result_mixed}"
 
-    def test_security_gate_fails(self, result_mixed: RunResult) -> None:
-        """vulnerability-blindness.py should fail — hardcoded INTERNAL_API_KEY triggers bandit.
+    def test_security_gate_is_scour_only(self, result_mixed: RunResult) -> None:
+        """Security gates are scour-level — they don't run during ``sm swab``.
 
-        Note: dependency-risk.py is scour-level and does not run during ``sm swab``.
+        vulnerability-blindness.py and dependency-risk.py are both scour now
+        (semgrep --config=auto needs the network), so neither appears in swab.
         """
         result_mixed.assert_prerequisites()
-        _assert_gate_failed(result_mixed, "vulnerability-blindness.py")
+        leaked = [
+            line
+            for line in result_mixed.output.splitlines()
+            if "vulnerability-blindness" in line.lower() and "fail" in line.lower()
+        ]
+        assert not leaked, (
+            "vulnerability-blindness.py is scour-level and must not run during "
+            "swab:\n" + "\n".join(leaked)
+        )
 
     def test_dead_code_gate_fails(self, result_mixed: RunResult) -> None:
         result_mixed.assert_prerequisites()

--- a/tests/unit/test_sm_cli_config.py
+++ b/tests/unit/test_sm_cli_config.py
@@ -503,7 +503,7 @@ class TestCmdConfig:
             exclude_dir=None,
             json=None,
             swabbing_timeout=None,
-            swab_off="myopia:vulnerability-blindness.py",
+            swab_off="laziness:sloppy-formatting.py",
             swab_on=None,
         )
 
@@ -511,9 +511,7 @@ class TestCmdConfig:
 
         assert result == 0
         config = json.loads((tmp_path / ".sb_config.json").read_text())
-        assert (
-            config["myopia"]["gates"]["vulnerability-blindness.py"]["run_on"] == "scour"
-        )
+        assert config["laziness"]["gates"]["sloppy-formatting.py"]["run_on"] == "scour"
 
     def test_swab_on_gate(self, tmp_path):
         """--swab-on promotes a gate into the swab rail."""


### PR DESCRIPTION
## Summary

The `SWAB` contract is documented as **"fast, local, no network or PR context."** Three gates violated it and are moved to `SCOUR` — which the agent rails (`_shared/core.md`) *already* route their tools to (`bandit`/`detect-secrets` → `sm scour`, `jscpd`/duplication → `sm scour`). This was code drifting from the project's own documented contract.

| Gate | Why it leaves swab |
|---|---|
| `myopia:vulnerability-blindness.py` | **Network**: semgrep `--config=auto` fetches rulesets from semgrep.dev on every run. Its docstring already said "Level: scour" but the `level` ClassVar was never set, so it ran on swab against its own stated intent. Security scanning is a pre-push concern; its sibling `dependency-risk.py` is already scour. |
| `laziness:repeated-code` | **Expense**: jscpd clone detection (~4–16s), slow-changing signal. |
| `myopia:string-duplication.py` | **Expense**: cross-file token scan (~10–50s). |

`untested-code` (the full test suite, the other big swab cost) is **deliberately left on swab** — "do the tests pass" is the most foundational per-commit signal; the right fix there is caching/impact-selection, not releveling.

Result: swab drops from 16 → 13 gates; scour is unchanged (superset). Teams wanting any of these per-commit can opt in via `run_on` in config.

## Test plan

- [x] `swab` (via checkout) now runs 13 gates — the three are excluded
- [x] `scour` runs 18 and stays green — the three still run there
- [x] Registry probe confirms all three resolve to SCOUR by default (no config override)
- [x] Unit test updated: swab-off example now uses an actual swab gate
- [x] Docker integration security assertions updated to verify the gates are scour-only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)