### PR TITLE
fix(formatting): defer to host ruff/black; guard black from migration dirs (#264, #263)

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "status": "Barnacle #264 — host formatter deference + migration exclusion, PR #273 open",
+    "status": "Addressing 8 reviewer threads on PR #273 — all valid, fixing now",
     "direction": "Get #273 merged, then pick up #263 or #253",
     "last_update": "2026-06-09T03:00:00Z"
   }

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Wrapping a batch of cleanups — open-source license switch, slow checks moved to the pre-PR sweep, version number now lives in one place. Now dogfooding on a big real-world repo and logging the snags as we hit them.",
-    "direction": "Turn those snags into fixes and keep making the project easy for newcomers to trust and adopt.",
-    "last_update": "2026-06-09T00:00:00Z"
+    "status": "Barnacle #264 — refit now defers to host ruff/black instead of forcing its own formatter, PR in progress",
+    "direction": "Get formatter-deference merged, then tackle #263 (migration exclusion) and #253 (detect-secrets allowlist)",
+    "last_update": "2026-06-09T02:00:00Z"
   }
 }

--- a/.willville.json
+++ b/.willville.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "status": "Second pass on PR #273 reviewer threads — 3 more fixes landed",
+    "status": "PR #273 — fixing coverage + constant + test URL issues",
     "direction": "Get #273 merged, then pick up #263 or #253",
     "last_update": "2026-06-09T03:00:00Z"
   }

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Barnacle #264 — refit now defers to host ruff/black instead of forcing its own formatter, PR in progress",
-    "direction": "Get formatter-deference merged, then tackle #263 (migration exclusion) and #253 (detect-secrets allowlist)",
-    "last_update": "2026-06-09T02:00:00Z"
+    "status": "Barnacle #264 — host formatter deference + migration exclusion, PR #273 open",
+    "direction": "Get #273 merged, then pick up #263 or #253",
+    "last_update": "2026-06-09T03:00:00Z"
   }
 }

--- a/.willville.json
+++ b/.willville.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "status": "Addressing 8 reviewer threads on PR #273 — all valid, fixing now",
+    "status": "Second pass on PR #273 reviewer threads — 3 more fixes landed",
     "direction": "Get #273 merged, then pick up #263 or #253",
     "last_update": "2026-06-09T03:00:00Z"
   }

--- a/slopmop/checks/python/_host_formatter.py
+++ b/slopmop/checks/python/_host_formatter.py
@@ -60,8 +60,9 @@ def detect_host_python_formatter(project_root: str) -> Optional[str]:
     if precommit.exists():
         try:
             content = precommit.read_text(encoding="utf-8")
-            # astral-sh/ruff-pre-commit or any repo with 'ruff' as hook id
-            if re.search(r"\bruff\b", content):
+            # Match `- id: ruff` or `- id: ruff-format` (actual hook IDs),
+            # not URLs or comments that merely mention "ruff".
+            if re.search(r"^\s*-\s+id:\s+ruff", content, re.MULTILINE):
                 return "ruff"
         except OSError:
             pass

--- a/slopmop/checks/python/_host_formatter.py
+++ b/slopmop/checks/python/_host_formatter.py
@@ -1,0 +1,65 @@
+"""Detect the Python formatter already configured by the host project.
+
+Used by sloppy-formatting.py to defer to the project's own formatter
+instead of imposing slop-mop's defaults (autoflake + black + isort).
+
+When a project already pins ruff (or black), slop-mop running a different
+formatter produces churn: the gate-fix commit ends up in a style that the
+host's CI then immediately undoes. Detecting the host formatter and using
+it keeps the output in sync with what CI expects.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+
+def detect_host_python_formatter(project_root: str) -> Optional[str]:
+    """Return the formatter the project has configured, or None.
+
+    Return values:
+      'ruff'  — project configured ruff; use ``ruff format`` + ``ruff check``
+      'black' — project configured black explicitly (no ruff)
+      None    — no host formatter detected; caller should use defaults
+
+    Detection priority:
+      1. pyproject.toml [tool.ruff.*] → 'ruff'
+      2. .ruff.toml or ruff.toml presence → 'ruff'
+      3. .pre-commit-config.yaml containing a ruff hook → 'ruff'
+      4. pyproject.toml [tool.black] (no ruff) → 'black'
+      5. Nothing found → None
+    """
+    root = Path(project_root)
+
+    # 1. pyproject.toml
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+            # Matches [tool.ruff], [tool.ruff.format], [tool.ruff.lint], etc.
+            if re.search(r"^\s*\[tool\.ruff[.\]]", content, re.MULTILINE):
+                return "ruff"
+            # Matches [tool.black] or [tool.black.*]
+            if re.search(r"^\s*\[tool\.black[.\]]", content, re.MULTILINE):
+                return "black"
+        except OSError:
+            pass  # Unreadable pyproject — fall through
+
+    # 2. Standalone ruff config files
+    if (root / ".ruff.toml").exists() or (root / "ruff.toml").exists():
+        return "ruff"
+
+    # 3. .pre-commit-config.yaml with a ruff hook
+    precommit = root / ".pre-commit-config.yaml"
+    if precommit.exists():
+        try:
+            content = precommit.read_text(encoding="utf-8")
+            # astral-sh/ruff-pre-commit or any repo with 'ruff' as hook id
+            if re.search(r"\bruff\b", content):
+                return "ruff"
+        except OSError:
+            pass
+
+    return None

--- a/slopmop/checks/python/_host_formatter.py
+++ b/slopmop/checks/python/_host_formatter.py
@@ -32,6 +32,7 @@ def detect_host_python_formatter(project_root: str) -> Optional[str]:
       5. Nothing found → None
     """
     root = Path(project_root)
+    pyproject_has_black = False
 
     # 1. pyproject.toml
     pyproject = root / "pyproject.toml"
