### PR TITLE
chore: bump version to 2.3.0 for PyPI release

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "displayName": "slop-mop",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Wraps pytest, black, mypy, gh, and every other tool behind a single `sm` CLI with caching, ordering, and directed remediation built in.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: slop-mop version
       description: "Output of `sm --version` (or the PyPI version installed)."
-      placeholder: "2.2.0"
+      placeholder: "2.3.0"
     validations:
       required: true
   - type: textarea

--- a/DOCS/MACHINE_INTERFACE.md
+++ b/DOCS/MACHINE_INTERFACE.md
@@ -185,7 +185,7 @@ sm capabilities
   "status": "info",
   "exit_code": 0,
   "data": {
-    "version": "2.2.0",
+    "version": "2.3.0",
     "verbs": [
       { "name": "swab", "summary": "…", "level": "core",
         "formats": ["human", "json", "porcelain", "sarif"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is purposefully opinionated, as structure begets adherence to best practices.
 
 ## Project Status
 
-slop-mop is at version 2.2.0. The current public policy surface for release and
+slop-mop is at version 2.3.0. The current public policy surface for release and
 stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)

--- a/slopmop/_version.py
+++ b/slopmop/_version.py
@@ -11,4 +11,4 @@ automatically. Everything else derives from it:
   from this value, so a mismatch can never be merged.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"


### PR DESCRIPTION
Release 2.2.0 -> 2.3.0.

This PR was created by the Release workflow. After checks pass, the workflow merges it into main; the protected main-branch push then runs the publish path.