### PR TITLE
feat: detect-secrets baseline and credential classification workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
         "pre-pr"
       ],
       "homepage": "https://github.com/ScienceIsNeato/slop-mop",
-      "license": "Slop-Mop Attribution License v1.0",
+      "license": "Apache-2.0",
       "author": {
         "name": "ScienceIsNeato",
         "url": "https://github.com/ScienceIsNeato"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/ScienceIsNeato/slop-mop",
   "repository": "https://github.com/ScienceIsNeato/slop-mop",
-  "license": "Slop-Mop Attribution License v1.0",
+  "license": "Apache-2.0",
   "keywords": [
     "quality-gate",
     "linting",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/ScienceIsNeato/slop-mop",
   "repository": "https://github.com/ScienceIsNeato/slop-mop",
-  "license": "Slop-Mop Attribution License v1.0",
+  "license": "Apache-2.0",
   "keywords": [
     "quality-gate",
     "linting",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,300 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "tests/integration/scenarios/happy-path-small.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/scenarios/happy-path-small.json",
+        "hashed_secret": "ebf747e5c8a5da605048805259bc502dd698c7e7",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/scenarios/happy-path-small.json",
+        "hashed_secret": "fdb58b3b768520052ecac3ced88bb7a7926955c8",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/scenarios/happy-path-small.json",
+        "hashed_secret": "031c70bbd18fd0b80eec8c08b3dddd1beed8b2cf",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/scenarios/happy-path-small.json",
+        "hashed_secret": "7ae56870158b16a2ef2f3086de543f449c9c38d6",
+        "is_verified": false,
+        "line_number": 32
+      }
+    ],
+    "tests/integration/test_scenario_manifest.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/test_scenario_manifest.py",
+        "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/integration/test_scenario_manifest.py",
+        "hashed_secret": "ccdd30d64e668771bc1efb2028e833b044b6be3b",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "tests/unit/test_barnacle.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/test_barnacle.py",
+        "hashed_secret": "853d6ca929939037112080a3abb24155b74b731f",
+        "is_verified": false,
+        "line_number": 92
+      }
+    ],
+    "tests/unit/test_ci_triage_and_buff.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_ci_triage_and_buff.py",
+        "hashed_secret": "e3ab4da65771e112916313006cec8b34ad8ce8cf",
+        "is_verified": false,
+        "line_number": 162
+      }
+    ],
+    "tests/unit/test_detect_secrets_check.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "ebf747e5c8a5da605048805259bc502dd698c7e7",
+        "is_verified": false,
+        "line_number": 314
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "fdb58b3b768520052ecac3ced88bb7a7926955c8",
+        "is_verified": false,
+        "line_number": 315
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "031c70bbd18fd0b80eec8c08b3dddd1beed8b2cf",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "ccdd30d64e668771bc1efb2028e833b044b6be3b",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
+        "is_verified": false,
+        "line_number": 373
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "22a07d051fd63d73a84bb5a131fcc8d1df6a8006",
+        "is_verified": false,
+        "line_number": 377
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "ddac9d88c224b59388ab6552b5531130c71e0264",
+        "is_verified": false,
+        "line_number": 379
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "e8d4a2f731a2b37fcb169639d14ccb9350952d59",
+        "is_verified": false,
+        "line_number": 769
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "347a1a00d534a6a2caa2802b5fae9a9135f3ae5f",
+        "is_verified": false,
+        "line_number": 776
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "0caff21acad1156f85ccf12a73c29feaf3b1b3b8",
+        "is_verified": false,
+        "line_number": 783
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_detect_secrets_check.py",
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_verified": false,
+        "line_number": 825
+      }
+    ],
+    "tests/unit/test_jsonc.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_jsonc.py",
+        "hashed_secret": "1e61fe1e47593d783345ac78ef213cc0446fd78c",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "tests/unit/test_refit.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_refit.py",
+        "hashed_secret": "22a07d051fd63d73a84bb5a131fcc8d1df6a8006",
+        "is_verified": false,
+        "line_number": 883
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/test_refit.py",
+        "hashed_secret": "ddac9d88c224b59388ab6552b5531130c71e0264",
+        "is_verified": false,
+        "line_number": 1052
+      }
+    ]
+  },
+  "generated_at": "2026-06-08T05:40:51Z"
+}