@@ -41,13 +42,16 @@ def detect_host_python_formatter(project_root: str) -> Optional[str]:
             # Matches [tool.ruff], [tool.ruff.format], [tool.ruff.lint], etc.
             if re.search(r"^\s*\[tool\.ruff[.\]]", content, re.MULTILINE):
                 return "ruff"
-            # Matches [tool.black] or [tool.black.*]
+            # Matches [tool.black] or [tool.black.*] — defer the return so that
+            # a standalone ruff config or pre-commit ruff hook can still win
+            # (e.g. a project that migrated from black to ruff but kept the
+            # legacy [tool.black] section for history).
             if re.search(r"^\s*\[tool\.black[.\]]", content, re.MULTILINE):
-                return "black"
+                pyproject_has_black = True
         except OSError:
             pass  # Unreadable pyproject — fall through
 
-    # 2. Standalone ruff config files
+    # 2. Standalone ruff config files (checked before honouring pyproject black)
     if (root / ".ruff.toml").exists() or (root / "ruff.toml").exists():
         return "ruff"
 
@@ -61,5 +65,9 @@ def detect_host_python_formatter(project_root: str) -> Optional[str]:
                 return "ruff"
         except OSError:
             pass
+
+    # 4. Fall back to black if we saw it in pyproject but no ruff signal won
+    if pyproject_has_black:
+        return "black"
 
     return None

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -26,6 +26,7 @@ from slopmop.checks.base import (
     RemediationChurn,
     ToolContext,
 )
+from slopmop.checks.constants import COMMAND_NOT_FOUND
 from slopmop.checks.mixins import PythonCheckMixin
 from slopmop.checks.python._host_formatter import detect_host_python_formatter
 from slopmop.constants import ISSUES_FOUND_TEMPLATE
@@ -388,7 +389,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         )
         if not result.success:
             output = (result.output or "").strip()
-            if "Command not found" in output:
+            if COMMAND_NOT_FOUND in output:
                 return _RUFF_SKIPPED
             return output or "Ruff format check failed"
         return None
@@ -402,7 +403,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         )
         if not result.success:
             output = (result.output or "").strip()
-            if "Command not found" in output:
+            if COMMAND_NOT_FOUND in output:
                 return _RUFF_SKIPPED
             if output:
                 lines = [line for line in output.splitlines() if line.strip()]

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -17,8 +17,6 @@ import re
 import time
 from typing import List, Optional
 
-from slopmop.checks.python._host_formatter import detect_host_python_formatter
-
 from slopmop.checks.base import (
     BaseCheck,
     CheckRole,
@@ -29,6 +27,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.python._host_formatter import detect_host_python_formatter
 from slopmop.constants import ISSUES_FOUND_TEMPLATE
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -61,7 +60,9 @@ _DEFAULT_EXCLUDE_DIRS = [
 # Black --extend-exclude regex built from _DEFAULT_EXCLUDE_DIRS so that
 # recursive runs on a top-level package (e.g. "enterprise") don't descend
 # into nested migration dirs like enterprise/migrations/versions/. (#263)
-_BLACK_EXTEND_EXCLUDE = r"/(" + "|".join(re.escape(d) for d in _DEFAULT_EXCLUDE_DIRS) + r")/"
+_BLACK_EXTEND_EXCLUDE = (
+    r"/(" + "|".join(re.escape(d) for d in _DEFAULT_EXCLUDE_DIRS) + r")/"
+)
 
 
 def _is_import_error(output: str) -> bool:

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -144,13 +144,15 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
             ConfigField(
                 name="formatter",
                 field_type="string",
-                default=None,
+                default="auto",
+                choices=["auto", "ruff", "black", "none"],
                 description=(
                     "Python formatter to use. Options: 'auto' (detect from project "
                     "config — default), 'ruff' (always use ruff format + ruff check), "
                     "'black' (always use autoflake + black + isort), 'none' (skip "
-                    "formatting entirely). Auto-detection checks pyproject.toml, "
-                    ".ruff.toml, and .pre-commit-config.yaml."
+                    "formatting entirely — flake8 syntax checks still run). "
+                    "Auto-detection checks pyproject.toml, .ruff.toml, and "
+                    ".pre-commit-config.yaml."
                 ),
             ),
         ]
@@ -299,13 +301,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         output_parts: List[str] = []
 
         if formatter == "none":
-            return self._create_result(
-                status=CheckStatus.PASSED,
-                duration=time.time() - start_time,
-                output="Formatting skipped (formatter: none)",
-            )
-
-        if formatter == "ruff":
+            output_parts.append("Formatting skipped (formatter: none)")
+            fix_hint = "Run: flake8 --select=E9,F63,F7,F82,F401 . to check syntax"
+        elif formatter == "ruff":
             # Check 1: ruff format
             fmt_result = self._check_ruff_format(project_root)
             if fmt_result:
@@ -398,7 +396,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         if not result.success:
             output = (result.output or "").strip()
             if output:
-                lines = [l for l in output.splitlines() if l.strip()]
+                lines = [line for line in output.splitlines() if line.strip()]
                 if len(lines) <= 5:
                     return "Import order issues:\n  " + "\n  ".join(lines)
                 shown = "\n  ".join(lines[:5])
@@ -429,6 +427,8 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                     "--check",
                     "--line-length",
                     "88",
+                    "--extend-exclude",
+                    _BLACK_EXTEND_EXCLUDE,
                     target,
                 ],
                 cwd=project_root,

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -1,16 +1,23 @@
 """Python lint and format check using black, isort, autoflake, and flake8.
 
 This check:
-1. Auto-removes unused imports with autoflake
-2. Auto-fixes formatting with black
-3. Auto-fixes import order with isort
+1. Auto-removes unused imports with autoflake (or ruff when configured)
+2. Auto-fixes formatting with black (or ruff when configured)
+3. Auto-fixes import order with isort (or ruff when configured)
 4. Checks for critical lint errors with flake8
+
+When the project already pins ruff (detected via pyproject.toml, ruff.toml,
+or .pre-commit-config.yaml), the gate defers to ruff format + ruff check
+instead of running black/isort/autoflake.  This prevents formatting churn
+when the host's CI would immediately reformat slop-mop's output.
 """
 
 import os
 import re
 import time
 from typing import List, Optional
