### PR TITLE
docs: add community standards (CoC, issue templates, PR template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something in slop-mop itself is broken or behaving incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! A focused, reproducible report gets fixed fastest.
+
+        **Using slop-mop in another repo and hit tool friction** (a gate giving
+        invalid guidance, a false positive, a blocked-but-valid workflow)? Prefer
+        `sm barnacle file` from that repo instead — it captures the right context
+        and labels automatically.
+  - type: input
+    id: version
+    attributes:
+      label: slop-mop version
+      description: "Output of `sm --version` (or the PyPI version installed)."
+      placeholder: "2.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      description: What actually happens.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact `sm` command(s) and minimal context to reproduce.
+      placeholder: |
+        1. Run `sm swab -g <gate>`
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, local vs CI, and the affected gate if known.
+      placeholder: "macOS 14, Python 3.12, local, gate: laziness:sloppy-formatting.py"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Tool friction while using slop-mop in another repo
+    url: https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/CONTRIBUTING.md
+    about: Run `sm barnacle file` from the affected repo — it captures reproduction context and applies the right labels automatically.
+  - name: Security vulnerability
+    url: https://github.com/ScienceIsNeato/slop-mop/security/policy
+    about: Please report security issues privately via the security policy, not as a public issue.
+  - name: Documentation & contributing guide
+    url: https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/CONTRIBUTING.md
+    about: How to set up, run the gates, and open a PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new gate, command, or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! For a **new gate**, consider prototyping it as a
+        [custom gate](../README.md#custom-gates) first to confirm it catches real
+        problems before proposing a full implementation (see the
+        [New Gate Protocol](../DOCS/NEW_GATE_PROTOCOL.md)).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What gap or friction are you hitting? What slop slips through today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: The gate, command, or change you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why this one.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for contributing to slop-mop! Keep this PR focused — one logical change.
+See DOCS/CONTRIBUTING.md for the full guide.
+-->
+
+## What & why
+
+<!-- A sentence or two: what this changes and the problem it solves. -->
+
+Closes #<!-- issue number, if any -->
+
+## Checklist
+
+- [ ] `sm scour` passes locally (the comprehensive pre-PR sweep; `sm swab` is the faster inner-loop check)
+- [ ] Tests added or updated for the change
+- [ ] Docs updated if behavior, CLI surface, or config changed
+- [ ] If adding a gate: followed the [New Gate Protocol](../DOCS/NEW_GATE_PROTOCOL.md)
+- [ ] If renaming a gate or changing config keys: added the matching `sm upgrade` migration
+- [ ] Commit messages follow the conventional style (`fix:`, `feat:`, `refactor:`, `test:`, `docs:`, `chore:`)
+
+## Notes for reviewers
+
+<!-- Anything that helps review: tradeoffs considered, areas to scrutinize, follow-ups deferred. -->

--- a/.willville.json
+++ b/.willville.json
@@ -25,8 +25,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Made the version number live in exactly one place. Everything else - the docs, the install files, the release tooling - now copies from that one spot, and a test fails the build if anything ever disagrees",
-    "direction": "So version numbers can never quietly fall out of sync again",
+    "status": "Putting out the welcome mat for outside contributors — house rules, a conduct policy, and fill-in-the-blank forms for reporting bugs and asking for features",
+    "direction": "Part of a bigger push to make the project easy for newcomers to trust and join",
     "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our pledge
+
+The slop-mop community is meant to be a welcoming, respectful, and harassment-free
+place for everyone, regardless of background or identity. Maintainers and
+contributors are expected to interact in good faith and treat each other with
+courtesy and professionalism.
+
+## Our standard
+
+In short: be respectful, be constructive, and assume good intent. Critique ideas,
+not people. Behavior that harasses, demeans, or excludes others has no place here.
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)**
+as its full code of conduct. That document defines the expected behavior, the
+unacceptable behavior, and the enforcement responsibilities in detail, and it
+governs all project spaces (issues, pull requests, discussions, and any other
+official channels).
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it privately to the
+project maintainer:
+
+- Use GitHub's private contact options for [@ScienceIsNeato](https://github.com/ScienceIsNeato), or
+- If a report can't be made privately, open a minimal issue stating that a code
+  of conduct concern needs a private channel — do not include details publicly.
+
+Reports will be reviewed and handled as confidentially as is practical. The
+maintainer is responsible for enforcement and may take any action deemed
+appropriate, up to and including a ban from project spaces.
+
+## Attribution
+
+This Code of Conduct adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/DOCS/CONTRIBUTING.md
+++ b/DOCS/CONTRIBUTING.md
@@ -9,6 +9,11 @@ Honestly, I'm not really sure what my plans are for this project long term? For 
 - **Self-validate.** Run `sm swab` before opening a PR. If the gates don't pass on slop-mop itself, the CI won't either.
 - **CI model.** The first-class merge blocker is the `slop-mop primary code scanning gate` workflow (`Primary Code Scanning Gate (blocking)` job). A downstream `slop-mop downstream dogfood sanity` workflow is optional and runs only after the primary gate passes on PRs.
 
+## Code of Conduct
+
+Participation in this project is governed by our
+[Code of Conduct](../CODE_OF_CONDUCT.md). Be respectful and constructive.
+
 ## License
 
 This project is licensed under the Slop-Mop Attribution License v1.0 — you're free to use, modify, and redistribute, but attribution back to [ScienceIsNeato/slop-mop](https://github.com/ScienceIsNeato/slop-mop) is required. See [LICENSE](../LICENSE) for full terms.


### PR DESCRIPTION
Part of the broad-adoption push (per the research-report triage). Fills the gaps in GitHub's community profile so the project is legible to outside contributors.

## What's added
- **CODE_OF_CONDUCT.md** — adopts [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) by reference, with a private reporting path. Linked from `DOCS/CONTRIBUTING.md`.
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` + `feature_request.yml` forms mirroring the repo's existing issue-reporting protocol, and a `config.yml` that:
  - redirects in-repo tool friction to `sm barnacle file`,
  - routes security reports to the security policy,
  - keeps blank issues enabled (so maintainer roadmap filing isn't blocked).
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist tied to the real workflow: `sm scour`, tests, docs, New Gate Protocol, and `sm upgrade` migrations.

## Notes
- `CONTRIBUTING` already existed (`.github/CONTRIBUTING.md` → `DOCS/CONTRIBUTING.md`), so it's left in place — just added a Code of Conduct section.
- Not addressed here (deliberately, per triage): doc version drift, license clarification, release-channel strategy. Those are separate decisions.

## Test plan
- [x] `sm swab` clean
- [x] Issue-template YAML parses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)