### PR TITLE
fix(buff): generate the scan artifact buff needs; degrade only on true absence (#252)

### DIFF
--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -172,6 +172,18 @@ jobs:
             --json-file slopmop-results.json \
             --no-json
 
+      # buff inspect downloads this actions artifact (gh run download --name
+      # slopmop-results) to verify code-scanning findings. upload-sarif feeds
+      # Code Scanning but is NOT downloadable, so buff needs this too. always()
+      # because findings exist precisely when the gate fails.
+      - name: Upload scan results for buff
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slopmop-results
+          path: slopmop-results.json
+          if-no-files-found: warn
+
       - name: Publish SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -890,6 +890,7 @@ def _render_inspect_failure(
     *,
     scan_exit: int,
     scan_unavailable: bool,
+    scan_kind: str,
     feedback_result: CheckResult,
     json_output: bool,
 ) -> None:
@@ -898,14 +899,17 @@ def _render_inspect_failure(
     if json_output:
         return
     if scan_exit != 0:
-        if scan_unavailable:
-            if feedback_result.status in {CheckStatus.FAILED, CheckStatus.ERROR}:
-                print("\nBuff inspect incomplete: CI scan artifact is still missing.")
-            else:
-                print(
-                    "\nBuff inspect incomplete: PR feedback is resolved, "
-                    "but the CI scan artifact is still missing."
-                )
+        if scan_unavailable and scan_kind == "artifact_missing":
+            print(
+                "\nBuff inspect: the code-scanning workflow ran but did not "
+                "produce the 'slopmop-results' artifact, so findings could not "
+                "be verified. Fix the workflow's artifact upload or re-run CI."
+            )
+        elif scan_unavailable:
+            print(
+                "\nBuff inspect: CI scan artifact unavailable "
+                "(no code-scanning run for this repo)."
+            )
         else:
             print("\nBuff inspect found unresolved CI scan signals.")
     if feedback_result.status == CheckStatus.FAILED:
@@ -917,6 +921,76 @@ def _render_inspect_failure(
         print("Buff inspect failed: could not verify unresolved PR feedback.")
         if feedback_result.error:
             print(f"ERROR: {feedback_result.error}")
+
+
+def _resolve_inspect_verdict(
+    scan_exit: int,
+    payload: dict[str, Any],
+    feedback_result: CheckResult,
+) -> tuple[int, bool, str]:
+    """Resolve (exit_code, scan_unavailable, scan_kind) for an inspect run.
+
+    Only a *genuinely absent* scan is non-blocking: the repo runs no
+    code-scanning gate, so no workflow run exists and the artifact cannot be
+    produced. A run that exists but didn't yield the artifact is a CI defect to
+    surface, not silence (#252).
+    """
+
+    feedback_blocking = feedback_result.status in {
+        CheckStatus.FAILED,
+        CheckStatus.ERROR,
+    }
+    scan_unavailable_obj = payload.get("scan_unavailable")
+    scan_unavailable = bool(scan_unavailable_obj)
+    scan_kind = ""
+    if isinstance(scan_unavailable_obj, dict):
+        unavailable = cast(dict[str, Any], scan_unavailable_obj)
+        scan_kind = str(unavailable.get("kind") or "")
+    scan_genuinely_absent = scan_unavailable and scan_kind == "no_workflow_run"
+    scan_blocking = scan_exit != 0 and not scan_genuinely_absent
+    exit_code = 1 if (scan_blocking or feedback_blocking) else 0
+    return exit_code, scan_unavailable, scan_kind
+
+
+def _render_inspect_result(
+    *,
+    exit_code: int,
+    scan_unavailable: bool,
+    scan_kind: str,
+    scan_exit: int,
+    payload: dict[str, Any],
+    feedback_result: CheckResult,
+) -> int:
+    """Print human inspect output + verdict; return the resolved exit code."""
+
+    _print_inspect_output(
+        payload=payload,
+        scan_exit=scan_exit,
+        feedback_result=feedback_result,
+    )
+
+    if exit_code == 1:
+        _render_inspect_failure(
+            scan_exit=scan_exit,
+            scan_unavailable=scan_unavailable,
+            scan_kind=scan_kind,
+            feedback_result=feedback_result,
+            json_output=False,
+        )
+        return 1
+
+    if scan_unavailable:
+        # Only reached for a genuinely-absent gate (no workflow run); a missing
+        # artifact from an existing run is blocking above.
+        print(
+            "\nBuff inspect: this repo runs no code-scanning gate, so there is "
+            "nothing to verify. PR feedback resolved — nothing to act on."
+        )
+        print("Next step: run 'sm buff finalize --push' when you want to publish.")
+        return 0
+    print("\nBuff inspect clean: CI scan signals and PR feedback are resolved.")
+    print("Next step: run 'sm buff finalize --push' when you want to publish.")
+    return 0
 
 
 def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
@@ -976,11 +1050,9 @@ def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
         feedback_result=feedback_result,
     )
 
-    feedback_blocking = feedback_result.status in {
-        CheckStatus.FAILED,
-        CheckStatus.ERROR,
-    }
-    exit_code = 1 if (scan_exit != 0 or feedback_blocking) else 0
+    exit_code, scan_unavailable, scan_kind = _resolve_inspect_verdict(
+        scan_exit, payload, feedback_result
+    )
 
     # The triage payload is the buff data slot verbatim — it keeps its own
     # ci-triage sub-schema stamp and instruction list. The envelope adds the
@@ -999,24 +1071,14 @@ def _cmd_buff_inspect(args: argparse.Namespace, pr_number: int | None) -> int:
         print(json.dumps(envelope, indent=2))
         return exit_code
 
-    scan_unavailable = _print_inspect_output(
-        payload=payload,
+    return _render_inspect_result(
+        exit_code=exit_code,
+        scan_unavailable=scan_unavailable,
+        scan_kind=scan_kind,
         scan_exit=scan_exit,
+        payload=payload,
         feedback_result=feedback_result,
     )
-
-    if exit_code == 1:
-        _render_inspect_failure(
-            scan_exit=scan_exit,
-            scan_unavailable=scan_unavailable,
-            feedback_result=feedback_result,
-            json_output=False,
-        )
-        return 1
-
-    print("\nBuff inspect clean: CI scan signals and PR feedback are resolved.")
-    print("Next step: run 'sm buff finalize --push' when you want to publish.")
-    return 0
 
 
 def cmd_buff(args: argparse.Namespace) -> int:

--- a/slopmop/cli/buff_narration.py
+++ b/slopmop/cli/buff_narration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from slopmop.cli.ci import _categorize_checks
 from slopmop.cli.scan_triage import PRResolutionSource
@@ -136,8 +136,14 @@ def print_ci_state_summary(checks: list[dict[str, Any]]) -> None:
 def _scan_state_label(scan_exit: int, payload: dict[str, Any]) -> tuple[str, str]:
     """Return a compact human status for the CI scan artifact."""
 
-    if payload.get("scan_unavailable"):
-        return "unavailable", "CI scan artifact is missing or not downloadable"
+    unavailable = payload.get("scan_unavailable")
+    if unavailable:
+        kind = ""
+        if isinstance(unavailable, dict):
+            kind = str(cast(dict[str, Any], unavailable).get("kind") or "")
+        if kind == "artifact_missing":
+            return "missing", "CI scan ran but its results artifact is missing"
+        return "unavailable", "no code-scanning run for this repo"
     if scan_exit == 0:
         return "clean", "CI scan artifact has no actionable signals"
     return "needs work", "CI scan artifact contains actionable signals"
@@ -151,13 +157,21 @@ def _inspect_overall_state(
 
     if scan_state == "clean" and feedback_state == "resolved":
         return "clean", "CI scan signals and PR feedback are resolved"
+    if scan_state == "missing":
+        return (
+            "blocked",
+            "CI scan ran but its results artifact is missing — fix the upload",
+        )
     if scan_state == "unavailable":
         if feedback_state == "resolved":
             return (
-                "incomplete",
-                "PR feedback is resolved, but the scan artifact is missing",
+                "resolved",
+                "PR feedback resolved; no code-scanning gate to verify",
             )
-        return "incomplete", "scan artifact is missing and PR feedback is not clean"
+        return (
+            "needs work",
+            "no code-scanning run; PR feedback still needs attention",
+        )
     if feedback_state == "error":
         return "blocked", "buff could not verify PR feedback"
     return "needs work", "CI scan signals or PR feedback still need attention"

--- a/slopmop/cli/buff_narration.py
+++ b/slopmop/cli/buff_narration.py
@@ -157,6 +157,8 @@ def _inspect_overall_state(
 
     if scan_state == "clean" and feedback_state == "resolved":
         return "clean", "CI scan signals and PR feedback are resolved"
+    if feedback_state == "error":
+        return "blocked", "buff could not verify PR feedback"
     if scan_state == "missing":
         return (
             "blocked",
@@ -172,8 +174,6 @@ def _inspect_overall_state(
             "needs work",
             "no code-scanning run; PR feedback still needs attention",
         )
-    if feedback_state == "error":
-        return "blocked", "buff could not verify PR feedback"
     return "needs work", "CI scan signals or PR feedback still need attention"
 
 

--- a/slopmop/cli/buff_scan.py
+++ b/slopmop/cli/buff_scan.py
@@ -22,6 +22,25 @@ def is_scan_unavailable_error(exc: TriageError) -> bool:
     return any(marker in message for marker in _SCAN_UNAVAILABLE_MARKERS)
 
 
+_NO_WORKFLOW_RUN_MARKER = "no workflow runs found for that pr/workflow"
+
+
+def scan_unavailable_kind(error: str) -> str:
+    """Classify why the CI scan is unavailable.
+
+    - ``no_workflow_run``: the repo doesn't run the code-scanning gate, so the
+      artifact genuinely cannot exist (non-blocking — nothing to verify).
+    - ``artifact_missing``: a workflow run exists but didn't yield the expected
+      results artifact — a CI defect to surface, not silence.
+    """
+
+    return (
+        "no_workflow_run"
+        if _NO_WORKFLOW_RUN_MARKER in error.lower()
+        else "artifact_missing"
+    )
+
+
 def scan_unavailable_detail(error: str) -> str:
     """Return a concise scan-unavailable detail line."""
 
@@ -57,6 +76,7 @@ def build_scan_unavailable_payload(
         ],
         "scan_unavailable": {
             "error": error,
+            "kind": scan_unavailable_kind(error),
         },
     }
 

--- a/tests/unit/test_buff_scan_fallback.py
+++ b/tests/unit/test_buff_scan_fallback.py
@@ -252,6 +252,14 @@ class TestBuffScanFallback:
 
 
 class TestBuffScanHelpers:
+    def test_overall_state_surfaces_feedback_error_over_unavailable(self):
+        from slopmop.cli.buff_narration import _inspect_overall_state
+
+        # A hard feedback-verification error must block, not be downgraded to
+        # "needs work" by the scan-unavailable branch.
+        state, _ = _inspect_overall_state("unavailable", "error")
+        assert state == "blocked"
+
     def test_scan_unavailable_kind_distinguishes_absence_from_missing(self):
         assert (
             buff_scan.scan_unavailable_kind(

--- a/tests/unit/test_buff_scan_fallback.py
+++ b/tests/unit/test_buff_scan_fallback.py
@@ -52,13 +52,18 @@ class TestBuffScanFallback:
         feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
         monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
 
-        assert buff_mod.cmd_buff(args) == 1
+        # #252 Case A: genuine absence (no code-scanning run on this repo)
+        # degrades to a pass once PR feedback is resolved — nothing to verify.
+        assert buff_mod.cmd_buff(args) == 0
         out = capsys.readouterr().out
-        assert "Buff inspect incomplete: PR feedback is resolved" in out
-        assert "CI scan artifact is still missing" in out
+        assert "PR feedback resolved" in out
+        assert "no code-scanning gate" in out
+        assert "Buff inspect incomplete" not in out
         feedback_gate.assert_called_once_with(86, "/repo")
 
-    def test_cmd_buff_falls_back_when_scan_artifact_missing(self, monkeypatch, capsys):
+    def test_cmd_buff_blocks_when_artifact_missing_from_existing_run(
+        self, monkeypatch, capsys
+    ):
         args = argparse.Namespace(
             json_output=False,
             repo=None,
@@ -96,10 +101,12 @@ class TestBuffScanFallback:
         feedback_gate = Mock(return_value=make_feedback_result(CheckStatus.PASSED))
         monkeypatch.setattr(buff_mod, "_run_pr_feedback_gate", feedback_gate)
 
+        # #252 Case B: a run exists but didn't produce the artifact — a CI
+        # defect buff surfaces (blocks) instead of silently passing.
         assert buff_mod.cmd_buff(args) == 1
         out = capsys.readouterr().out
         assert "CI scan artifact unavailable" in out
-        assert "Buff inspect incomplete: PR feedback is resolved" in out
+        assert "did not produce the 'slopmop-results' artifact" in out
         feedback_gate.assert_called_once_with(84, "/repo")
 
     def test_cmd_buff_scan_fallback_still_blocks_on_review_feedback(
@@ -154,8 +161,7 @@ class TestBuffScanFallback:
         assert buff_mod.cmd_buff(args) == 1
         out = capsys.readouterr().out
         assert "CI scan artifact unavailable" in out
-        assert "Buff inspect incomplete: CI scan artifact is still missing." in out
-        assert "PR feedback is resolved" not in out
+        assert "no code-scanning run for this repo" in out
         assert "Buff inspect found unresolved PR review threads." in out
         assert "PR #85 has unresolved review threads." in out
 
@@ -200,7 +206,7 @@ class TestBuffScanFallback:
         assert "CI scan artifact unavailable" in out
         assert "Scan detail:" not in out
 
-    def test_cmd_buff_json_mode_keeps_scan_absence_nonzero(self, monkeypatch, capsys):
+    def test_cmd_buff_json_mode_blocks_when_artifact_missing(self, monkeypatch, capsys):
         args = argparse.Namespace(
             json_output=True,
             repo=None,
@@ -237,13 +243,29 @@ class TestBuffScanFallback:
             Mock(return_value=make_feedback_result(CheckStatus.PASSED)),
         )
 
+        # #252 Case B: a missing artifact from an existing run is a CI defect —
+        # the JSON envelope reports fail, scan_unavailable kept for detail.
         assert buff_mod.cmd_buff(args) == 1
         out = capsys.readouterr().out
         assert '"scan_unavailable"' in out
-        assert "Buff inspect incomplete" not in out
+        assert '"status": "fail"' in out
 
 
 class TestBuffScanHelpers:
+    def test_scan_unavailable_kind_distinguishes_absence_from_missing(self):
+        assert (
+            buff_scan.scan_unavailable_kind(
+                "No workflow runs found for that PR/workflow. Pass --run-id."
+            )
+            == "no_workflow_run"
+        )
+        assert (
+            buff_scan.scan_unavailable_kind(
+                "no artifact matches any of the names or patterns provided"
+            )
+            == "artifact_missing"
+        )
+
     def test_is_scan_unavailable_error_matches_known_missing_sources(self):
         assert buff_scan.is_scan_unavailable_error(
             triage.TriageError("No workflow runs found for that PR/workflow")


### PR DESCRIPTION
Closes #252. (Repurposed from a symptom-only patch after review — see below.)

## Root cause
slop-mop's own CI never produced the artifact buff inspects. `slopmop-sarif.yml` feeds **Code Scanning** via `upload-sarif` (which is *not* downloadable) and writes `slopmop-results.json` locally — but had **no `actions/upload-artifact` step**. buff fetches findings with `gh run download --name slopmop-results` (an *actions* artifact), so on every slop-mop PR that download failed ("no valid artifacts found") and `sm buff inspect` could never verify code-scanning.

## Primary fix — generate the artifact where buff needs it
Add an `actions/upload-artifact` step (`if: always()`, since findings exist precisely when the gate fails) uploading `slopmop-results.json` as `slopmop-results`. Now `gh run download` resolves and buff does its job.

## Corrected fallback — degrade only on *genuine* absence
The first version of this PR made *any* missing artifact a free pass — which is the baseline-it-away anti-pattern slop-mop exists to catch (it would have made buff inspect silently pass without ever verifying code-scanning). Fixed to distinguish:
- **`no_workflow_run`** (the repo runs no code-scanning gate): non-blocking — there's nothing to verify; inspect passes once PR feedback is resolved.
- **`artifact_missing`** (a run exists but didn't yield the artifact): a **CI defect** — buff surfaces it (blocks, names the missing `slopmop-results` artifact) instead of silently passing.

Verdict, message, and the `Overall:` line are all consistent across both cases and JSON mode.

## Tests
Both cases + the classifier covered; full suite green (3132); swab + scour clean. Helpers (`_resolve_inspect_verdict`, `_render_inspect_result`) extracted to stay under the sprawl limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix buff's code scanning artifact verification with graceful degradation

Problem: sm buff inspect could not obtain the CI artifact (gh run download) and treated all missing-artifact cases as non-blocking or left PRs "incomplete", blocking resolved PRs.

Key changes:
- CI workflow (.github/workflows/slopmop-sarif.yml): add actions/upload-artifact@v4 step (if: always()) to upload slopmop-results.json as slopmop-results so gh run download succeeds.
- Artifact classification (slopmop/cli/buff_scan.py): add scan_unavailable_kind(error) and include scan_unavailable.kind in the payload to distinguish no_workflow_run vs artifact_missing.
- Verdict and rendering (slopmop/cli/buff.py): extract _resolve_inspect_verdict(...) and _render_inspect_result(...); treat no_workflow_run as non-blocking (passes when PR feedback resolved) and treat artifact_missing (or scan failures) as blocking.
- Narration (slopmop/cli/buff_narration.py): _scan_state_label parses scan_unavailable.kind; _inspect_overall_state now prioritizes feedback error (blocks) and maps artifact_missing → blocked, no_workflow_run + resolved feedback → resolved.
- Tests (tests/unit/test_buff_scan_fallback.py): update expectations — no-workflow exits 0 and reports "no code-scanning gate", artifact-missing exits 1 and surfaces missing-artifact messaging; JSON-mode assertions aligned; added/regressed test ensuring feedback verification errors are prioritized.

Impact: Resolved PRs on repos without a code-scanning gate are no longer stuck; genuine CI defects (existing run but missing artifact) are surfaced and block as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->