+
+from slopmop.checks.python._host_formatter import detect_host_python_formatter
 
 from slopmop.checks.base import (
     BaseCheck,
@@ -50,6 +57,11 @@ _DEFAULT_EXCLUDE_DIRS = [
     "alembic",
     "ephemeral",
 ]
+
+# Black --extend-exclude regex built from _DEFAULT_EXCLUDE_DIRS so that
+# recursive runs on a top-level package (e.g. "enterprise") don't descend
+# into nested migration dirs like enterprise/migrations/versions/. (#263)
+_BLACK_EXTEND_EXCLUDE = r"/(" + "|".join(re.escape(d) for d in _DEFAULT_EXCLUDE_DIRS) + r")/"
 
 
 def _is_import_error(output: str) -> bool:
@@ -128,7 +140,33 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                 description="Maximum line length for black",
                 permissiveness="lower_is_stricter",
             ),
+            ConfigField(
+                name="formatter",
+                field_type="string",
+                default=None,
+                description=(
+                    "Python formatter to use. Options: 'auto' (detect from project "
+                    "config — default), 'ruff' (always use ruff format + ruff check), "
+                    "'black' (always use autoflake + black + isort), 'none' (skip "
+                    "formatting entirely). Auto-detection checks pyproject.toml, "
+                    ".ruff.toml, and .pre-commit-config.yaml."
+                ),
+            ),
         ]
+
+    def _effective_formatter(self, project_root: str) -> Optional[str]:
+        """Return 'ruff', 'black', or None (use black defaults).
+
+        Respects an explicit 'formatter' config override; falls back to
+        auto-detection via the project's own config files.
+        """
+        override = self.config.get("formatter")
+        if override == "none":
+            return "none"
+        if override in ("ruff", "black"):
+            return override
+        # 'auto' or unset: detect from project
+        return detect_host_python_formatter(project_root)
 
     def is_applicable(self, project_root: str) -> bool:
         return self.is_python_project(project_root)
@@ -137,7 +175,46 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         return True
 
     def auto_fix(self, project_root: str) -> bool:
-        """Auto-fix formatting issues with autoflake, black, and isort."""
+        """Auto-fix formatting issues.
+
+        Defers to the project's own formatter when one is configured
+        (ruff), falling back to autoflake + black + isort otherwise.
+        """
+        formatter = self._effective_formatter(project_root)
+        if formatter == "none":
+            return False
+        if formatter == "ruff":
+            return self._auto_fix_ruff(project_root)
+        return self._auto_fix_black(project_root)
+
+    def _auto_fix_ruff(self, project_root: str) -> bool:
+        """Format with ruff — defers to the project's own ruff config."""
+        fixed = False
+
+        # ruff format replaces black
+        result = self._run_command(
+            ["ruff", "format", "."],
+            cwd=project_root,
+            timeout=60,
+        )
+        if result.success:
+            fixed = True
+
+        # ruff check --fix --select I replaces isort; F401 replaces autoflake.
+        # --select overrides pyproject config for this invocation so we touch
+        # only style (not logic-altering rules).
+        result = self._run_command(
+            ["ruff", "check", "--fix", "--select", "I,F401", "."],
+            cwd=project_root,
+            timeout=60,
+        )
+        if result.success:
+            fixed = True
+
+        return fixed
+
+    def _auto_fix_black(self, project_root: str) -> bool:
+        """Format with autoflake + black + isort (slop-mop defaults)."""
         fixed = False
 
         # Find Python source directories to format
@@ -161,13 +238,16 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         if result.success:
             fixed = True
 
