### PR TITLE
refactor(version): single source of truth in slopmop/_version.py

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "displayName": "slop-mop",
-  "version": "1.2.0",
+  "version": "2.1.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Wraps pytest, black, mypy, gh, and every other tool behind a single `sm` CLI with caching, ordering, and directed remediation built in.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           import os
           import re
           import subprocess
-          import tomllib
+          import sys
           from pathlib import Path
 
 
@@ -113,11 +113,15 @@ jobs:
 
 
           def project_version(text: str) -> str:
-              return tomllib.loads(text)["project"]["version"]
+              # Single source of truth: slopmop/_version.py.
+              match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', text)
+              if not match:
+                  raise SystemExit("Could not find __version__ in slopmop/_version.py")
+              return match.group(1)
 
 
-          pyproject = Path("pyproject.toml")
-          current_text = pyproject.read_text()
+          version_file = Path("slopmop/_version.py")
+          current_text = version_file.read_text()
           current = project_version(current_text)
           commit_sha = ""
           release_branch = ""
@@ -141,13 +145,13 @@ jobs:
           ).stdout.strip()
           if commit_sha:
               current_text = subprocess.run(
-                  ["git", "show", f"{commit_sha}:pyproject.toml"],
+                  ["git", "show", f"{commit_sha}:slopmop/_version.py"],
                   capture_output=True,
                   text=True,
                   check=True,
               ).stdout
               parent_text = subprocess.run(
-                  ["git", "show", f"{commit_sha}^:pyproject.toml"],
+                  ["git", "show", f"{commit_sha}^:slopmop/_version.py"],
                   capture_output=True,
                   text=True,
                   check=True,
@@ -172,26 +176,20 @@ jobs:
               previous = current
               release_branch = f"release/v{version}"
               updated = re.sub(
-                  r'^version\s*=\s*"[^"]+"',
-                  f'version = "{version}"',
+                  r'^__version__\s*=\s*"[^"]+"',
+                  f'__version__ = "{version}"',
                   current_text,
                   count=1,
                   flags=re.MULTILINE,
               )
               if updated == current_text:
-                  raise SystemExit("Could not update version in pyproject.toml")
-              pyproject.write_text(updated)
+                  raise SystemExit("Could not update __version__ in slopmop/_version.py")
+              version_file.write_text(updated)
 
-              plugin_json = Path(".cursor-plugin/plugin.json")
-              if plugin_json.exists():
-                  plugin_text = plugin_json.read_text()
-                  plugin_updated = re.sub(
-                      r'"version"\s*:\s*"[^"]+"',
-                      f'"version": "{version}"',
-                      plugin_text,
-                      count=1,
-                  )
-                  plugin_json.write_text(plugin_updated)
+              # Propagate the new version into every file that mentions it
+              # (README, machine-interface example, issue template, cursor
+              # plugin manifest). One source, no drift.
+              subprocess.run([sys.executable, "scripts/sync_version.py"], check=True)
 
           if version == previous:
               raise SystemExit("Release workflow requires a version bump")
@@ -242,7 +240,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$RELEASE_BRANCH"
-          git add pyproject.toml
+          git add -A
           git commit -m "chore: bump version to ${VERSION} for PyPI release [release-run:${GITHUB_RUN_ID}]"
           trap 'git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"' EXIT
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -356,9 +354,9 @@ jobs:
       - name: Verify package version matches release version
         run: |
           EXPECTED_VERSION="${{ needs.release-context.outputs.version }}"
-          TOML_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          if [ "$EXPECTED_VERSION" != "$TOML_VERSION" ]; then
-            echo "Detected release version ($EXPECTED_VERSION) does not match pyproject.toml ($TOML_VERSION)"
+          SRC_VERSION=$(python -c "import re, pathlib; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('slopmop/_version.py').read_text()).group(1))")
+          if [ "$EXPECTED_VERSION" != "$SRC_VERSION" ]; then
+            echo "Detected release version ($EXPECTED_VERSION) does not match slopmop/_version.py ($SRC_VERSION)"
             exit 1
           fi
           echo "Version match: $EXPECTED_VERSION"

--- a/.willville.json
+++ b/.willville.json
@@ -5,7 +5,9 @@
     "display_name": "The Mop Bucket",
     "district": "slop-wharf",
     "stop": "the-mop-bucket",
-    "lines": ["quality"],
+    "lines": [
+      "quality"
+    ],
     "visibility": "public",
     "homepage": "https://github.com/ScienceIsNeato/slop-mop",
     "repo": "ScienceIsNeato/slop-mop"
@@ -23,8 +25,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Moved the slow and network-using checks out of the quick every-commit pass and into the thorough pre-PR pass, so the quick loop stays fast and stays offline like it's supposed to",
-    "direction": "Getting this reviewed and shipped; also flagging that my local copy of the tool is out of date",
+    "status": "Made the version number live in exactly one place. Everything else - the docs, the install files, the release tooling - now copies from that one spot, and a test fails the build if anything ever disagrees",
+    "direction": "So version numbers can never quietly fall out of sync again",
     "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {

--- a/DOCS/MACHINE_INTERFACE.md
+++ b/DOCS/MACHINE_INTERFACE.md
@@ -185,7 +185,7 @@ sm capabilities
   "status": "info",
   "exit_code": 0,
   "data": {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "verbs": [
       { "name": "swab", "summary": "…", "level": "core",
         "formats": ["human", "json", "porcelain", "sarif"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is purposefully opinionated, as structure begets adherence to best practices.
 
 ## Project Status
 
-slop-mop has reached 2.0.0. The current public policy surface for release and
+slop-mop is at version 2.1.0. The current public policy surface for release and
 stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slopmop"
-version = "2.1.0"
+# Version is the single source of truth in slopmop/_version.py (read below via
+# [tool.setuptools.dynamic]). Do not hardcode a version here.
+dynamic = ["version"]
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
 license = {text = "Slop-Mop Attribution License v1.0"}
@@ -109,6 +111,9 @@ Homepage = "https://github.com/ScienceIsNeato/slop-mop"
 Repository = "https://github.com/ScienceIsNeato/slop-mop"
 Issues = "https://github.com/ScienceIsNeato/slop-mop/issues"
 Changelog = "https://github.com/ScienceIsNeato/slop-mop/releases"
+
+[tool.setuptools.dynamic]
+version = { attr = "slopmop._version.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,10 +7,11 @@
 #   ./scripts/release.sh major   # 0.3.0 → 1.0.0
 #
 # What it does:
-#   1. Reads the current version from pyproject.toml
+#   1. Reads the current version from slopmop/_version.py (the single source)
 #   2. Computes the bumped version
 #   3. Creates a release/<new_version> branch off main
-#   4. Updates pyproject.toml with the new version
+#   4. Updates slopmop/_version.py and runs scripts/sync_version.py to
+#      propagate it into the docs, issue template, and cursor plugin manifest
 #   5. Commits, pushes, and opens a PR
 #
 # The PR merge is still manual. This script is the PR-based fallback for cases
@@ -34,12 +35,14 @@ usage() {
     exit 1
 }
 
-pyproject_version_from_stream() {
+version_from_stream() {
     python3 -c "
+import re
 import sys
-import tomllib
 
-print(tomllib.loads(sys.stdin.read())['project']['version'])
+text = sys.stdin.read()
+match = re.search(r'__version__\s*=\s*[\"\']([^\"\']+)[\"\']', text)
+print(match.group(1) if match else '')
 "
 }
 
@@ -82,13 +85,9 @@ if [[ -n "$(git status --porcelain)" ]]; then
     die "Working tree is dirty. Commit or stash changes first."
 fi
 
-# ── Read current version from pyproject.toml ─────────────
+# ── Read current version from the single source of truth ─
 
-CURRENT_VERSION=$(python3 -c "
-import tomllib
-with open('pyproject.toml', 'rb') as f:
-    print(tomllib.load(f)['project']['version'])
-")
+CURRENT_VERSION=$(version_from_stream < slopmop/_version.py)
 
 echo "📦 Current version: $CURRENT_VERSION"
 
@@ -133,38 +132,37 @@ if [[ "$REMOTE_BRANCH_EXISTS" == "true" ]]; then
     echo "ℹ️  Remote branch $BRANCH_NAME already exists. Reusing it..."
     git fetch origin "$BRANCH_NAME" >/dev/null 2>&1 || die "Could not fetch existing remote branch $BRANCH_NAME"
 
-    REMOTE_VERSION="$(git show FETCH_HEAD:pyproject.toml 2>/dev/null | pyproject_version_from_stream 2>/dev/null || true)"
+    REMOTE_VERSION="$(git show FETCH_HEAD:slopmop/_version.py 2>/dev/null | version_from_stream 2>/dev/null || true)"
     if [[ "$REMOTE_VERSION" != "$NEW_VERSION" ]]; then
         die "Remote branch $BRANCH_NAME already exists but targets version ${REMOTE_VERSION:-unknown}, not $NEW_VERSION. Inspect or delete the branch first."
     fi
 else
     git checkout -b "$BRANCH_NAME"
 
-    # ── Bump version in pyproject.toml ───────────────────────
+    # ── Bump the single source of truth, then sync everything ─
 
     # Use python to do a precise in-place replacement (no sed portability issues)
     python3 -c "
 import re, pathlib
-p = pathlib.Path('pyproject.toml')
+p = pathlib.Path('slopmop/_version.py')
 text = p.read_text()
 text = re.sub(
-    r'^version\s*=\s*\"[^\"]+\"',
-    'version = \"${NEW_VERSION}\"',
+    r'^__version__\s*=\s*\"[^\"]+\"',
+    '__version__ = \"${NEW_VERSION}\"',
     text,
     count=1,
     flags=re.MULTILINE,
 )
 p.write_text(text)
-print('✅ pyproject.toml updated')
+print('✅ slopmop/_version.py updated')
 "
+
+    # Propagate into README, docs, issue template, and the cursor plugin.
+    python3 scripts/sync_version.py
 
     # ── Verify the bump ─────────────────────────────────────
 
-    VERIFY_VERSION=$(python3 -c "
-import tomllib
-with open('pyproject.toml', 'rb') as f:
-    print(tomllib.load(f)['project']['version'])
-")
+    VERIFY_VERSION=$(version_from_stream < slopmop/_version.py)
 
     if [[ "$VERIFY_VERSION" != "$NEW_VERSION" ]]; then
         die "Version verification failed: expected $NEW_VERSION, got $VERIFY_VERSION"
@@ -172,7 +170,7 @@ with open('pyproject.toml', 'rb') as f:
 
     # ── Commit + push ────────────────────────────────────────
 
-    git add pyproject.toml
+    git add -A
     git commit -m "chore: bump version to ${NEW_VERSION} for PyPI release"
 
     echo "🚀 Pushing $BRANCH_NAME..."

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Propagate the single-source version into the docs that state it.
+
+The version lives in exactly one place: ``slopmop/_version.py``. This script
+pushes that value into the handful of non-code files that mention the *current*
+slop-mop version, and a ``--check`` mode reports drift without writing.
+
+  python scripts/sync_version.py          # rewrite docs to match the source
+  python scripts/sync_version.py --check  # exit 1 if any target is out of sync
+
+``tests/unit/test_version_consistency.py`` calls :func:`check` so a mismatch
+can never be merged.
+
+Only *current-slop-mop-version* mentions are managed. Versions that are NOT
+slop-mop's — the SARIF spec version, the Contributor Covenant version, the
+``1.0.0`` stability-policy boundary, and illustrative migration examples — are
+intentionally left untouched by keeping the target patterns narrow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_VERSION_RE = re.compile(r"__version__\s*=\s*[\"']([^\"']+)[\"']")
+
+
+def source_version() -> str:
+    """Read the canonical version from slopmop/_version.py (no import needed)."""
+    text = (REPO_ROOT / "slopmop" / "_version.py").read_text(encoding="utf-8")
+    match = _VERSION_RE.search(text)
+    if not match:
+        raise SystemExit("Could not find __version__ in slopmop/_version.py")
+    return match.group(1)
+
+
+@dataclass(frozen=True)
+class Target:
+    """A file + a narrow pattern whose single capture group is the version."""
+
+    path: str
+    pattern: str
+    description: str
+
+
+# Each pattern must have exactly ONE capture group around the version number,
+# and must be specific enough to match only the current-slop-mop-version
+# mention(s) in that file.
+TARGETS: Tuple[Target, ...] = (
+    Target(
+        "README.md",
+        r"slop-mop is at version (\d+\.\d+\.\d+)",
+        "README project-status line",
+    ),
+    Target(
+        "DOCS/MACHINE_INTERFACE.md",
+        r'"version": "(\d+\.\d+\.\d+)"',
+        "sm capabilities example envelope",
+    ),
+    Target(
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        r'placeholder: "(\d+\.\d+\.\d+)"',
+        "bug-report version-field example",
+    ),
+    Target(
+        ".cursor-plugin/plugin.json",
+        r'"version": "(\d+\.\d+\.\d+)"',
+        "Cursor plugin manifest version",
+    ),
+)
+
+
+def _sub_version(text: str, pattern: str, version: str) -> str:
+    return re.sub(pattern, lambda m: m.group(0).replace(m.group(1), version), text)
+
+
+def check() -> Tuple[str, List[str]]:
+    """Return (source_version, problems). Empty problems means fully in sync."""
+    version = source_version()
+    problems: List[str] = []
+    for target in TARGETS:
+        path = REPO_ROOT / target.path
+        if not path.exists():
+            # Tolerate targets that live on a not-yet-merged branch.
+            continue
+        text = path.read_text(encoding="utf-8")
+        found = re.findall(target.pattern, text)
+        if not found:
+            problems.append(
+                f"{target.path}: pattern for {target.description!r} matched nothing "
+                f"(did the surrounding text change?)"
+            )
+            continue
+        stale = sorted({v for v in found if v != version})
+        if stale:
+            problems.append(
+                f"{target.path}: {target.description} has {stale}, expected "
+                f"{version!r}"
+            )
+    return version, problems
+
+
+def apply() -> Tuple[str, List[str]]:
+    """Rewrite targets to the source version. Return (version, changed_paths)."""
+    version = source_version()
+    changed: List[str] = []
+    for target in TARGETS:
+        path = REPO_ROOT / target.path
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        updated = _sub_version(text, target.pattern, version)
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(target.path)
+    return version, changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift and exit non-zero instead of rewriting.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        version, problems = check()
+        if problems:
+            print(f"Version drift from slopmop/_version.py ({version}):", file=sys.stderr)
+            for problem in problems:
+                print(f"  - {problem}", file=sys.stderr)
+            return 1
+        print(f"All version mentions are in sync at {version}.")
+        return 0
+
+    version, changed = apply()
+    if changed:
+        print(f"Synced {len(changed)} file(s) to {version}:")
+        for path in changed:
+            print(f"  - {path}")
+    else:
+        print(f"Already in sync at {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -24,15 +24,16 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 _VERSION_RE = re.compile(r"__version__\s*=\s*[\"']([^\"']+)[\"']")
 
 
-def source_version() -> str:
-    """Read the canonical version from slopmop/_version.py (no import needed)."""
-    text = (REPO_ROOT / "slopmop" / "_version.py").read_text(encoding="utf-8")
+def source_version(root: Optional[Path] = None) -> str:
+    """Read the canonical version from <root>/slopmop/_version.py (no import)."""
+    root = root or REPO_ROOT
+    text = (root / "slopmop" / "_version.py").read_text(encoding="utf-8")
     match = _VERSION_RE.search(text)
     if not match:
         raise SystemExit("Could not find __version__ in slopmop/_version.py")
@@ -79,12 +80,16 @@ def _sub_version(text: str, pattern: str, version: str) -> str:
     return re.sub(pattern, lambda m: m.group(0).replace(m.group(1), version), text)
 
 
-def check() -> Tuple[str, List[str]]:
+def check(
+    root: Optional[Path] = None, targets: Optional[Iterable[Target]] = None
+) -> Tuple[str, List[str]]:
     """Return (source_version, problems). Empty problems means fully in sync."""
-    version = source_version()
+    root = root or REPO_ROOT
+    targets = TARGETS if targets is None else targets
+    version = source_version(root)
     problems: List[str] = []
-    for target in TARGETS:
-        path = REPO_ROOT / target.path
+    for target in targets:
+        path = root / target.path
         if not path.exists():
             # Tolerate targets that live on a not-yet-merged branch.
             continue
@@ -105,12 +110,16 @@ def check() -> Tuple[str, List[str]]:
     return version, problems
 
 
-def apply() -> Tuple[str, List[str]]:
+def apply(
+    root: Optional[Path] = None, targets: Optional[Iterable[Target]] = None
+) -> Tuple[str, List[str]]:
     """Rewrite targets to the source version. Return (version, changed_paths)."""
-    version = source_version()
+    root = root or REPO_ROOT
+    targets = TARGETS if targets is None else targets
+    version = source_version(root)
     changed: List[str] = []
-    for target in TARGETS:
-        path = REPO_ROOT / target.path
+    for target in targets:
+        path = root / target.path
         if not path.exists():
             continue
         text = path.read_text(encoding="utf-8")
@@ -121,14 +130,14 @@ def apply() -> Tuple[str, List[str]]:
     return version, changed
 
 
-def main() -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--check",
         action="store_true",
         help="Report drift and exit non-zero instead of rewriting.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.check:
         version, problems = check()

--- a/slopmop/__init__.py
+++ b/slopmop/__init__.py
@@ -1,9 +1,6 @@
 """Slop-Mop: Quality gates for AI-assisted codebases."""
 
-from importlib.metadata import version as _pkg_version
-
+from slopmop._version import __version__
 from slopmop.exceptions import MissingDependencyError
-
-__version__ = _pkg_version("slopmop")
 
 __all__ = ["MissingDependencyError", "__version__"]

--- a/slopmop/_version.py
+++ b/slopmop/_version.py
@@ -1,0 +1,14 @@
+"""Single source of truth for the slop-mop version.
+
+Bump **only this value** to change the version — the release workflow does it
+automatically. Everything else derives from it:
+
+- ``pyproject.toml`` reads it via ``[tool.setuptools.dynamic]``.
+- ``slopmop/__init__.py`` re-exports it as ``slopmop.__version__``.
+- ``scripts/sync_version.py`` propagates it into the docs that state the
+  current version.
+- ``tests/unit/test_version_consistency.py`` fails CI if any of those drift
+  from this value, so a mismatch can never be merged.
+"""
+
+__version__ = "2.1.0"

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 _RELEASE_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release.sh"
+_SYNC_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "sync_version.py"
 _HAS_BASH = shutil.which("bash") is not None
 _HAS_GIT = shutil.which("git") is not None
 _IS_UNIX = os.name != "nt"
@@ -43,11 +44,9 @@ def _checked(
     return result.stdout.strip()
 
 
-def _write_pyproject(path: Path, version: str) -> None:
-    path.write_text(
-        "[project]\n" 'name = "slopmop"\n' f'version = "{version}"\n',
-        encoding="utf-8",
-    )
+def _write_version_file(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'__version__ = "{version}"\n', encoding="utf-8")
 
 
 def _init_release_repo(tmp_path: Path) -> Path:
@@ -76,10 +75,17 @@ def _init_release_repo(tmp_path: Path) -> Path:
 
     (work / "scripts").mkdir()
     shutil.copy2(_RELEASE_SCRIPT, work / "scripts" / "release.sh")
-    _write_pyproject(work / "pyproject.toml", "0.14.1")
+    shutil.copy2(_SYNC_SCRIPT, work / "scripts" / "sync_version.py")
+    _write_version_file(work / "slopmop" / "_version.py", "0.14.1")
 
     _checked(
-        work, "git", "add", "pyproject.toml", "scripts/release.sh", label="git add"
+        work,
+        "git",
+        "add",
+        "slopmop/_version.py",
+        "scripts/release.sh",
+        "scripts/sync_version.py",
+        label="git add",
     )
     _checked(work, "git", "commit", "-m", "initial", label="git commit")
     _checked(work, "git", "push", "-u", "origin", "main", label="git push main")
@@ -88,8 +94,8 @@ def _init_release_repo(tmp_path: Path) -> Path:
 
 def _create_remote_release_branch(work: Path, branch_name: str, version: str) -> str:
     _checked(work, "git", "checkout", "-b", branch_name, label="git checkout release")
-    _write_pyproject(work / "pyproject.toml", version)
-    _checked(work, "git", "add", "pyproject.toml", label="git add release")
+    _write_version_file(work / "slopmop" / "_version.py", version)
+    _checked(work, "git", "add", "slopmop/_version.py", label="git add release")
     _checked(
         work,
         "git",

--- a/tests/unit/test_sync_version.py
+++ b/tests/unit/test_sync_version.py
@@ -1,0 +1,131 @@
+"""Tests for scripts/sync_version.py (version propagation + drift detection)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load():
+    path = REPO_ROOT / "scripts" / "sync_version.py"
+    spec = importlib.util.spec_from_file_location("sync_version_under_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sync = _load()
+
+
+def _make_repo(tmp_path: Path, version: str) -> Path:
+    (tmp_path / "slopmop").mkdir()
+    (tmp_path / "slopmop" / "_version.py").write_text(
+        f'__version__ = "{version}"\n', encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _doc_target():
+    return sync.Target("doc.md", r"version (\d+\.\d+\.\d+)", "doc line")
+
+
+# ── pure helpers ──────────────────────────────────────────────────────────
+
+
+def test_sub_version_replaces_only_the_captured_group():
+    text = 'see version 1.0.0 here, and a glob "src/**"'
+    out = sync._sub_version(text, r"version (\d+\.\d+\.\d+)", "2.5.9")
+    assert "version 2.5.9" in out
+    assert "src/**" in out  # untouched
+
+
+def test_source_version_reads_the_file(tmp_path):
+    _make_repo(tmp_path, "3.4.5")
+    assert sync.source_version(tmp_path) == "3.4.5"
+
+
+def test_source_version_raises_when_missing(tmp_path):
+    (tmp_path / "slopmop").mkdir()
+    (tmp_path / "slopmop" / "_version.py").write_text("# no version here\n")
+    with pytest.raises(SystemExit):
+        sync.source_version(tmp_path)
+
+
+# ── check / apply with injected root + targets ────────────────────────────
+
+
+def test_check_clean_when_in_sync(tmp_path):
+    _make_repo(tmp_path, "1.2.3")
+    (tmp_path / "doc.md").write_text("the doc says version 1.2.3\n")
+    version, problems = sync.check(tmp_path, [_doc_target()])
+    assert version == "1.2.3"
+    assert problems == []
+
+
+def test_check_reports_drift(tmp_path):
+    _make_repo(tmp_path, "1.2.3")
+    (tmp_path / "doc.md").write_text("the doc says version 9.9.9\n")
+    _version, problems = sync.check(tmp_path, [_doc_target()])
+    assert problems and "9.9.9" in problems[0]
+
+
+def test_check_reports_missing_pattern(tmp_path):
+    _make_repo(tmp_path, "1.2.3")
+    (tmp_path / "doc.md").write_text("the prose was reworded; no version token\n")
+    _version, problems = sync.check(tmp_path, [_doc_target()])
+    assert problems and "matched nothing" in problems[0]
+
+
+def test_check_tolerates_missing_target_file(tmp_path):
+    _make_repo(tmp_path, "1.2.3")
+    # doc.md does not exist -> skipped, no problem
+    _version, problems = sync.check(tmp_path, [_doc_target()])
+    assert problems == []
+
+
+def test_apply_rewrites_then_check_is_clean(tmp_path):
+    _make_repo(tmp_path, "4.0.0")
+    doc = tmp_path / "doc.md"
+    doc.write_text("the doc says version 1.0.0\n")
+    version, changed = sync.apply(tmp_path, [_doc_target()])
+    assert version == "4.0.0"
+    assert changed == ["doc.md"]
+    assert "version 4.0.0" in doc.read_text()
+    # Idempotent: second apply changes nothing.
+    _v, changed_again = sync.apply(tmp_path, [_doc_target()])
+    assert changed_again == []
+
+
+# ── main() CLI surface (monkeypatch the module's REPO_ROOT) ────────────────
+
+
+def test_main_check_passes_on_real_repo(capsys):
+    assert sync.main(["--check"]) == 0
+    assert "in sync" in capsys.readouterr().out
+
+
+def test_main_check_fails_on_drift(tmp_path, monkeypatch, capsys):
+    _make_repo(tmp_path, "1.2.3")
+    (tmp_path / "README.md").write_text("slop-mop is at version 9.9.9\n")
+    monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+    assert sync.main(["--check"]) == 1
+    assert "drift" in capsys.readouterr().err.lower()
+
+
+def test_main_apply_syncs_then_reports_already_in_sync(tmp_path, monkeypatch, capsys):
+    _make_repo(tmp_path, "2.2.2")
+    readme = tmp_path / "README.md"
+    readme.write_text("slop-mop is at version 1.1.1\n")
+    monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
+
+    assert sync.main([]) == 0
+    assert "Synced" in capsys.readouterr().out
+    assert "version 2.2.2" in readme.read_text()
+
+    assert sync.main([]) == 0
+    assert "Already in sync" in capsys.readouterr().out

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,62 @@
+"""Guard tests: the version must never drift from slopmop/_version.py.
+
+slopmop/_version.py is the single source of truth. These tests fail CI if the
+package, pyproject, or any version-bearing doc disagrees with it — so a
+mismatch can never be merged. The set of managed doc targets lives in
+scripts/sync_version.py (imported here so there is one definition, not two).
+"""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on py310
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import slopmop
+from slopmop._version import __version__ as SOURCE_VERSION
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_sync_module():
+    path = REPO_ROOT / "scripts" / "sync_version.py"
+    spec = importlib.util.spec_from_file_location("sync_version", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve annotations against the
+    # module (sys.modules.get(cls.__module__) must not be None).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_source_version_is_semver():
+    assert re.fullmatch(r"\d+\.\d+\.\d+", SOURCE_VERSION), SOURCE_VERSION
+
+
+def test_package_version_matches_source():
+    assert slopmop.__version__ == SOURCE_VERSION
+
+
+def test_pyproject_does_not_hardcode_version():
+    """pyproject must derive the version dynamically, not pin its own literal."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert "version" not in data["project"], (
+        "pyproject.toml hardcodes a version; it must use "
+        "dynamic = ['version'] reading slopmop/_version.py"
+    )
+    assert "version" in data["project"].get("dynamic", [])
+    attr = data["tool"]["setuptools"]["dynamic"]["version"]["attr"]
+    assert attr == "slopmop._version.__version__", attr
+
+
+def test_docs_are_in_sync_with_source():
+    """Every managed doc states exactly the source version (no drift)."""
+    sync = _load_sync_module()
+    version, problems = sync.check()
+    assert version == SOURCE_VERSION
+    assert not problems, "version drift detected:\n  " + "\n  ".join(problems)


### PR DESCRIPTION
You spotted a version string that would drift (the bug-report template placeholder) — turns out several already had. This makes drift structurally impossible.

## The problem
Version was de-facto defined in `pyproject.toml` and re-stated, **unguarded**, in multiple files — which had already drifted while shipping 2.1.0:
- `README.md` → "reached 2.0.0"
- `.cursor-plugin/plugin.json` → "1.2.0"
- `DOCS/MACHINE_INTERFACE.md` example → "2.0.0"

## The design (one source, enforced)
- **`slopmop/_version.py`** holds `__version__` — the single source of truth.
- **`pyproject.toml`** reads it via `[tool.setuptools.dynamic]` — no hardcoded version literal anymore. *(Verified the build resolves it: installed metadata = 2.1.0.)*
- **`slopmop/__init__.py`** imports it directly.
- **`scripts/sync_version.py`** propagates it into the files that state the current version (README, machine-interface example, issue-template placeholder, cursor plugin). It's **allowlist-precise** — it never touches the SARIF spec version, the Contributor Covenant version, the `1.0.0` policy boundary, or migration examples (those are *not* slopmop's version).
- **`tests/unit/test_version_consistency.py`** fails CI if the package, pyproject, or any managed file drifts from the source — so a mismatch **can't be merged**.
- **`release.yml` + `scripts/release.sh`** now bump `_version.py` and run the sync (replacing the old pyproject-regex bump and the bespoke plugin bump).

Stale references synced to 2.1.0 in the process.

## ⚠️ Reviewer attention — release workflow
`release.yml` is the one piece I can't fully exercise locally. I validated: the bump regex against `_version.py` (2.1.0→2.1.1 ✓), the `release.sh` path end-to-end via its regression tests, the dynamic build resolving the version, and bash syntax. But the live PyPI-publish path only runs on dispatch — worth a careful read of the `release.yml` diff.

## Test plan
- [x] `sm scour` clean (incl. new guard test + updated release-script tests)
- [x] Build resolves dynamic version (metadata = 2.1.0)
- [x] `sync_version.py --check` passes; drift simulation caught by the guard test
- [ ] CI green

> The bug-report template placeholder you flagged lives on #254; it's already wired as a managed sync target here, so once #254 merges it's guarded too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)