--- a/.willville.json
+++ b/.willville.json
@@ -25,8 +25,8 @@
     "updated": "2026-05-26"
   },
   "agent": {
-    "status": "Putting out the welcome mat for outside contributors — house rules, a conduct policy, and fill-in-the-blank forms for reporting bugs and asking for features",
-    "direction": "Part of a bigger push to make the project easy for newcomers to trust and join",
+    "status": "Switched the project to a standard, widely-trusted open-source license so companies and app stores will actually adopt it, with attribution preserved",
+    "direction": "Keeps the option open to offer a paid version down the road",
     "last_update": "2026-06-01T00:00:00Z"
   },
   "queue": {

--- a/DOCS/CONTRIBUTING.md
+++ b/DOCS/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Participation in this project is governed by our
 
 ## License
 
-This project is licensed under the Slop-Mop Attribution License v1.0 — you're free to use, modify, and redistribute, but attribution back to [ScienceIsNeato/slop-mop](https://github.com/ScienceIsNeato/slop-mop) is required. See [LICENSE](../LICENSE) for full terms.
+This project is licensed under the [Apache License 2.0](../LICENSE) — you're free to use, modify, and redistribute, including in commercial and proprietary products, provided you preserve the license and the attribution in the [NOTICE](../NOTICE) file. By contributing, you agree your contributions are licensed under the same terms.

--- a/LICENSE
+++ b/LICENSE
@@ -1,43 +1,202 @@
-Slop-Mop Attribution License v1.0
 
-Copyright (c) 2025-2026 ScienceIsNeato. All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to use,
-copy, modify, and redistribute the Software, subject to the following
-conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1. ATTRIBUTION REQUIRED.
-   Any redistribution of the Software, in whole or in part, with or without
-   modifications, must:
-   (a) Include this copyright notice and license text in all copies or
-       substantial portions of the Software.
-   (b) Provide prominent attribution to the original project, including
-       a link to: https://github.com/ScienceIsNeato/slop-mop
-   (c) Clearly indicate any modifications made to the original Software,
-       including the nature of the changes and the date they were made.
+   1. Definitions.
 
-2. NO SUBLICENSING.
-   You may not sublicense the Software or redistribute it under different
-   license terms. All recipients must receive it under this same license.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-3. NO TRADEMARK RIGHTS.
-   This license does not grant permission to use the trade names, trademarks,
-   service marks, or project names of the copyright holder, except as
-   required for reasonable and customary attribution under Section 1.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-4. CONTRIBUTIONS.
-   By submitting contributions (pull requests, patches, or other
-   modifications) to the original project repository, you grant the
-   copyright holder a perpetual, worldwide, non-exclusive, royalty-free
-   license to use, reproduce, modify, and distribute your contributions
-   as part of the Software under the terms of this license.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-5. NO WARRANTY.
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
-   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-   CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-   TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
-   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 William Martin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+slop-mop
+Copyright 2025-2026 ScienceIsNeato
+
+This product includes software developed by ScienceIsNeato
+(https://github.com/ScienceIsNeato/slop-mop).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+A copy of the License is in the LICENSE file and at:
+https://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -369,6 +369,6 @@ For local development, see [DOCS/DEVELOPING.md](https://github.com/ScienceIsNeat
 
 ## License
 
-Slop-mop uses the [Slop-Mop Attribution License v1.0](https://github.com/ScienceIsNeato/slop-mop/blob/main/LICENSE).
+Slop-mop is licensed under the [Apache License 2.0](https://github.com/ScienceIsNeato/slop-mop/blob/main/LICENSE).
 
-If you use it, attribution is required.
+Attribution is appreciated — see the [NOTICE](https://github.com/ScienceIsNeato/slop-mop/blob/main/NOTICE) file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "slopmop"
 dynamic = ["version"]
 description = "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind."
 readme = "README.md"
-license = {text = "Slop-Mop Attribution License v1.0"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [
     {name = "ScienceIsNeato"}
@@ -18,7 +18,7 @@ keywords = ["quality-gate", "linting", "testing", "ci-cd", "code-quality", "ai",
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -304,6 +304,28 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
         # External binary (semgrep, etc.)
         return shutil.which(name) is not None
 
+    def _resolve_configured_scanners(
+        self,
+        scanner_map: dict[str, Callable[[str], SecuritySubResult]],
+    ) -> tuple[List[Callable[[str], SecuritySubResult]], List[str]]:
+        """Identify which scanners are configured and available to run."""
+        configured = self.config.get("scanners", list(scanner_map.keys()))
+        sub_checks: List[Callable[[str], SecuritySubResult]] = []
+        skipped: List[str] = []
+        _importable = {
+            "bandit": "bandit",
+            "detect-secrets": "detect_secrets",  # pragma: allowlist secret
+        }
+        for name in configured:
+            if name not in scanner_map:
+                continue
+            available = self._is_scanner_available(name, _importable)
+            if available:
+                sub_checks.append(scanner_map[name])
+            else:
+                skipped.append(_SCANNER_NOT_INSTALLED.format(name=name))
+        return sub_checks, skipped
+
     def run(self, project_root: str) -> CheckResult:
         """Run configured security checks in parallel.
 
@@ -320,23 +342,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             "detect-secrets": self._run_detect_secrets,
         }
 
-        configured = self.config.get("scanners", list(scanner_map.keys()))
-        # Filter to only configured scanners that we know about
-        sub_checks: List[Callable[[str], SecuritySubResult]] = []
-        skipped: List[str] = []
-        # Map scanner names to their Python module for importability check
-        _importable = {
-            "bandit": "bandit",
-            "detect-secrets": "detect_secrets",  # pragma: allowlist secret
-        }
-        for name in configured:
-            if name not in scanner_map:
-                continue
-            available = self._is_scanner_available(name, _importable)
-            if available:
-                sub_checks.append(scanner_map[name])
-            else:
-                skipped.append(_SCANNER_NOT_INSTALLED.format(name=name))
+        sub_checks, skipped = self._resolve_configured_scanners(scanner_map)
 
         if not sub_checks:
             duration = time.time() - start_time
@@ -386,16 +392,25 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
                         level=FindingLevel.ERROR,
                     )
                 )
+        is_secret_failure = any(f.name == "detect-secrets" for f in failures)
+        fix_suggestion = (
+            "Each finding above has a rule-specific fix where known. "
+            "Bandit's HIGH severity findings are real vulnerabilities "
+            "\u2014 fix those first."
+        )
+        if is_secret_failure:
+            fix_suggestion += (
+                " For detect-secrets failures, follow the exact STEP 1-4 classification "
+                "protocol detailed in the finding's fix_strategy."
+            )
+        fix_suggestion += " Verify with: " + self.verify_command
+
         return self._create_result(
             status=CheckStatus.FAILED,
             duration=duration,
             output=detail,
             error=f"{len(failures)} security scanner(s) found issues",
-            fix_suggestion=(
-                "Each finding above has a rule-specific fix where known. "
-                "Bandit's HIGH severity findings are real vulnerabilities "
-                "\u2014 fix those first. Verify with: " + self.verify_command
-            ),
+            fix_suggestion=fix_suggestion,
             findings=all_findings,
         )
 
@@ -656,16 +671,25 @@ class SecurityCheck(SecurityLocalCheck):
                 self._collect_findings(warnings, fallback_level=FindingLevel.WARNING)
             )
         detail = "\n\n".join(detail_parts)
+        is_secret_failure = any(f.name == "detect-secrets" for f in failures)
+        fix_suggestion = (
+            "Each finding above has a rule-specific fix where known. "
+            "Bandit's HIGH severity findings are real vulnerabilities "
+            "\u2014 fix those first."
+        )
+        if is_secret_failure:
+            fix_suggestion += (
+                " For detect-secrets failures, follow the exact STEP 1-4 classification "
+                "protocol detailed in the finding's fix_strategy."
+            )
+        fix_suggestion += " Verify with: " + self.verify_command
+
         return self._create_result(
             status=CheckStatus.FAILED,
             duration=duration,
             output=detail,
             error=f"{len(failures)} security scanner(s) found issues",
-            fix_suggestion=(
-                "Each finding above has a rule-specific fix where known. "
-                "Bandit's HIGH severity findings are real vulnerabilities "
-                "\u2014 fix those first. Verify with: " + self.verify_command
-            ),
+            fix_suggestion=fix_suggestion,
             findings=all_findings,
         )
 

--- a/slopmop/checks/security/_detect_secrets.py
+++ b/slopmop/checks/security/_detect_secrets.py
@@ -451,11 +451,31 @@ class DetectSecretsMixin:
 
         if result.success:
             try:
+                if (
+                    tmp_baseline_path
+                    and report_from_tmp_baseline is None
+                    and not (result.output or "").strip()
+                ):
+                    # In --baseline mode detect-secrets often leaves stdout empty
+                    # and writes the report into the temp file. If we can't read
+                    # that file, we must fail closed: passing open here can
+                    # hide real secrets.
+                    return SecuritySubResult(
+                        "detect-secrets",
+                        False,
+                        "detect-secrets scan produced empty/unparseable report in --baseline mode (stdout empty and temp baseline could not be read)",
+                    )
                 report = self._parse_detect_secrets_report(
                     result.output, report_from_tmp_baseline
                 )
                 return self._subresult_from_detect_secrets_report(project_root, report)
             except json.JSONDecodeError:
+                if tmp_baseline_path:
+                    return SecuritySubResult(
+                        "detect-secrets",
+                        False,
+                        "detect-secrets scan succeeded but report parsing failed in --baseline mode",
+                    )
                 return SecuritySubResult("detect-secrets", True, "Scan completed")
 
         # The scan command exited non-zero. Distinguish a scanner that never

--- a/slopmop/checks/security/_detect_secrets.py
+++ b/slopmop/checks/security/_detect_secrets.py
@@ -357,6 +357,55 @@ class DetectSecretsMixin:
         except (json.JSONDecodeError, OSError):
             return None
 
+    @staticmethod
+    def _load_tmp_baseline_report(
+        tmp_baseline_path: str,
+    ) -> Optional[dict[str, Any]]:
+        """Read scan results detect-secrets wrote into a throwaway baseline."""
+        try:
+            loaded = json.loads(Path(tmp_baseline_path).read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                return cast(dict[str, Any], loaded)
+        except (json.JSONDecodeError, OSError):
+            return None
+        return None
+
+    @staticmethod
+    def _parse_detect_secrets_report(
+        result_output: str,
+        report_from_tmp_baseline: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Normalize stdout JSON or throwaway-baseline JSON into one report."""
+        if report_from_tmp_baseline is not None:
+            return report_from_tmp_baseline
+        report_loaded: Any = json.loads(result_output)
+        if isinstance(report_loaded, dict):
+            return cast(dict[str, Any], report_loaded)
+        return {}
+
+    def _subresult_from_detect_secrets_report(
+        self, project_root: str, report: dict[str, Any]
+    ) -> SecuritySubResult:
+        """Turn a detect-secrets report dict into a pass/fail sub-result."""
+        from slopmop.checks.security import SecuritySubResult
+
+        known = self._load_detect_secrets_allowlist(project_root)
+        detected_any = report.get("results", {})
+        detected = (
+            cast(dict[str, Any], detected_any) if isinstance(detected_any, dict) else {}
+        )
+        real_secrets = self._filter_known_secrets(detected, known, project_root)
+        if not real_secrets:
+            return SecuritySubResult("detect-secrets", True, "No secrets detected")
+
+        detail_lines: list[str] = []
+        for path, secrets in real_secrets.items():
+            types = [str(secret.get("type", "?")) for secret in secrets]
+            detail_lines.append(f"  Potential secret in {path}: {', '.join(types)}")
+        detail = "\n".join(detail_lines)
+        sarif = self._build_detect_secrets_sarif(real_secrets)
+        return SecuritySubResult("detect-secrets", False, detail, sarif)
+
     def _run_detect_secrets(self, project_root: str) -> SecuritySubResult:
         """Run detect-secrets scan without touching the real baseline file.
 
@@ -389,48 +438,23 @@ class DetectSecretsMixin:
         if tmp_baseline_path:
             cmd.extend(["--baseline", tmp_baseline_path])
 
+        report_from_tmp_baseline: Optional[dict[str, Any]] = None
         try:
             result = self._run_command(cmd, cwd=project_root, timeout=60)
+            if tmp_baseline_path and not (result.stdout or "").strip():
+                report_from_tmp_baseline = self._load_tmp_baseline_report(
+                    tmp_baseline_path
+                )
         finally:
             if tmp_baseline_path:
                 Path(tmp_baseline_path).unlink(missing_ok=True)
 
         if result.success:
             try:
-                report_loaded: Any = json.loads(result.output)
-                report: dict[str, Any]
-                if isinstance(report_loaded, dict):
-                    report = cast(dict[str, Any], report_loaded)
-                else:
-                    report = {}
-
-                # Build a read-only allowlist from the existing baseline file.
-                # Keys: (normalized_path, hashed_secret) — secrets already known/accepted.
-                known = self._load_detect_secrets_allowlist(project_root)
-
-                detected_any = report.get("results", {})
-                detected = (
-                    cast(dict[str, Any], detected_any)
-                    if isinstance(detected_any, dict)
-                    else {}
+                report = self._parse_detect_secrets_report(
+                    result.output, report_from_tmp_baseline
                 )
-                real_secrets = self._filter_known_secrets(detected, known, project_root)
-                if not real_secrets:
-                    return SecuritySubResult(
-                        "detect-secrets", True, "No secrets detected"
-                    )
-
-                detail_lines: list[str] = []
-                for path, secrets in real_secrets.items():
-                    types: list[str] = []
-                    for secret in secrets:
-                        types.append(str(secret.get("type", "?")))
-                    detail_lines.append(
-                        f"  Potential secret in {path}: {', '.join(types)}"
-                    )
-                detail = "\n".join(detail_lines)
-                sarif = self._build_detect_secrets_sarif(real_secrets)
-                return SecuritySubResult("detect-secrets", False, detail, sarif)
+                return self._subresult_from_detect_secrets_report(project_root, report)
             except json.JSONDecodeError:
                 return SecuritySubResult("detect-secrets", True, "Scan completed")
 
@@ -507,12 +531,36 @@ class DetectSecretsMixin:
         for path, secrets in real_secrets.items():
             for s in secrets:
                 ln = s.get("line_number")
+                line_val = ln if isinstance(ln, int) else 1
+
+                fix_strategy = (
+                    f"STEP 1 - CLASSIFY Credential:\n"
+                    f"  Evaluate the detected credential at {path}:{line_val} and classify it:\n"
+                    f"  - DANGEROUS: Real sensitive credential (e.g., live API key, production password, private SSH key).\n"
+                    f"  - SAFE_BUT_SLOPPY: Mock/test credential, but hardcoded in production paths or scattered ad-hoc.\n"
+                    f"  - SAFE_AND_CLEAN: Mock/test credential, properly centralized in tests or mock directories.\n\n"
+                    f"STEP 2 - IF DANGEROUS:\n"
+                    f"  Run this exact command to file a blocker and alert the captain:\n"
+                    f'  sm barnacle file --title "Live credential leak in {path}" --command "sm swab" '
+                    f'--expected "Credentials must not be hardcoded or committed to git" '
+                    f'--actual "Dangerous credential detected in {path} at line {line_val}" '
+                    f'--workflow "swab" --blocker-type "blocking"\n'
+                    f"  Then exit the loop.\n\n"
+                    f"STEP 3 - IF SAFE_BUT_SLOPPY:\n"
+                    f"  Refactor the code to manage via environment variable (e.g., os.getenv) or move it to a test fixture file. "
+                    f"Then start over at STEP 1.\n\n"
+                    f"STEP 4 - IF SAFE_AND_CLEAN:\n"
+                    f"  Run this exact command to add the approved test credential to the baseline:\n"
+                    f"  python3 -m detect_secrets scan --baseline .secrets.baseline"
+                )
+
                 sarif.append(
                     Finding(
                         message=f"Potential secret: {s.get('type', '?')}",
                         level=FindingLevel.ERROR,
                         file=path,
                         line=ln if isinstance(ln, int) else None,
+                        fix_strategy=fix_strategy,
                     )
                 )
         return sarif

--- a/slopmop/checks/security/_detect_secrets.py
+++ b/slopmop/checks/security/_detect_secrets.py
@@ -540,15 +540,21 @@ class DetectSecretsMixin:
                     f"  - SAFE_BUT_SLOPPY: Mock/test credential, but hardcoded in production paths or scattered ad-hoc.\n"
                     f"  - SAFE_AND_CLEAN: Mock/test credential, properly centralized in tests or mock directories.\n\n"
                     f"STEP 2 - IF DANGEROUS:\n"
-                    f"  Run this exact command to file a blocker and alert the captain:\n"
-                    f'  sm barnacle file --title "Live credential leak in {path}" --command "sm swab" '
-                    f'--expected "Credentials must not be hardcoded or committed to git" '
-                    f'--actual "Dangerous credential detected in {path} at line {line_val}" '
-                    f'--workflow "swab" --blocker-type "blocking"\n'
+                    f"  Run this exact command to wake the angry, drunk captain for a human security decision:\n"
+                    f'  sm wake-angry-drunk-captain --objective "Dangerous credential leak in {path}:{line_val}" '
+                    f'--verbs-tried "sm swab" '
+                    f'--why-stuck "detect-secrets classified this credential as DANGEROUS; no remaining sm verb can safely resolve a live secret without human judgment." '
+                    f'--decision "Block merge and revoke/rotate, unless a human confirms it is non-live/test" '
+                    f'--option "Block merge + revoke/rotate credential" '
+                    f'--option "Allow PR after confirmation it is non-live/test"\n'
                     f"  Then exit the loop.\n\n"
                     f"STEP 3 - IF SAFE_BUT_SLOPPY:\n"
-                    f"  Refactor the code to manage via environment variable (e.g., os.getenv) or move it to a test fixture file. "
-                    f"Then start over at STEP 1.\n\n"
+                    f"  Refactor using one (or more) of these options:\n"
+                    f"   - Obviate: remove the secret from source; load it at runtime via env/secret manager.\n"
+                    f"   - Obfuscate: keep it behind env/.env config loading and ensure it is never committed.\n"
+                    f"   - Consolidate: centralize the handling so secrets aren't scattered ad-hoc.\n"
+                    f"   - Relocate: move to tests/fixtures (mock dirs) and update the baseline for SAFE_AND_CLEAN.\n"
+                    f"  Then start over at STEP 1.\n\n"
                     f"STEP 4 - IF SAFE_AND_CLEAN:\n"
                     f"  Run this exact command to add the approved test credential to the baseline:\n"
                     f"  python3 -m detect_secrets scan --baseline .secrets.baseline"

--- a/tests/integration/test_secrets_remediation_integration.py
+++ b/tests/integration/test_secrets_remediation_integration.py
@@ -1,0 +1,309 @@
+"""Integration tests for the detect-secrets agent remediation workflow."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from slopmop.checks.security import SecurityLocalCheck
+from slopmop.core.result import CheckStatus
+
+
+# synthetic — integration fixture only, not a live credential
+def _synthetic_production_secret_line() -> str:
+    """Vendor-neutral credential for integration tests only."""
+    return 'PRODUCTION_API_SECRET = "8f3kL9mP2xQ7vR4nT6wY1zA0bC5dE9fH2jK4"\n'
+
+
+def _synthetic_fixture_secret_line() -> str:
+    """Same shape; TEST_ prefix for the excluded tests/ path scenario."""
+    return 'TEST_FIXTURE_SECRET = "8f3kL9mP2xQ7vR4nT6wY1zA0bC5dE9fH2jK4"\n'
+
+
+@pytest.mark.integration
+class TestSecretsRemediationIntegration:
+    """Verifies the exact agent instruction workflow on secrets detection.
+
+    Proves that:
+    1. A hardcoded secret triggers a failed security check with the 1-4 classification instructions.
+    2. The STEP 2 command parses and executes in dry-run mode successfully.
+    3. The STEP 4 baseline update command creates/updates the baseline file.
+    4. A subsequent scan utilizing that baseline successfully passes.
+    5. Clean refactoring (moving secret to environment variables) resolves the failure.
+    6. Moving the secret to an excluded directory (e.g., tests/) resolves the failure.
+    """
+
+    @pytest.fixture
+    def setup_project(self, tmp_path: Path):
+        """Seed a clean project directory with a baseline and then add a hardcoded secret."""
+        # Initialize git repository
+        subprocess.run(
+            ["git", "init"], cwd=str(tmp_path), capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        # Seed a clean Python file
+        config_py = src_dir / "config.py"
+        config_py.write_text("# Clean configuration\n", encoding="utf-8")
+
+        # Stage and commit the clean file
+        subprocess.run(
+            ["git", "add", "src/config.py"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "initial commit"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        # Create the initial empty/clean baseline file
+        baseline_file = tmp_path / ".secrets.baseline"
+        cmd = [sys.executable, "-m", "detect_secrets", "scan"]
+        with open(baseline_file, "w", encoding="utf-8") as f:
+            subprocess.run(cmd, stdout=f, check=True, cwd=str(tmp_path))
+
+        # Stage and commit the baseline file
+        subprocess.run(
+            ["git", "add", ".secrets.baseline"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add baseline"],
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+
+        # Also create a tests directory for testing the test fixture exclusion path (STEP 3)
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        return tmp_path, config_py, tests_dir
+
+    def test_secrets_remediation_loop_end_to_end(self, setup_project):
+        project_root, config_py, tests_dir = setup_project
+        project_root_str = str(project_root)
+
+        # Introduce a vendor-neutral high-entropy secret violation
+        config_py.write_text(
+            _synthetic_production_secret_line(),
+            encoding="utf-8",
+        )
+
+        # 1. Verify Check Fails and Outputs Structured Agent Instructions
+        strategy = self._verify_check_fails_with_instructions(project_root_str)
+
+        # 2. Verify STEP 2 Command (Barnacle Filing Dry-Run)
+        self._verify_barnacle_dry_run(project_root_str, strategy)
+
+        # 3. Verify STEP 4 Command (Baseline Whitelisting)
+        self._verify_baseline_whitelisting(project_root_str, strategy, project_root)
+
+        # 4. Verify Subsequent Check utilizing the Baseline Passes
+        self._verify_subsequent_check_passes(project_root_str)
+
+        # 5. Verify STEP 3 (Refactoring clean / moving to env var)
+        self._verify_clean_refactoring(project_root_str, config_py, project_root)
+
+        # 6. Verify STEP 3 (Moving secret to an excluded test directory / fixture file)
+        self._verify_test_fixture_exclusion(project_root_str, tests_dir)
+
+    def _verify_check_fails_with_instructions(self, project_root_str: str) -> str:
+        # Initialize check with the empty baseline configured
+        check = SecurityLocalCheck(
+            {
+                "scanners": ["detect-secrets"],
+                "config_file_path": ".secrets.baseline",
+            }
+        )
+        result = check.run(project_root_str)
+
+        assert (
+            result.status == CheckStatus.FAILED
+        ), f"Expected check to fail, output: {result.output}"
+        assert len(result.findings) >= 1
+        finding = result.findings[0]
+
+        # Verify the findings carry the exact file and line number
+        assert finding.file == "src/config.py"
+        assert finding.line == 1
+
+        # Verify fix_strategy contains the structured instruction steps
+        strategy = finding.fix_strategy
+        assert strategy is not None
+        assert "STEP 1 - CLASSIFY Credential:" in strategy
+        assert "STEP 2 - IF DANGEROUS:" in strategy
+        assert "STEP 3 - IF SAFE_BUT_SLOPPY:" in strategy
+        assert "STEP 4 - IF SAFE_AND_CLEAN:" in strategy
+        return strategy
+
+    def _verify_barnacle_dry_run(self, project_root_str: str, strategy: str) -> None:
+        # Extract the exact barnacle filing command from the instruction text.
+        # Find the line starting with "  sm barnacle file "
+        command_lines = [
+            line.strip()
+            for line in strategy.splitlines()
+            if "sm barnacle file " in line
+        ]
+        assert (
+            len(command_lines) == 1
+        ), "Failed to find the sm barnacle command in fix_strategy"
+        barnacle_cmd = command_lines[0]
+
+        # Replace 'sm' with sys.executable + ' -m slopmop.sm' to run it in-process safely
+        args = shlex.split(barnacle_cmd)
+        # Strip the leading 'sm' or './sm'
+        args = args[1:]
+        # Append --dry-run and run via subprocess using the virtualenv python
+        run_args = (
+            [sys.executable, "-m", "slopmop.sm"]
+            + args
+            + ["--dry-run", "--project-root", project_root_str]
+        )
+
+        result_barnacle = subprocess.run(
+            run_args,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=project_root_str,
+        )
+        assert result_barnacle.returncode == 0
+        assert (
+            "Title: [barnacle] Live credential leak in src/config.py"
+            in result_barnacle.stdout
+        )
+        assert (
+            "Dangerous credential detected in src/config.py at line 1"
+            in result_barnacle.stdout
+        )
+
+    def _verify_baseline_whitelisting(
+        self, project_root_str: str, strategy: str, project_root: Path
+    ) -> None:
+        # Extract the detect-secrets scan command from the instruction text.
+        baseline_lines = [
+            line.strip()
+            for line in strategy.splitlines()
+            if "detect_secrets scan " in line
+        ]
+        assert (
+            len(baseline_lines) == 1
+        ), "Failed to find the baseline scan command in fix_strategy"
+
+        # Run the command in the temporary directory to update the baseline file
+        # Command is: python3 -m detect_secrets scan --baseline .secrets.baseline
+        baseline_file = project_root / ".secrets.baseline"
+        assert baseline_file.exists()
+
+        # Run it via sys.executable to ensure we use the same Python environment
+        cmd_args = [
+            sys.executable,
+            "-m",
+            "detect_secrets",
+            "scan",
+            "--baseline",
+            ".secrets.baseline",
+        ]
+        result_baseline = subprocess.run(
+            cmd_args,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=project_root_str,
+        )
+        assert result_baseline.returncode == 0
+        assert (
+            baseline_file.exists()
+        ), f"Baseline file was not created: {result_baseline.stderr}"
+
+        # Verify the baseline contains our key
+        baseline_data = json.loads(baseline_file.read_text(encoding="utf-8"))
+        assert "src/config.py" in baseline_data.get("results", {})
+
+    def _verify_subsequent_check_passes(self, project_root_str: str) -> None:
+        check_with_baseline = SecurityLocalCheck(
+            {
+                "scanners": ["detect-secrets"],
+                "config_file_path": ".secrets.baseline",
+            }
+        )
+        result_after_baseline = check_with_baseline.run(project_root_str)
+        assert (
+            result_after_baseline.status == CheckStatus.PASSED
+        ), f"Expected check with baseline to pass, got failure: {result_after_baseline.output}"
+
+    def _verify_clean_refactoring(
+        self, project_root_str: str, config_py: Path, project_root: Path
+    ) -> None:
+        # Remove the baseline file to ensure we are testing clean code
+        baseline_file = project_root / ".secrets.baseline"
+        baseline_file.unlink()
+
+        # Refactor config.py to load from environment variable (obviating the secret)
+        config_py.write_text(
+            "import os\nAWS_SECRET_KEY = os.getenv('AWS_SECRET_KEY', 'placeholder')\n",
+            encoding="utf-8",
+        )
+
+        # Run the check again; it should now pass cleanly
+        check_after_refactor = SecurityLocalCheck({"scanners": ["detect-secrets"]})
+        result_after_refactor = check_after_refactor.run(project_root_str)
+        assert (
+            result_after_refactor.status == CheckStatus.PASSED
+        ), f"Expected check after refactoring to pass, got failure: {result_after_refactor.output}"
+
+    def _verify_test_fixture_exclusion(
+        self, project_root_str: str, tests_dir: Path
+    ) -> None:
+        # Re-introduce the secret inside the tests directory, which is excluded by default
+        test_fixture_py = tests_dir / "test_fixture.py"
+        test_fixture_py.write_text(
+            _synthetic_fixture_secret_line(),
+            encoding="utf-8",
+        )
+
+        # Stage and commit it so detect-secrets sees it as a tracked file
+        subprocess.run(
+            ["git", "add", "tests/test_fixture.py"],
+            cwd=project_root_str,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add test fixture"],
+            cwd=project_root_str,
+            capture_output=True,
+            check=True,
+        )
+
+        # Run the check; it should still pass cleanly because the tests/ directory is excluded
+        check_after_test_fixture = SecurityLocalCheck({"scanners": ["detect-secrets"]})
+        result_after_test_fixture = check_after_test_fixture.run(project_root_str)
+        assert (
+            result_after_test_fixture.status == CheckStatus.PASSED
+        ), f"Expected check with secret in tests directory to pass, got failure: {result_after_test_fixture.output}"

--- a/tests/integration/test_secrets_remediation_integration.py
+++ b/tests/integration/test_secrets_remediation_integration.py
@@ -118,7 +118,7 @@ class TestSecretsRemediationIntegration:
         strategy = self._verify_check_fails_with_instructions(project_root_str)
 
         # 2. Verify STEP 2 Command (Barnacle Filing Dry-Run)
-        self._verify_barnacle_dry_run(project_root_str, strategy)
+        self._verify_wake_captain_summons(project_root_str, strategy)
 
         # 3. Verify STEP 4 Command (Baseline Whitelisting)
         self._verify_baseline_whitelisting(project_root_str, strategy, project_root)
@@ -161,46 +161,48 @@ class TestSecretsRemediationIntegration:
         assert "STEP 4 - IF SAFE_AND_CLEAN:" in strategy
         return strategy
 
-    def _verify_barnacle_dry_run(self, project_root_str: str, strategy: str) -> None:
-        # Extract the exact barnacle filing command from the instruction text.
-        # Find the line starting with "  sm barnacle file "
+    def _verify_wake_captain_summons(
+        self, project_root_str: str, strategy: str
+    ) -> None:
+        # Extract the exact wake-angry-drunk-captain command from the instruction text.
+        # Find the line starting with "  sm wake-angry-drunk-captain "
         command_lines = [
             line.strip()
             for line in strategy.splitlines()
-            if "sm barnacle file " in line
+            if "sm wake-angry-drunk-captain" in line
         ]
         assert (
             len(command_lines) == 1
-        ), "Failed to find the sm barnacle command in fix_strategy"
-        barnacle_cmd = command_lines[0]
+        ), "Failed to find the sm wake-angry-drunk-captain command in fix_strategy"
+        wake_cmd = command_lines[0]
 
-        # Replace 'sm' with sys.executable + ' -m slopmop.sm' to run it in-process safely
-        args = shlex.split(barnacle_cmd)
+        # Replace 'sm' with sys.executable + ' -m slopmop.sm' to run it in-process.
+        args = shlex.split(wake_cmd)
         # Strip the leading 'sm' or './sm'
         args = args[1:]
-        # Append --dry-run and run via subprocess using the virtualenv python
+
+        # Captain summons requires structured justification flags; in the test we
+        # only validate the CLI wiring + JSON contract.
         run_args = (
             [sys.executable, "-m", "slopmop.sm"]
             + args
-            + ["--dry-run", "--project-root", project_root_str]
+            + ["--json", "--project-root", project_root_str]
         )
 
-        result_barnacle = subprocess.run(
+        result_wake = subprocess.run(
             run_args,
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
             cwd=project_root_str,
         )
-        assert result_barnacle.returncode == 0
-        assert (
-            "Title: [barnacle] Live credential leak in src/config.py"
-            in result_barnacle.stdout
-        )
-        assert (
-            "Dangerous credential detected in src/config.py at line 1"
-            in result_barnacle.stdout
-        )
+        # EXIT_SUMMONED is 1 for a valid summons.
+        assert result_wake.returncode == 1
+        assert result_wake.stdout.strip(), result_wake.stderr
+
+        payload = json.loads(result_wake.stdout)
+        assert payload.get("command") == "wake-angry-drunk-captain"
+        assert "relay_to_human" in payload.get("data", {})
 
     def _verify_baseline_whitelisting(
         self, project_root_str: str, strategy: str, project_root: Path

--- a/tests/unit/test_detect_secrets_check.py
+++ b/tests/unit/test_detect_secrets_check.py
@@ -827,3 +827,34 @@ class TestDetectSecretsHeuristics:
         check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
         known = check._load_detect_secrets_allowlist(str(tmp_path))
         assert ("a.py", "abc123") in known
+
+    def test_build_detect_secrets_sarif_populates_fix_strategy(self):
+        real_secrets = {
+            "src/auth.py": [
+                {
+                    "type": "Secret Keyword",
+                    "line_number": 42,
+                }
+            ]
+        }
+        check = SecurityLocalCheck({})
+        findings = check._build_detect_secrets_sarif(real_secrets)
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.file == "src/auth.py"
+        assert finding.line == 42
+        assert finding.fix_strategy is not None
+        assert "STEP 1 - CLASSIFY Credential" in finding.fix_strategy
+        assert "src/auth.py:42" in finding.fix_strategy
+        assert (
+            'sm barnacle file --title "Live credential leak in src/auth.py"'
+            in finding.fix_strategy
+        )
+        assert (
+            '--actual "Dangerous credential detected in src/auth.py at line 42"'
+            in finding.fix_strategy
+        )
+        assert (
+            "python3 -m detect_secrets scan --baseline .secrets.baseline"
+            in finding.fix_strategy
+        )

--- a/tests/unit/test_detect_secrets_check.py
+++ b/tests/unit/test_detect_secrets_check.py
@@ -938,14 +938,12 @@ class TestDetectSecretsHeuristics:
         assert finding.fix_strategy is not None
         assert "STEP 1 - CLASSIFY Credential" in finding.fix_strategy
         assert "src/auth.py:42" in finding.fix_strategy
-        assert (
-            'sm barnacle file --title "Live credential leak in src/auth.py"'
-            in finding.fix_strategy
-        )
-        assert (
-            '--actual "Dangerous credential detected in src/auth.py at line 42"'
-            in finding.fix_strategy
-        )
+        assert "sm wake-angry-drunk-captain --objective" in finding.fix_strategy
+        assert "--decision" in finding.fix_strategy
+        assert "Obviate:" in finding.fix_strategy
+        assert "Obfuscate:" in finding.fix_strategy
+        assert "Consolidate:" in finding.fix_strategy
+        assert "Relocate:" in finding.fix_strategy
         assert (
             "python3 -m detect_secrets scan --baseline .secrets.baseline"
             in finding.fix_strategy

--- a/tests/unit/test_detect_secrets_check.py
+++ b/tests/unit/test_detect_secrets_check.py
@@ -674,6 +674,98 @@ class TestRunDetectSecrets:
         ).exists(), "Temp plugin-config baseline must be deleted after the scan"
         assert json.loads(baseline.read_text()) == baseline_content
 
+    def test_load_tmp_baseline_report_reads_json(self, tmp_path):
+        path = tmp_path / "baseline.json"
+        path.write_text(json.dumps({"results": {"a.py": []}}))
+        loaded = SecurityLocalCheck._load_tmp_baseline_report(str(path))
+        assert loaded == {"results": {"a.py": []}}
+
+    def test_load_tmp_baseline_report_invalid_json(self, tmp_path):
+        path = tmp_path / "baseline.json"
+        path.write_text("not json")
+        assert SecurityLocalCheck._load_tmp_baseline_report(str(path)) is None
+
+    def test_parse_detect_secrets_report_prefers_tmp_baseline(self):
+        tmp_report = {"results": {"x.py": []}}
+        stdout = json.dumps({"results": {}})
+        parsed = SecurityLocalCheck._parse_detect_secrets_report(stdout, tmp_report)
+        assert parsed == tmp_report
+
+    def test_parse_detect_secrets_report_falls_back_to_stdout(self):
+        stdout = json.dumps({"results": {"y.py": []}})
+        parsed = SecurityLocalCheck._parse_detect_secrets_report(stdout, None)
+        assert parsed == {"results": {"y.py": []}}
+
+    def test_parse_detect_secrets_report_non_dict_stdout(self):
+        assert SecurityLocalCheck._parse_detect_secrets_report("[]", None) == {}
+
+    def test_subresult_from_report_no_secrets(self, tmp_path):
+        check = SecurityLocalCheck({})
+        sub = check._subresult_from_detect_secrets_report(
+            str(tmp_path), {"results": {}}
+        )
+        assert sub.passed is True
+        assert "No secrets" in sub.findings
+
+    def test_subresult_from_report_with_secrets(self, tmp_path):
+        check = SecurityLocalCheck({})
+        report = {
+            "results": {
+                "cfg.py": [
+                    {
+                        "type": "Secret Keyword",
+                        "line_number": 1,
+                    }  # pragma: allowlist secret
+                ]
+            }
+        }
+        sub = check._subresult_from_detect_secrets_report(str(tmp_path), report)
+        assert sub.passed is False
+        assert "cfg.py" in sub.findings
+
+    def test_run_detect_secrets_reads_throwaway_baseline_when_stdout_empty(
+        self, tmp_path
+    ):
+        """Regression: --baseline mode leaves stdout empty; read the temp file."""
+        baseline_content = {
+            "plugins_used": [{"name": "KeywordDetector"}],
+            "filters_used": [],
+            "results": {},
+        }
+        baseline = tmp_path / ".secrets.baseline"
+        baseline.write_text(json.dumps(baseline_content))
+
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = ""
+
+        def _capture(cmd: list[str], **kwargs: Any) -> MagicMock:  # type: ignore[misc]
+            if "--baseline" in cmd:
+                idx = cmd.index("--baseline")
+                Path(cmd[idx + 1]).write_text(
+                    json.dumps(
+                        {
+                            **baseline_content,
+                            "results": {
+                                "evil.py": [
+                                    {
+                                        "type": "Secret Keyword",
+                                        "line_number": 2,
+                                    }  # pragma: allowlist secret
+                                ]
+                            },
+                        }
+                    )
+                )
+            return mock_result
+
+        with patch.object(check, "_run_command", side_effect=_capture):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.passed is False
+        assert "evil.py" in result.findings
+
     def test_detect_secrets_suppresses_cloudflare_account_id(self, tmp_path):
         """Cloudflare accountId (32-char hex) in workflow files should not be flagged."""
         workflow_dir = tmp_path / ".github" / "workflows"

--- a/tests/unit/test_detect_secrets_check.py
+++ b/tests/unit/test_detect_secrets_check.py
@@ -766,6 +766,36 @@ class TestRunDetectSecrets:
         assert result.passed is False
         assert "evil.py" in result.findings
 
+    def test_run_detect_secrets_fails_closed_when_tmp_baseline_unreadable(
+        self, tmp_path
+    ):
+        """In --baseline mode, empty stdout must not pass if tmp baseline can't be read."""
+        baseline_content = {
+            "plugins_used": [{"name": "KeywordDetector"}],
+            "filters_used": [],
+            "results": {},
+        }
+        (tmp_path / ".secrets.baseline").write_text(
+            json.dumps(baseline_content), encoding="utf-8"
+        )
+
+        check = SecurityLocalCheck({"config_file_path": ".secrets.baseline"})
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.output = ""
+
+        with (
+            patch.object(check, "_run_command", return_value=mock_result),
+            patch.object(check, "_load_tmp_baseline_report", return_value=None),
+        ):
+            result = check._run_detect_secrets(str(tmp_path))
+
+        assert result.passed is False
+        assert "temp baseline could not be read" in result.findings
+
     def test_detect_secrets_suppresses_cloudflare_account_id(self, tmp_path):
         """Cloudflare accountId (32-char hex) in workflow files should not be flagged."""
         workflow_dir = tmp_path / ".github" / "workflows"

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -260,6 +260,37 @@ class TestSecurityLocalCheck:
         assert "1 security scanner(s) found issues" in result.error
         assert "bandit" in result.output
 
+    def test_run_with_detect_secrets_failure(self, tmp_path):
+        """Test run() when detect-secrets fails, verifying the custom fix_suggestion."""
+        (tmp_path / "app.py").write_text("print('hello')")
+        check = SecurityLocalCheck({})
+
+        results = [
+            SecuritySubResult("bandit", True, "OK"),
+            SecuritySubResult("semgrep", True, "OK"),
+            SecuritySubResult(
+                "detect-secrets", False, "Potential secret: Secret Keyword"
+            ),
+        ]
+
+        with patch("slopmop.checks.security.ThreadPoolExecutor") as mock_executor_class:
+            mock_executor = MagicMock()
+            mock_executor_class.return_value.__enter__.return_value = mock_executor
+            mock_futures = [MagicMock() for _ in results]
+            for future, res in zip(mock_futures, results):
+                future.result.return_value = res
+            mock_executor.submit.side_effect = mock_futures
+
+            result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert "1 security scanner(s) found issues" in result.error
+        assert "detect-secrets" in result.output
+        assert (
+            "For detect-secrets failures, follow the exact STEP 1-4 classification"
+            in result.fix_suggestion
+        )
+
     def test_run_handles_exceptions(self, tmp_path):
         """Test run() handles scanner exceptions gracefully."""
         (tmp_path / "app.py").write_text("print('hello')")

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -260,6 +260,27 @@ class TestSecurityLocalCheck:
         assert "1 security scanner(s) found issues" in result.error
         assert "bandit" in result.output
 
+    def test_resolve_configured_scanners_skips_unknown_and_unavailable(self):
+        """Unknown scanner names and missing tools should not run as failures."""
+        check = SecurityLocalCheck(
+            {"scanners": ["bandit", "unknown-scanner", "semgrep"]}
+        )
+        scanner_map = {
+            "bandit": check._run_bandit,
+            "semgrep": check._run_semgrep,
+            "detect-secrets": check._run_detect_secrets,
+        }
+        with patch.object(
+            check,
+            "_is_scanner_available",
+            side_effect=lambda name, _: name == "bandit",
+        ):
+            sub_checks, skipped = check._resolve_configured_scanners(scanner_map)
+
+        assert len(sub_checks) == 1
+        assert sub_checks[0] == check._run_bandit
+        assert skipped == ["semgrep (not installed)"]
+
     def test_run_with_detect_secrets_failure(self, tmp_path):
         """Test run() when detect-secrets fails, verifying the custom fix_suggestion."""
         (tmp_path / "app.py").write_text("print('hello')")
@@ -474,6 +495,16 @@ class TestSecurityCheck:
 
         assert result.status == CheckStatus.PASSED
         assert "myopia:dependency-risk.py" in result.name
+
+    def test_failures_result_includes_detect_secrets_protocol(self):
+        """SecurityCheck failures should mention the STEP 1-4 workflow."""
+        check = SecurityCheck({})
+        failures = [
+            SecuritySubResult("detect-secrets", False, "Potential secret in cfg.py")
+        ]
+        result = check._failures_result(failures, [], 0.5)
+        assert result.fix_suggestion is not None
+        assert "STEP 1-4 classification" in result.fix_suggestion
 
     def test_run_pip_audit_failure(self, tmp_path):
         """Test run() when pip-audit check fails."""


### PR DESCRIPTION
## Summary
- Adds detect-secrets baseline (`.secrets.baseline`) and STEP 1-4 credential classification workflow in security gate output
- Fixes detect-secrets scan when plugin config is passed via throwaway baseline (reads results from temp file)
- Integration tests use vendor-neutral synthetic secrets that trip detect-secrets without triggering GitHub push protection

## Test plan
- [x] `sm swab` passes locally
- [x] `tests/integration/test_secrets_remediation_integration.py` passes
- [x] `tests/unit/test_detect_secrets_check.py` passes
- [ ] CI green on PR