-        # Run black on each target
+        # Run black on each target.  --extend-exclude prevents recursive
+        # descent into nested migration/alembic dirs (#263).
         for target in targets:
             result = self._run_command(
                 [
                     "black",
                     "--line-length",
                     "88",
+                    "--extend-exclude",
+                    _BLACK_EXTEND_EXCLUDE,
                     target,
                 ],
                 cwd=project_root,
@@ -207,30 +287,63 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         return targets
 
     def run(self, project_root: str) -> CheckResult:
-        """Run lint and format checks."""
+        """Run lint and format checks.
+
+        Uses ruff when the project has it configured; black/isort otherwise.
+        Flake8 runs in both cases for critical syntax/undefined-name errors.
+        """
         start_time = time.time()
+        formatter = self._effective_formatter(project_root)
         issues: List[str] = []
         output_parts: List[str] = []
 
-        # Check 1: Black formatting
-        black_result = self._check_black(project_root)
-        if black_result == _BLACK_SKIPPED:
-            output_parts.append("Black: ⚠️ Skipped (broken installation)")
-        elif black_result:
-            issues.append(black_result)
-            output_parts.append(f"Black: {black_result}")
-        else:
-            output_parts.append("Black: ✅ Formatting OK")
+        if formatter == "none":
+            return self._create_result(
+                status=CheckStatus.PASSED,
+                duration=time.time() - start_time,
+                output="Formatting skipped (formatter: none)",
+            )
 
-        # Check 2: Isort imports
-        isort_result = self._check_isort(project_root)
-        if isort_result:
-            issues.append(isort_result)
-            output_parts.append(f"Isort: {isort_result}")
-        else:
-            output_parts.append("Isort: ✅ Import order OK")
+        if formatter == "ruff":
+            # Check 1: ruff format
+            fmt_result = self._check_ruff_format(project_root)
+            if fmt_result:
+                issues.append(fmt_result)
+                output_parts.append(f"Ruff format: {fmt_result}")
+            else:
+                output_parts.append("Ruff format: ✅ Formatting OK")
 
-        # Check 3: Flake8 critical errors
+            # Check 2: ruff import order
+            import_result = self._check_ruff_imports(project_root)
+            if import_result:
+                issues.append(import_result)
+                output_parts.append(f"Ruff imports: {import_result}")
+            else:
+                output_parts.append("Ruff imports: ✅ Import order OK")
+
+            fix_hint = "Run: ruff format . && ruff check --fix --select I,F401 ."
+        else:
+            # Check 1: Black formatting
+            black_result = self._check_black(project_root)
+            if black_result == _BLACK_SKIPPED:
+                output_parts.append("Black: ⚠️ Skipped (broken installation)")
+            elif black_result:
+                issues.append(black_result)
+                output_parts.append(f"Black: {black_result}")
+            else:
+                output_parts.append("Black: ✅ Formatting OK")
+
+            # Check 2: Isort imports
+            isort_result = self._check_isort(project_root)
+            if isort_result:
+                issues.append(isort_result)
+                output_parts.append(f"Isort: {isort_result}")
+            else:
+                output_parts.append("Isort: ✅ Import order OK")
+
+            fix_hint = "Run: black . && isort . to auto-fix formatting"
+
+        # Check 3: Flake8 critical errors (always)
         flake8_result, flake8_findings = self._check_flake8(project_root)
         if flake8_result:
             issues.append(flake8_result)
@@ -242,7 +355,6 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
 
         if issues:
             msg = ISSUES_FOUND_TEMPLATE.format(count=len(issues))
-            # Prefer flake8_findings if available; if none, use generic message
             final_findings = (
                 flake8_findings
                 if flake8_findings
@@ -253,7 +365,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                 duration=duration,
                 output="\n".join(output_parts),
                 error=msg,
-                fix_suggestion="Run: black . && isort . to auto-fix formatting",
+                fix_suggestion=fix_hint,
                 findings=final_findings,
             )
 
@@ -262,6 +374,36 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
             duration=duration,
             output="\n".join(output_parts),
         )
+
+    def _check_ruff_format(self, project_root: str) -> Optional[str]:
+        """Check ruff formatting (equivalent of black --check)."""
+        result = self._run_command(
+            ["ruff", "format", "--check", "."],
+            cwd=project_root,
+            timeout=60,
+        )
+        if not result.success:
+            output = (result.output or result.stderr or "").strip()
+            return output or "Ruff format check failed"
+        return None
+
+    def _check_ruff_imports(self, project_root: str) -> Optional[str]:
+        """Check import order with ruff (equivalent of isort --check-only)."""
+        result = self._run_command(
+            ["ruff", "check", "--select", "I", "."],
+            cwd=project_root,
+            timeout=60,
+        )
+        if not result.success:
+            output = (result.output or "").strip()
+            if output:
+                lines = [l for l in output.splitlines() if l.strip()]
+                if len(lines) <= 5:
+                    return "Import order issues:\n  " + "\n  ".join(lines)
+                shown = "\n  ".join(lines[:5])
+                return f"Import order issues:\n  {shown}\n  ... and {len(lines)-5} more"
+            return "Import order issues found"
+        return None
 
     def _check_black(self, project_root: str) -> Optional[str]:
         """Check black formatting.

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -39,6 +39,7 @@ _FLAKE8_RE = re.compile(r"^(.+?):(\d+):(\d+): (\w+) (.+)$")
 # a string (real formatting failure) so that run() can report the
 # skip without treating it as a pass.
 _BLACK_SKIPPED = "__BLACK_SKIPPED_BROKEN_INSTALL__"
+_RUFF_SKIPPED = "__RUFF_SKIPPED_NOT_INSTALLED__"
 
 _DEFAULT_EXCLUDE_DIRS = [
     "venv",
@@ -106,7 +107,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["black", "isort", "autoflake", "flake8"]
+    required_tools = ["black", "isort", "autoflake", "flake8", "ruff"]
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_UNLIKELY
     is_formatting_gate = True
@@ -306,7 +307,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         elif formatter == "ruff":
             # Check 1: ruff format
             fmt_result = self._check_ruff_format(project_root)
-            if fmt_result:
+            if fmt_result == _RUFF_SKIPPED:
+                output_parts.append("Ruff format: ⚠️ Skipped (ruff not installed)")
+            elif fmt_result:
                 issues.append(fmt_result)
                 output_parts.append(f"Ruff format: {fmt_result}")
             else:
@@ -314,7 +317,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
 
             # Check 2: ruff import order
             import_result = self._check_ruff_imports(project_root)
-            if import_result:
+            if import_result == _RUFF_SKIPPED:
+                output_parts.append("Ruff imports: ⚠️ Skipped (ruff not installed)")
+            elif import_result:
                 issues.append(import_result)
                 output_parts.append(f"Ruff imports: {import_result}")
             else:
@@ -382,7 +387,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
             timeout=60,
         )
         if not result.success:
-            output = (result.output or result.stderr or "").strip()
+            output = (result.output or "").strip()
+            if "Command not found" in output:
+                return _RUFF_SKIPPED
             return output or "Ruff format check failed"
         return None
 
@@ -395,6 +402,8 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         )
         if not result.success:
             output = (result.output or "").strip()
+            if "Command not found" in output:
+                return _RUFF_SKIPPED
             if output:
                 lines = [line for line in output.splitlines() if line.strip()]
                 if len(lines) <= 5:

--- a/tests/unit/test_python_host_formatter.py
+++ b/tests/unit/test_python_host_formatter.py
@@ -8,7 +8,7 @@ Covers:
   - _BLACK_EXTEND_EXCLUDE presence in black calls (barnacle #263)
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from slopmop.checks.python._host_formatter import detect_host_python_formatter
 from slopmop.checks.python.lint_format import (
@@ -100,11 +100,10 @@ class TestDetectHostPythonFormatter:
         assert detect_host_python_formatter(str(tmp_path)) is None
 
     def test_precommit_ruff_url_without_hook_returns_none(self, tmp_path):
-        # Repo URL contains 'ruff' but no actual ruff hook — should NOT match
+        # Repo URL contains 'ruff' but hook ID is not ruff — should NOT match
         (tmp_path / ".pre-commit-config.yaml").write_text(
-            "# migrated away from ruff-pre-commit\n"
             "repos:\n"
-            "  - repo: https://github.com/psf/black\n"
+            "  - repo: https://github.com/astral-sh/ruff-pre-commit\n"
             "    hooks:\n"
             "      - id: black\n"
         )
@@ -299,6 +298,135 @@ class TestRunRuffBranch:
 
         assert result.status == CheckStatus.FAILED
         assert "ruff" in result.fix_suggestion.lower()
+
+
+# ---------------------------------------------------------------------------
+# _RUFF_SKIPPED paths and _check_ruff_imports error paths
+# ---------------------------------------------------------------------------
+
+
+class TestRuffSkippedAndErrorPaths:
+    """Coverage for _RUFF_SKIPPED sentinel and _check_ruff_imports error branches."""
+
+    def _cmd_not_found_result(self):
+        return SubprocessResult(
+            returncode=-1, stdout="", stderr="Command not found: ruff", duration=0.1
+        )
+
+    def _success(self):
+        return SubprocessResult(returncode=0, stdout="", stderr="", duration=0.1)
+
+    def test_run_skips_ruff_format_when_not_installed(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = MagicMock()
+
+        def side_effect(cmd, *args, **kwargs):
+            if cmd and "ruff" in cmd[0] and "format" in cmd:
+                return self._cmd_not_found_result()
+            return self._success()
+
+        runner.run.side_effect = side_effect
+        check = PythonLintFormatCheck({}, runner=runner)
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+        assert "skipped" in result.output.lower()
+
+    def test_run_skips_ruff_imports_when_not_installed(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = MagicMock()
+
+        def side_effect(cmd, *args, **kwargs):
+            if cmd and "ruff" in cmd[0] and "check" in cmd:
+                return self._cmd_not_found_result()
+            return self._success()
+
+        runner.run.side_effect = side_effect
+        check = PythonLintFormatCheck({}, runner=runner)
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+        assert "skipped" in result.output.lower()
+
+    def test_run_ruff_imports_fail_adds_to_issues(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = MagicMock()
+
+        def side_effect(cmd, *args, **kwargs):
+            if cmd and "ruff" in cmd[0] and "check" in cmd and "--select" in cmd:
+                return SubprocessResult(
+                    returncode=1,
+                    stdout="src/main.py:1:1: I001 Import block is un-sorted",
+                    stderr="",
+                    duration=0.1,
+                )
+            return self._success()
+
+        runner.run.side_effect = side_effect
+        check = PythonLintFormatCheck({}, runner=runner)
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+
+    def test_check_ruff_imports_no_output_returns_generic_message(self, tmp_path):
+        runner = MagicMock()
+        runner.run.return_value = SubprocessResult(
+            returncode=1, stdout="", stderr="", duration=0.1
+        )
+        check = PythonLintFormatCheck({"formatter": "ruff"}, runner=runner)
+        result = check._check_ruff_imports(str(tmp_path))
+
+        assert result == "Import order issues found"
+
+    def test_check_ruff_imports_many_lines_truncates(self, tmp_path):
+        many_lines = "\n".join(
+            f"src/file.py:{i}:1: I001 Import block is un-sorted" for i in range(10)
+        )
+        runner = MagicMock()
+        runner.run.return_value = SubprocessResult(
+            returncode=1, stdout=many_lines, stderr="", duration=0.1
+        )
+        check = PythonLintFormatCheck({"formatter": "ruff"}, runner=runner)
+        result = check._check_ruff_imports(str(tmp_path))
+
+        assert result is not None
+        assert "... and 5 more" in result
+
+    def test_auto_fix_ruff_returns_false_when_all_fail(self, tmp_path):
+        runner = MagicMock()
+        runner.run.return_value = SubprocessResult(
+            returncode=1, stdout="", stderr="", duration=0.1
+        )
+        check = PythonLintFormatCheck({"formatter": "ruff"}, runner=runner)
+        result = check.auto_fix(str(tmp_path))
+
+        assert result is False
+
+
+class TestHostFormatterOsErrors:
+    """Coverage for OSError paths in detect_host_python_formatter."""
+
+    def test_oserror_reading_pyproject_falls_through(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.black]\n")
+        with patch("pathlib.Path.read_text", side_effect=OSError("permission denied")):
+            result = detect_host_python_formatter(str(tmp_path))
+        # OSError swallowed; no ruff signal → None
+        assert result is None
+
+    def test_oserror_reading_precommit_falls_through(self, tmp_path):
+        (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+        with patch("pathlib.Path.read_text", side_effect=OSError("permission denied")):
+            result = detect_host_python_formatter(str(tmp_path))
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_python_host_formatter.py
+++ b/tests/unit/test_python_host_formatter.py
@@ -1,0 +1,295 @@
+"""Tests for host-formatter detection and the sloppy-formatting.py ruff branch.
+
+Covers:
+  - detect_host_python_formatter() detection signals
+  - PythonLintFormatCheck._effective_formatter() config override
+  - auto_fix() dispatching to ruff vs black
+  - run() using ruff format --check when ruff is detected
+  - _BLACK_EXTEND_EXCLUDE presence in black calls (barnacle #263)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from slopmop.checks.python._host_formatter import detect_host_python_formatter
+from slopmop.checks.python.lint_format import (
+    _BLACK_EXTEND_EXCLUDE,
+    PythonLintFormatCheck,
+)
+from slopmop.core.result import CheckStatus
+from slopmop.subprocess.runner import SubprocessResult
+
+
+# ---------------------------------------------------------------------------
+# detect_host_python_formatter
+# ---------------------------------------------------------------------------
+
+
+class TestDetectHostPythonFormatter:
+    def test_no_config_returns_none(self, tmp_path):
+        assert detect_host_python_formatter(str(tmp_path)) is None
+
+    def test_tool_ruff_section_in_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\nselect = ['E']\n")
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_tool_ruff_format_section_in_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.ruff.format]\nquote-style = 'double'\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_tool_ruff_lint_section_in_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.ruff.lint]\nselect = ['E', 'F']\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_tool_black_section_returns_black(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.black]\nline-length = 88\n")
+        assert detect_host_python_formatter(str(tmp_path)) == "black"
+
+    def test_ruff_takes_priority_over_black(self, tmp_path):
+        # Both configured — ruff section appears first
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.ruff]\nselect = ['E']\n[tool.black]\nline-length = 88\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_dot_ruff_toml_returns_ruff(self, tmp_path):
+        (tmp_path / ".ruff.toml").write_text("line-length = 88\n")
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_ruff_toml_returns_ruff(self, tmp_path):
+        (tmp_path / "ruff.toml").write_text("line-length = 88\n")
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_precommit_with_ruff_hook(self, tmp_path):
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n"
+            "  - repo: https://github.com/astral-sh/ruff-pre-commit\n"
+            "    hooks:\n"
+            "      - id: ruff\n"
+            "      - id: ruff-format\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_precommit_without_ruff_returns_none(self, tmp_path):
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n"
+            "  - repo: https://github.com/psf/black\n"
+            "    hooks:\n"
+            "      - id: black\n"
+        )
+        # black via pre-commit alone doesn't return 'black' — no pyproject.toml
+        assert detect_host_python_formatter(str(tmp_path)) is None
+
+    def test_unreadable_pyproject_falls_through(self, tmp_path):
+        # Can't chmod in a tmp_path test to make it unreadable portably,
+        # but a malformed pyproject.toml should not crash detection.
+        (tmp_path / "pyproject.toml").write_text("not valid toml [[[")
+        # Should not raise; may return None or a value based on text match
+        result = detect_host_python_formatter(str(tmp_path))
+        assert result in (None, "ruff", "black")
+
+
+# ---------------------------------------------------------------------------
+# _effective_formatter() config override
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveFormatter:
+    def test_auto_detects_ruff_from_project(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        check = PythonLintFormatCheck({})
+        assert check._effective_formatter(str(tmp_path)) == "ruff"
+
+    def test_auto_returns_none_when_nothing_configured(self, tmp_path):
+        check = PythonLintFormatCheck({})
+        assert check._effective_formatter(str(tmp_path)) is None
+
+    def test_override_ruff_ignores_project(self, tmp_path):
+        # No project config, but explicit override
+        check = PythonLintFormatCheck({"formatter": "ruff"})
+        assert check._effective_formatter(str(tmp_path)) == "ruff"
+
+    def test_override_black_ignores_ruff_config(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        check = PythonLintFormatCheck({"formatter": "black"})
+        assert check._effective_formatter(str(tmp_path)) == "black"
+
+    def test_override_none_returns_none_sentinel(self, tmp_path):
+        check = PythonLintFormatCheck({"formatter": "none"})
+        assert check._effective_formatter(str(tmp_path)) == "none"
+
+
+# ---------------------------------------------------------------------------
+# auto_fix() dispatching
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFixDispatching:
+    def _make_runner(self, success: bool = True) -> MagicMock:
+        runner = MagicMock()
+        runner.run.return_value = SubprocessResult(
+            returncode=0 if success else 1,
+            stdout="",
+            stderr="",
+            duration=0.1,
+        )
+        return runner
+
+    def test_auto_fix_uses_ruff_when_detected(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        runner = self._make_runner()
+        check = PythonLintFormatCheck({}, runner=runner)
+        check.auto_fix(str(tmp_path))
+
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        # Executable path may be resolved (/usr/bin/ruff etc.)
+        assert any("ruff" in c[0] for c in calls if c)
+        assert not any("black" in c[0] for c in calls if c)
+
+    def test_auto_fix_uses_black_when_no_ruff(self, tmp_path):
+        runner = self._make_runner()
+        check = PythonLintFormatCheck({}, runner=runner)
+        check.auto_fix(str(tmp_path))
+
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        assert any("black" in c[0] for c in calls if c)
+        assert not any("ruff" in c[0] for c in calls if c)
+
+    def test_auto_fix_skips_all_when_formatter_none(self, tmp_path):
+        runner = self._make_runner()
+        check = PythonLintFormatCheck({"formatter": "none"}, runner=runner)
+        result = check.auto_fix(str(tmp_path))
+
+        assert result is False
+        runner.run.assert_not_called()
+
+    def test_auto_fix_ruff_calls_format_and_check(self, tmp_path):
+        runner = self._make_runner()
+        check = PythonLintFormatCheck({"formatter": "ruff"}, runner=runner)
+        check.auto_fix(str(tmp_path))
+
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        ruff_cmds = [c for c in calls if c and "ruff" in c[0]]
+        subcommands = [c[1] for c in ruff_cmds if len(c) > 1]
+        assert "format" in subcommands
+        assert "check" in subcommands
+
+    def test_black_call_includes_extend_exclude(self, tmp_path):
+        """Black must pass --extend-exclude to skip migration dirs (#263)."""
+        runner = self._make_runner()
+        check = PythonLintFormatCheck({"formatter": "black"}, runner=runner)
+        check.auto_fix(str(tmp_path))
+
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        black_calls = [c for c in calls if c and "black" in c[0]]
+        assert black_calls, "black should have been called"
+        for cmd in black_calls:
+            assert "--extend-exclude" in cmd, (
+                "black must pass --extend-exclude to skip migration dirs"
+            )
+
+
+# ---------------------------------------------------------------------------
+# run() ruff branch
+# ---------------------------------------------------------------------------
+
+
+class TestRunRuffBranch:
+    def _make_runner(self, returncode: int = 0) -> MagicMock:
+        runner = MagicMock()
+        runner.run.return_value = SubprocessResult(
+            returncode=returncode, stdout="", stderr="", duration=0.1
+        )
+        return runner
+
+    def test_run_uses_ruff_format_check_when_ruff_configured(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = self._make_runner(returncode=0)
+        check = PythonLintFormatCheck({}, runner=runner)
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        ruff_format_check = [
+            c for c in calls if c and "ruff" in c[0] and "format" in c and "--check" in c
+        ]
+        assert ruff_format_check, "ruff format --check should have been called"
+
+    def test_run_uses_black_check_when_no_ruff(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = self._make_runner(returncode=0)
+        check = PythonLintFormatCheck({}, runner=runner)
+        check.run(str(tmp_path))
+
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        black_check = [c for c in calls if c and "black" in c[0] and "--check" in c]
+        assert black_check, "black --check should have been called"
+
+    def test_run_passes_when_formatter_none(self, tmp_path):
+        check = PythonLintFormatCheck({"formatter": "none"})
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.PASSED
+        assert "none" in result.output.lower()
+
+    def test_run_fails_when_ruff_format_fails(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+
+        runner = MagicMock()
+
+        def side_effect(cmd, *args, **kwargs):
+            if cmd and "ruff" in cmd[0] and "format" in cmd:
+                return SubprocessResult(
+                    returncode=1,
+                    stdout="Would reformat src/main.py",
+                    stderr="",
+                    duration=0.1,
+                )
+            return SubprocessResult(returncode=0, stdout="", stderr="", duration=0.1)
+
+        runner.run.side_effect = side_effect
+        check = PythonLintFormatCheck({}, runner=runner)
+        result = check.run(str(tmp_path))
+
+        assert result.status == CheckStatus.FAILED
+        assert "ruff" in result.fix_suggestion.lower()
+
+
+# ---------------------------------------------------------------------------
+# _BLACK_EXTEND_EXCLUDE sanity
+# ---------------------------------------------------------------------------
+
+
+class TestBlackExtendExclude:
+    def test_migrations_in_pattern(self):
+        import re
+
+        assert re.search(_BLACK_EXTEND_EXCLUDE, "/migrations/")
+
+    def test_alembic_in_pattern(self):
+        import re
+
+        assert re.search(_BLACK_EXTEND_EXCLUDE, "/alembic/")
+
+    def test_venv_in_pattern(self):
+        import re
+
+        assert re.search(_BLACK_EXTEND_EXCLUDE, "/venv/")
+
+    def test_normal_source_not_excluded(self):
+        import re
+
+        assert not re.search(_BLACK_EXTEND_EXCLUDE, "/myapp/")
+        assert not re.search(_BLACK_EXTEND_EXCLUDE, "/server/")

--- a/tests/unit/test_python_host_formatter.py
+++ b/tests/unit/test_python_host_formatter.py
@@ -54,6 +54,23 @@ class TestDetectHostPythonFormatter:
         )
         assert detect_host_python_formatter(str(tmp_path)) == "ruff"
 
+    def test_ruff_toml_wins_over_pyproject_black(self, tmp_path):
+        # Migrated project: pyproject.toml still has [tool.black] but .ruff.toml exists
+        (tmp_path / "pyproject.toml").write_text("[tool.black]\nline-length = 88\n")
+        (tmp_path / ".ruff.toml").write_text("line-length = 88\n")
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
+    def test_precommit_ruff_wins_over_pyproject_black(self, tmp_path):
+        # Migrated project: pyproject.toml has [tool.black] but pre-commit uses ruff
+        (tmp_path / "pyproject.toml").write_text("[tool.black]\nline-length = 88\n")
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n"
+            "  - repo: https://github.com/astral-sh/ruff-pre-commit\n"
+            "    hooks:\n"
+            "      - id: ruff\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) == "ruff"
+
     def test_dot_ruff_toml_returns_ruff(self, tmp_path):
         (tmp_path / ".ruff.toml").write_text("line-length = 88\n")
         assert detect_host_python_formatter(str(tmp_path)) == "ruff"
@@ -235,11 +252,18 @@ class TestRunRuffBranch:
         assert black_check, "black --check should have been called"
 
     def test_run_passes_when_formatter_none(self, tmp_path):
-        check = PythonLintFormatCheck({"formatter": "none"})
+        # formatter: none skips formatting but flake8 still runs
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "__init__.py").touch()
+        runner = self._make_runner(returncode=0)
+        check = PythonLintFormatCheck({"formatter": "none"}, runner=runner)
         result = check.run(str(tmp_path))
 
         assert result.status == CheckStatus.PASSED
         assert "none" in result.output.lower()
+        # Flake8 must still have been called
+        calls = [c.args[0] for c in runner.run.call_args_list]
+        assert any("flake8" in c[0] for c in calls if c)
 
     def test_run_fails_when_ruff_format_fails(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")

--- a/tests/unit/test_python_host_formatter.py
+++ b/tests/unit/test_python_host_formatter.py
@@ -99,6 +99,17 @@ class TestDetectHostPythonFormatter:
         # black via pre-commit alone doesn't return 'black' — no pyproject.toml
         assert detect_host_python_formatter(str(tmp_path)) is None
 
+    def test_precommit_ruff_url_without_hook_returns_none(self, tmp_path):
+        # Repo URL contains 'ruff' but no actual ruff hook — should NOT match
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "# migrated away from ruff-pre-commit\n"
+            "repos:\n"
+            "  - repo: https://github.com/psf/black\n"
+            "    hooks:\n"
+            "      - id: black\n"
+        )
+        assert detect_host_python_formatter(str(tmp_path)) is None
+
     def test_unreadable_pyproject_falls_through(self, tmp_path):
         # Can't chmod in a tmp_path test to make it unreadable portably,
         # but a malformed pyproject.toml should not crash detection.

--- a/tests/unit/test_python_host_formatter.py
+++ b/tests/unit/test_python_host_formatter.py
@@ -8,9 +8,7 @@ Covers:
   - _BLACK_EXTEND_EXCLUDE presence in black calls (barnacle #263)
 """
 
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from slopmop.checks.python._host_formatter import detect_host_python_formatter
 from slopmop.checks.python.lint_format import (
@@ -19,7 +17,6 @@ from slopmop.checks.python.lint_format import (
 )
 from slopmop.core.result import CheckStatus
 from slopmop.subprocess.runner import SubprocessResult
-
 
 # ---------------------------------------------------------------------------
 # detect_host_python_formatter
@@ -189,9 +186,9 @@ class TestAutoFixDispatching:
         black_calls = [c for c in calls if c and "black" in c[0]]
         assert black_calls, "black should have been called"
         for cmd in black_calls:
-            assert "--extend-exclude" in cmd, (
-                "black must pass --extend-exclude to skip migration dirs"
-            )
+            assert (
+                "--extend-exclude" in cmd
+            ), "black must pass --extend-exclude to skip migration dirs"
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +216,9 @@ class TestRunRuffBranch:
         assert result.status == CheckStatus.PASSED
         calls = [c.args[0] for c in runner.run.call_args_list]
         ruff_format_check = [
-            c for c in calls if c and "ruff" in c[0] and "format" in c and "--check" in c
+            c
+            for c in calls
+            if c and "ruff" in c[0] and "format" in c and "--check" in c
         ]
         assert ruff_format_check, "ruff format --check should have been called"
 


### PR DESCRIPTION
## Summary

- **Barnacle #264 — defer to host formatter**: `auto_fix()` and `run()` now detect whether the project uses ruff or black (via `pyproject.toml`, `.ruff.toml`, `.pre-commit-config.yaml`) and use that formatter instead of always running autoflake + black + isort. Projects with no detected formatter fall back to the existing black path. A new `formatter` config option (`auto`/`ruff`/`black`/`none`) allows explicit override.
- **Barnacle #263 — black skips migration dirs**: black is now called with `--extend-exclude` built from `_DEFAULT_EXCLUDE_DIRS` (which already contained `migrations` and `alembic`), preventing slop-mop from reformatting files it has no business touching.
- New module `slopmop/checks/python/_host_formatter.py` isolates formatter detection; 29 new unit tests in `tests/unit/test_python_host_formatter.py`.

## Test plan

- [ ] All existing unit tests pass (`pytest tests/unit/`)
- [ ] `test_python_host_formatter.py` — 29 tests covering detection, config override, dispatch, ruff branch, and `_BLACK_EXTEND_EXCLUDE`
- [ ] Project with `[tool.ruff]` in `pyproject.toml` → ruff runs, black never called
- [ ] Project with `[tool.black]` (no ruff) → black + isort runs with `--extend-exclude`
- [ ] Project with neither → falls back to black path (unchanged behavior)
- [ ] `formatter: none` config → formatting gate skipped entirely
- [ ] `formatter: ruff` override → ruff even if project has black config
- [ ] `formatter: black` override → black even if project has ruff config
- [ ] Black called with `--extend-exclude` containing `migrations` and `alembic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Detects the host Python formatter (ruff or black) and defers to it instead of always running autoflake+black+isort. Adds a configurable formatter option (auto|ruff|black|none; default auto). Ruff detection takes precedence over pyproject black and pre-commit detection is tightened to avoid false positives. formatter:none emits “Formatting skipped” but still runs flake8-style checks. Black fix and black --check both receive a computed --extend-exclude to exclude migrations/alembic (and other default exclude dirs). Ruff missing/broken tooling is handled by a skipped sentinel and warning; sm doctor now includes ruff when required. Config validation tightened (typos now fail).

## Changes

- New: slopmop/checks/python/_host_formatter.py — detect_host_python_formatter(project_root) reads pyproject.toml, .ruff.toml/ruff.toml, and .pre-commit-config.yaml, prioritizing Ruff over Black.
- Updated: slopmop/checks/python/lint_format.py — adds formatter config (choices/default), implements ruff codepaths (format/check and import fixes) and _RUFF_SKIPPED handling, defers to host formatter in auto mode, passes _BLACK_EXTEND_EXCLUDE to black for both fix and check, preserves flake8 checks for formatter:none, updates fix_suggestion messaging, and minor clarity/robustness fixes.
- Tests: tests/unit/test_python_host_formatter.py — ~29 unit tests covering detection logic, overrides, ruff vs black precedence, formatter:none behavior, ruff missing/skipped/error paths, tightened pre-commit detection, and black --extend-exclude regex checks.
- Misc: .willville.json updated; sm doctor now verifies ruff when applicable.

## Test coverage

Unit tests validate detection, formatter overrides, ruff and black execution and skip paths, handling of missing/broken ruff, pre-commit false-positive avoidance, config validation, and black exclude behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->