### PR TITLE
feat: export hooks for the pre-commit framework (pre-commit.com)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 #
 #   repos:
 #     - repo: https://github.com/ScienceIsNeato/slop-mop
-#       rev: v2.3.1  # use the latest tag
+#       rev: v2.3.2  # use the latest tag
 #       hooks:
 #         - id: slopmop-swab
 #         - id: slopmop-scour
@@ -12,6 +12,10 @@
 # Both hooks are no-ops (warn + pass) until the repo is onboarded via
 # `sm init` + `sm refit --start`, so adding them never blocks a team
 # that hasn't adopted slop-mop yet.
+#
+# minimum_pre_commit_version 3.2.0: the stage names used below
+# (`pre-commit`, `pre-push`) replaced the legacy `commit`/`push` names
+# in pre-commit 3.2.0 (https://github.com/pre-commit/pre-commit/releases/tag/v3.2.0).
 
 - id: slopmop-swab
   name: slop-mop swab (quick quality gates)

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,39 @@
+# Hooks exported for the pre-commit framework (https://pre-commit.com).
+#
+# Consumers add to their .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/ScienceIsNeato/slop-mop
+#       rev: v2.3.1  # use the latest tag
+#       hooks:
+#         - id: slopmop-swab
+#         - id: slopmop-scour
+#
+# Both hooks are no-ops (warn + pass) until the repo is onboarded via
+# `sm init` + `sm refit --start`, so adding them never blocks a team
+# that hasn't adopted slop-mop yet.
+
+- id: slopmop-swab
+  name: slop-mop swab (quick quality gates)
+  description: >-
+    Run slop-mop's swab-level quality gates — the fast, every-commit
+    validation suite. Skips with a warning if the repo is not onboarded.
+  entry: sm hook swab
+  language: python
+  pass_filenames: false
+  always_run: true
+  stages: [pre-commit]
+  minimum_pre_commit_version: "3.2.0"
+
+- id: slopmop-scour
+  name: slop-mop scour (full PR-readiness validation)
+  description: >-
+    Run the complete slop-mop gate suite (swab + scour levels) before
+    push — the same bar a PR must clear. Skips with a warning if the
+    repo is not onboarded.
+  entry: sm hook scour
+  language: python
+  pass_filenames: false
+  always_run: true
+  stages: [pre-push]
+  minimum_pre_commit_version: "3.2.0"

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Fixing barnacle #262 — pyright was sweeping venv when no source dirs configured, PR in progress",
-    "direction": "Get the type-blindness scope fix merged, then continue the barnacle queue",
-    "last_update": "2026-06-09T01:00:00Z"
+    "status": "Building pre-commit framework hooks so teams can adopt slop-mop straight from their pre-commit config",
+    "direction": "Land the hooks, then submit slop-mop to the pre-commit.com directory for organic discovery",
+    "last_update": "2026-06-12T00:00:00Z"
   }
 }

--- a/DOCS/DISTRIBUTION_EFFORTS.md
+++ b/DOCS/DISTRIBUTION_EFFORTS.md
@@ -1,15 +1,16 @@
-# Penetration Efforts
+# Distribution Efforts
 
-This is the working notebook for getting slop-mop into more developer and agent
-workflows. Each vector should record the current theory, the next concrete
-actions, how we will know whether it worked, and what we learned.
+This is the working notebook for sharing slop-mop with more developers and
+agent workflows. Each channel should record the current theory, the next
+concrete actions, how we will know whether it is helping people, and what we
+learned.
 
-Use this as a campaign log, not polished marketing copy. Keep it blunt and
+Use this as a working log, not polished marketing copy. Keep it honest and
 update it whenever a channel produces signal.
 
 ## Operating Loop
 
-For each vector:
+For each channel:
 
 1. Name the audience and the moment where slop-mop helps.
 2. Make the install path obvious.
@@ -56,7 +57,7 @@ Five-minute Friday ritual:
 4. Record stars/forks delta.
 5. Add any notable channel-specific observations below.
 
-## Vector: Claude Plugin Marketplace
+## Channel: Claude Plugin Marketplace
 
 ### Theory
 
@@ -123,7 +124,7 @@ Claude config may mirror them, but it should not become the publishing source.
   `/plugin install slopmop`, then prompt with `sail this repo`.
 - [ ] Tag pushed and GitHub release notes published.
 
-### Promotion TODOs
+### Sharing TODOs
 
 - [ ] Submit to Anthropic's official curated marketplace once the plugin is
   stable enough for broader discovery.
@@ -137,7 +138,7 @@ Claude config may mirror them, but it should not become the publishing source.
 
 ### Success Signals
 
-- PyPI downloads rise after plugin promotion.
+- PyPI downloads rise after the plugin is shared.
 - GitHub unique cloners rise after marketplace links are shared.
 - Referrers show Claude/Discord/community-list traffic.
 - Users ask questions or file issues mentioning Claude Code or Cowork.
@@ -149,7 +150,7 @@ Claude config may mirror them, but it should not become the publishing source.
 - Do not include hidden user telemetry in the plugin. If better attribution is
   needed later, use an explicit landing page or opt-in CLI telemetry.
 
-## Vector: PyPI / Direct CLI
+## Channel: PyPI / Direct CLI
 
 ### Theory
 
@@ -169,19 +170,19 @@ for AI-heavy repos. The fastest path is still `pipx install slopmop[all]`.
 - Issues mention direct CLI usage rather than Claude plugin install.
 - People ask about integrating `sm` into existing CI or repo templates.
 
-## Vector: pre-commit Framework Registry
+## Channel: pre-commit Framework Registry
 
 ### Theory
 
 Python developers setting up a new project almost always run
 `pre-commit install` and browse the hooks directory at pre-commit.com.
 Slop-mop already wraps the same tools people put in pre-commit (ruff,
-black, mypy), so discovery there feels natural rather than "also add
+black, mypy), so finding it there feels natural rather than "also add
 this." The repo exports `.pre-commit-hooks.yaml` with two hooks:
 `slopmop-swab` (quick gates, pre-commit stage) and `slopmop-scour`
 (full PR-readiness suite, pre-push stage). Both warn-and-pass in
 repos that haven't been onboarded, so adding them to a shared config
-is zero-risk — the hook itself becomes the adoption nudge, printing
+is zero-risk — the hook itself becomes a friendly nudge, printing
 the onboarding command to every contributor until someone runs it.
 
 ### TODOs
@@ -201,7 +202,7 @@ the onboarding command to every contributor until someone runs it.
   (pre-commit clones the repo rather than pip-installing from PyPI).
 - Issues mention the hook ids or the not-onboarded warning text.
 
-## Vector: GitHub / OSS Discovery
+## Channel: GitHub / OSS Discovery
 
 ### Theory
 
@@ -223,7 +224,7 @@ pile of linters.
 - Referrers show GitHub search, curated lists, blog posts, or newsletters.
 - New issues reference the README language or demo directly.
 
-## Vector: Community Lists and Newsletters
+## Channel: Community Lists and Newsletters
 
 ### Theory
 
@@ -244,18 +245,19 @@ people revisit.
 - PyPI downloads rise in the same week.
 - Users arrive with vocabulary from the listing blurb.
 
-## Vector: Direct User Conversations
+## Channel: Direct User Conversations
 
 ### Theory
 
 The best early signal may come from people already feeling agent-code pain.
-Manual outreach can reveal whether the positioning lands before broader
-promotion burns attention.
+Talking with them directly can reveal whether the positioning lands — and
+what is missing — before sharing more broadly.
 
 ### TODOs
 
 - [ ] Identify 5-10 likely users maintaining AI-assisted repos.
-- [ ] Ask what currently breaks in their agent workflow before pitching.
+- [ ] Ask what currently breaks in their agent workflow before suggesting
+  slop-mop.
 - [ ] Offer one concrete command path: `sm init`, `sm swab`, `sm scour`.
 - [ ] Record objections and missing docs.
 

--- a/DOCS/PENETRATION_EFFORTS.md
+++ b/DOCS/PENETRATION_EFFORTS.md
@@ -169,6 +169,38 @@ for AI-heavy repos. The fastest path is still `pipx install slopmop[all]`.
 - Issues mention direct CLI usage rather than Claude plugin install.
 - People ask about integrating `sm` into existing CI or repo templates.
 
+## Vector: pre-commit Framework Registry
+
+### Theory
+
+Python developers setting up a new project almost always run
+`pre-commit install` and browse the hooks directory at pre-commit.com.
+Slop-mop already wraps the same tools people put in pre-commit (ruff,
+black, mypy), so discovery there feels natural rather than "also add
+this." The repo exports `.pre-commit-hooks.yaml` with two hooks:
+`slopmop-swab` (quick gates, pre-commit stage) and `slopmop-scour`
+(full PR-readiness suite, pre-push stage). Both warn-and-pass in
+repos that haven't been onboarded, so adding them to a shared config
+is zero-risk — the hook itself becomes the adoption nudge, printing
+the onboarding command to every contributor until someone runs it.
+
+### TODOs
+
+- [ ] Submit the repo to the pre-commit.com hooks directory
+  (PR against https://github.com/pre-commit/pre-commit.github.io
+  adding the repo to `all-repos.yaml`).
+- [ ] Cut a release tag after the hooks land so `rev:` has a target
+  with `.pre-commit-hooks.yaml` in it.
+- [ ] Keep the README pre-commit snippet's `rev:` example current
+  with each release.
+
+### Success Signals
+
+- GitHub referrers show pre-commit.com.
+- Clones spike without corresponding PyPI download spikes
+  (pre-commit clones the repo rather than pip-installing from PyPI).
+- Issues mention the hook ids or the not-onboarded warning text.
+
 ## Vector: GitHub / OSS Discovery
 
 ### Theory

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ When `sm` itself gives invalid guidance or blocks valid work, use
 reporting path; do not file ad hoc `gh issue create` reports for slop-mop
 tooling defects.
 
-Distribution notes, promotion TODOs, and adoption-tracking signals live in
-[DOCS/PENETRATION_EFFORTS.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/PENETRATION_EFFORTS.md).
+Distribution notes, sharing TODOs, and adoption-tracking signals live in
+[DOCS/DISTRIBUTION_EFFORTS.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/DISTRIBUTION_EFFORTS.md).
 
 ## Use with pre-commit
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,33 @@ tooling defects.
 Distribution notes, promotion TODOs, and adoption-tracking signals live in
 [DOCS/PENETRATION_EFFORTS.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/PENETRATION_EFFORTS.md).
 
+## Use with pre-commit
+
+Slop-mop exports hooks for the [pre-commit framework](https://pre-commit.com).
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/ScienceIsNeato/slop-mop
+    rev: v2.3.1  # use the latest release tag
+    hooks:
+      - id: slopmop-swab    # quick gates on every commit
+      - id: slopmop-scour   # full PR-readiness suite on push
+```
+
+`slopmop-swab` runs the fast every-commit gate suite; `slopmop-scour` runs
+the complete validation (the same bar a PR must clear) at `pre-push` — the
+last local checkpoint before you open a PR. Install both stages with
+`pre-commit install --hook-type pre-commit --hook-type pre-push`.
+
+Both hooks are safe to add to a shared config before the whole team has
+adopted slop-mop: in a repo that hasn't been onboarded (`sm init` +
+`sm refit --start`), they print a one-line note and pass instead of
+blocking the commit.
+
+If you prefer raw git hooks without the pre-commit framework,
+`sm commit-hooks install` does the same job with sm-managed scripts.
+
 ## The Loop
 
 Slop-mop has five verbs you will actually use:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/ScienceIsNeato/slop-mop
-    rev: v2.3.1  # use the latest release tag
+    rev: v2.3.2  # use the latest release tag
     hooks:
       - id: slopmop-swab    # quick gates on every commit
       - id: slopmop-scour   # full PR-readiness suite on push

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -73,6 +73,16 @@ TARGETS: Tuple[Target, ...] = (
         r'"version": "(\d+\.\d+\.\d+)"',
         "Cursor plugin manifest version",
     ),
+    Target(
+        "README.md",
+        r"rev: v(\d+\.\d+\.\d+)  # use the latest release tag",
+        "README pre-commit framework rev example",
+    ),
+    Target(
+        ".pre-commit-hooks.yaml",
+        r"rev: v(\d+\.\d+\.\d+)  # use the latest tag",
+        "pre-commit hooks manifest rev example",
+    ),
 )
 
 

--- a/slopmop/cli/__init__.py
+++ b/slopmop/cli/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from slopmop.cli.help import cmd_help
     from slopmop.cli.hooks import cmd_commit_hooks
     from slopmop.cli.init import cmd_init
+    from slopmop.cli.precommit_hook import cmd_hook
     from slopmop.cli.refit import cmd_refit
     from slopmop.cli.sail import cmd_sail
     from slopmop.cli.scan_triage import run_triage
@@ -42,6 +43,7 @@ _EXPORT_MAP = {
     "cmd_config": ("slopmop.cli.config", "cmd_config"),
     "cmd_doctor": ("slopmop.cli.doctor", "cmd_doctor"),
     "cmd_help": ("slopmop.cli.help", "cmd_help"),
+    "cmd_hook": ("slopmop.cli.precommit_hook", "cmd_hook"),
     "cmd_init": ("slopmop.cli.init", "cmd_init"),
     "cmd_gang": ("slopmop.cli.gang", "cmd_gang"),
     "cmd_refit": ("slopmop.cli.refit", "cmd_refit"),
@@ -79,6 +81,7 @@ __all__ = [
     "cmd_config",
     "cmd_doctor",
     "cmd_help",
+    "cmd_hook",
     "cmd_init",
     "cmd_buff",
     "cmd_gang",

--- a/slopmop/cli/capabilities.py
+++ b/slopmop/cli/capabilities.py
@@ -215,6 +215,16 @@ _VERB_CATALOG: List[Dict[str, object]] = [
         },
     },
     {
+        "name": "hook",
+        "summary": "Pre-commit framework entry point: run swab/scour if onboarded, warn-and-pass otherwise.",
+        "group": "setup",
+        "formats": ["human"],
+        "exit_codes": {
+            "0": "gates passed or repo not onboarded",
+            "1": "gates failed",
+        },
+    },
+    {
         "name": "gang",
         "summary": "Press-gang forbidden shell commands into the correct sm rail.",
         "group": "setup",

--- a/slopmop/cli/capabilities.py
+++ b/slopmop/cli/capabilities.py
@@ -222,6 +222,7 @@ _VERB_CATALOG: List[Dict[str, object]] = [
         "exit_codes": {
             "0": "gates passed or repo not onboarded",
             "1": "gates failed",
+            "2": "invalid hook verb",
         },
     },
     {

--- a/slopmop/cli/parser_builders.py
+++ b/slopmop/cli/parser_builders.py
@@ -7,6 +7,7 @@ main verb registry module.
 from __future__ import annotations
 
 import argparse
+import sys
 
 from slopmop.agent_install.registry import (
     INSTALL_HELP_HOME_PREVIEW_ROOT,
@@ -16,6 +17,124 @@ from slopmop.agent_install.registry import (
     preview_install_paths,
 )
 from slopmop.constants import PROJECT_ROOT_HELP
+
+
+def try_suggest_config_command(message: str, flag_set: set[str]) -> bool:
+    """Suggest correct config syntax if error message contains a config flag.
+
+    Returns True if a suggestion was printed and error should exit, False otherwise.
+    """
+    words = message.lower().split()
+    for flag in flag_set:
+        if flag in words:
+            print(f"\n❌ {message}")
+            print("\n💡 Hint: Did you forget the '--' prefix?")
+            print(f"   Try: sm config --{flag}")
+            if flag == "set":
+                print("        sm config --set <gate> <field> <value>")
+            elif flag == "unset":
+                print("        sm config --unset <gate> <field>")
+            return True
+    return False
+
+
+def add_config_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Add the config subcommand parser."""
+    config_parser = subparsers.add_parser(
+        "config",
+        help="View or update configuration",
+        description="View or update quality gate configuration.",
+    )
+
+    # Store original error method
+    original_error = config_parser.error
+
+    # Custom error handler to catch common mistakes
+    def config_error(message: str) -> None:
+        """Custom error handler with helpful suggestions."""
+        common_flags = {"enable", "disable", "set", "unset", "show", "json"}
+        if try_suggest_config_command(message, common_flags):
+            sys.exit(2)
+        original_error(message)
+
+    config_parser.error = config_error  # type: ignore[method-assign]
+
+    config_parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Show current configuration and enabled gates",
+    )
+    config_parser.add_argument(
+        "--enable",
+        metavar="GATE",
+        help="Enable a specific quality gate",
+    )
+    config_parser.add_argument(
+        "--disable",
+        metavar="GATE",
+        help="Disable a specific quality gate",
+    )
+    config_parser.add_argument(
+        "--json",
+        metavar="FILE",
+        help="Update configuration from JSON file",
+    )
+    config_parser.add_argument(
+        "--swabbing-timeout",
+        type=int,
+        metavar="SECONDS",
+        help="Set the swabbing-timeout budget (seconds). 0 or negative disables the limit.",
+    )
+    config_parser.add_argument(
+        "--swabbing-time",
+        type=int,
+        metavar="SECONDS",
+        dest="swabbing_timeout",
+        help=argparse.SUPPRESS,  # deprecated alias for --swabbing-timeout
+    )
+    config_parser.add_argument(
+        "--swab-off",
+        metavar="GATE",
+        help="Keep a gate out of swab while still running it during scour.",
+    )
+    config_parser.add_argument(
+        "--swab-on",
+        metavar="GATE",
+        help="Make a gate run during both swab and scour.",
+    )
+    config_parser.add_argument(
+        "--set",
+        dest="set_field",
+        nargs=3,
+        metavar=("GATE", "FIELD", "VALUE"),
+        help="Set gate config field: --set <gate> <field> <value> where gate is category:name (e.g., myopia:ignore-feedback)",
+    )
+    config_parser.add_argument(
+        "--unset",
+        dest="unset_field",
+        nargs=2,
+        metavar=("GATE", "FIELD"),
+        help="Remove a gate-specific config field override.",
+    )
+    config_parser.add_argument(
+        "--current-pr-number",
+        type=int,
+        metavar="PR",
+        help="Set the working pull request number for buff commands.",
+    )
+    config_parser.add_argument(
+        "--clear-current-pr",
+        action="store_true",
+        help="Clear the working pull request number.",
+    )
+    config_parser.add_argument(
+        "--project-root",
+        type=str,
+        default=".",
+        help=PROJECT_ROOT_HELP,
+    )
 
 
 class BuffParserBuilder:

--- a/slopmop/cli/parser_builders.py
+++ b/slopmop/cli/parser_builders.py
@@ -53,7 +53,13 @@ def add_config_parser(
 
     # Custom error handler to catch common mistakes
     def config_error(message: str) -> None:
-        """Custom error handler with helpful suggestions."""
+        """Custom error handler with helpful suggestions.
+
+        When a suggestion is printed, exit directly instead of calling
+        ``original_error``: argparse's handler would re-print the raw
+        message plus a usage dump after our friendlier hint. Exit code 2
+        matches what argparse itself uses for argument errors.
+        """
         common_flags = {"enable", "disable", "set", "unset", "show", "json"}
         if try_suggest_config_command(message, common_flags):
             sys.exit(2)

--- a/slopmop/cli/precommit_hook.py
+++ b/slopmop/cli/precommit_hook.py
@@ -34,6 +34,9 @@ def cmd_hook(args: argparse.Namespace) -> int:
 
     from slopmop.cli.sail import _onboard_status
 
+    # Contract (see _onboard_status docstring): returns exactly one of
+    # "onboarded" | "init_done" | "fresh". All three paths are covered by
+    # tests/unit/test_precommit_hook.py, so a contract change breaks loudly.
     status = _onboard_status(project_root)
     if status != "onboarded":
         remedy = (

--- a/slopmop/cli/precommit_hook.py
+++ b/slopmop/cli/precommit_hook.py
@@ -1,0 +1,58 @@
+"""Entry point for pre-commit framework hooks (.pre-commit-hooks.yaml).
+
+When slop-mop is consumed via https://pre-commit.com, the hook runs in
+every contributor's checkout of the host repo — including checkouts
+where slop-mop has never been onboarded. The guard here is what makes
+that safe: the real gate only runs in maintenance mode (the repo went
+through ``sm init`` + ``sm refit``, leaving a ``.slopmop/`` directory).
+Anything earlier in the lifecycle gets a one-line nudge and exit 0, so
+adding the hook to a team's ``.pre-commit-config.yaml`` never blocks a
+contributor who hasn't adopted slop-mop yet.
+"""
+
+import argparse
+from pathlib import Path
+
+# Hook verb → sm validation verb. Identity today, but the indirection
+# documents that the hook surface is intentionally narrower than the CLI.
+_HOOK_VERBS = ("swab", "scour")
+
+
+def cmd_hook(args: argparse.Namespace) -> int:
+    """Handle ``sm hook <swab|scour>`` — the pre-commit framework entry.
+
+    Exit codes:
+      0 — gates passed, or repo not yet onboarded (warn-and-allow)
+      nonzero — gates failed in an onboarded repo (block the commit/push)
+    """
+    verb = args.hook_verb
+    if verb not in _HOOK_VERBS:
+        print(f"❌ Unknown hook verb: {verb} (expected one of {_HOOK_VERBS})")
+        return 2
+
+    project_root = Path(args.project_root).resolve()
+
+    from slopmop.cli.sail import _onboard_status
+
+    status = _onboard_status(project_root)
+    if status != "onboarded":
+        remedy = (
+            "sm refit --start"
+            if status == "init_done"
+            else "sm init && sm refit --start"
+        )
+        print(
+            f"⚠️  slop-mop hook skipped: this repo is not onboarded "
+            f"(status: {status}).\n"
+            f"   To activate quality gates, run: {remedy}\n"
+            f"   Until then this hook always passes."
+        )
+        return 0
+
+    from slopmop.sm import main as sm_main
+
+    argv = [verb, "--porcelain", "--project-root", str(project_root)]
+    if verb == "swab":
+        # Hooks must be deterministic: never skip gates on a time budget.
+        argv += ["--swabbing-timeout", "0"]
+    return sm_main(argv)

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -1014,7 +1014,15 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def _disable_tty_stdout() -> None:
-    """Wrap stdout so it reports non-TTY, and disable color output."""
+    """Wrap stdout so it reports non-TTY, and disable color output.
+
+    The proxy delegates every attribute to the real stream and only
+    overrides ``isatty()``. Limitation: after wrapping, identity/type
+    checks like ``isinstance(sys.stdout, io.TextIOWrapper)`` no longer
+    hold — acceptable here because slop-mop only probes ``isatty()``.
+    The ``Any``-typed ``__getattr__`` is intentional: it is a pure
+    delegation shim over a dynamic stream object.
+    """
     os.environ["NO_COLOR"] = "1"
 
     class _NT:

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -51,6 +51,8 @@ from slopmop.cli.parser_builders import (
     CapabilitiesParserBuilder,
     RefitParserBuilder,
     SchemaParserBuilder,
+    add_config_parser,
+    try_suggest_config_command,
 )
 from slopmop.constants import PROJECT_ROOT_HELP
 from slopmop.utils import as_str_list, dedupe_str_list
@@ -512,124 +514,6 @@ def _add_upgrade_parser(
     )
 
 
-def _try_suggest_config_command(message: str, flag_set: set[str]) -> bool:
-    """Suggest correct config syntax if error message contains a config flag.
-
-    Returns True if a suggestion was printed and error should exit, False otherwise.
-    """
-    words = message.lower().split()
-    for flag in flag_set:
-        if flag in words:
-            print(f"\n❌ {message}")
-            print(f"\n💡 Hint: Did you forget the '--' prefix?")
-            print(f"   Try: sm config --{flag}")
-            if flag == "set":
-                print(f"        sm config --set <gate> <field> <value>")
-            elif flag == "unset":
-                print(f"        sm config --unset <gate> <field>")
-            return True
-    return False
-
-
-def _add_config_parser(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> None:
-    """Add the config subcommand parser."""
-    config_parser = subparsers.add_parser(
-        "config",
-        help="View or update configuration",
-        description="View or update quality gate configuration.",
-    )
-
-    # Store original error method
-    original_error = config_parser.error
-
-    # Custom error handler to catch common mistakes
-    def config_error(message: str) -> None:
-        """Custom error handler with helpful suggestions."""
-        common_flags = {"enable", "disable", "set", "unset", "show", "json"}
-        if _try_suggest_config_command(message, common_flags):
-            sys.exit(2)
-        original_error(message)
-
-    config_parser.error = config_error  # type: ignore[method-assign]
-
-    config_parser.add_argument(
-        "--show",
-        action="store_true",
-        help="Show current configuration and enabled gates",
-    )
-    config_parser.add_argument(
-        "--enable",
-        metavar="GATE",
-        help="Enable a specific quality gate",
-    )
-    config_parser.add_argument(
-        "--disable",
-        metavar="GATE",
-        help="Disable a specific quality gate",
-    )
-    config_parser.add_argument(
-        "--json",
-        metavar="FILE",
-        help="Update configuration from JSON file",
-    )
-    config_parser.add_argument(
-        "--swabbing-timeout",
-        type=int,
-        metavar="SECONDS",
-        help="Set the swabbing-timeout budget (seconds). 0 or negative disables the limit.",
-    )
-    config_parser.add_argument(
-        "--swabbing-time",
-        type=int,
-        metavar="SECONDS",
-        dest="swabbing_timeout",
-        help=argparse.SUPPRESS,  # deprecated alias for --swabbing-timeout
-    )
-    config_parser.add_argument(
-        "--swab-off",
-        metavar="GATE",
-        help="Keep a gate out of swab while still running it during scour.",
-    )
-    config_parser.add_argument(
-        "--swab-on",
-        metavar="GATE",
-        help="Make a gate run during both swab and scour.",
-    )
-    config_parser.add_argument(
-        "--set",
-        dest="set_field",
-        nargs=3,
-        metavar=("GATE", "FIELD", "VALUE"),
-        help="Set gate config field: --set <gate> <field> <value> where gate is category:name (e.g., myopia:ignore-feedback)",
-    )
-    config_parser.add_argument(
-        "--unset",
-        dest="unset_field",
-        nargs=2,
-        metavar=("GATE", "FIELD"),
-        help="Remove a gate-specific config field override.",
-    )
-    config_parser.add_argument(
-        "--current-pr-number",
-        type=int,
-        metavar="PR",
-        help="Set the working pull request number for buff commands.",
-    )
-    config_parser.add_argument(
-        "--clear-current-pr",
-        action="store_true",
-        help="Clear the working pull request number.",
-    )
-    config_parser.add_argument(
-        "--project-root",
-        type=str,
-        default=".",
-        help=PROJECT_ROOT_HELP,
-    )
-
-
 def _add_help_parser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -725,6 +609,36 @@ def _add_hooks_parser(
         help="Remove all sm-managed commit hooks",
     )
     hooks_uninstall.add_argument(
+        "--project-root",
+        type=str,
+        default=".",
+        help=PROJECT_ROOT_HELP,
+    )
+
+
+def _add_hook_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Add the hook subcommand parser (pre-commit framework entry point)."""
+    hook_parser = subparsers.add_parser(
+        "hook",
+        help="Entry point for pre-commit framework hooks (.pre-commit-hooks.yaml)",
+        description=(
+            "Run a validation verb as a pre-commit framework hook. "
+            "Unlike the bare verbs, this entry point checks the repo's "
+            "onboarding status first: repos that have not completed "
+            "`sm init` + `sm refit` get a warning and exit 0 instead of "
+            "a blocked commit. Used by .pre-commit-hooks.yaml; not "
+            "intended for interactive use — run `sm swab` or `sm scour` "
+            "directly instead."
+        ),
+    )
+    hook_parser.add_argument(
+        "hook_verb",
+        choices=["swab", "scour"],
+        help="Validation verb to run: swab (pre-commit) or scour (pre-push)",
+    )
+    hook_parser.add_argument(
         "--project-root",
         type=str,
         default=".",
@@ -1057,7 +971,7 @@ def create_parser() -> argparse.ArgumentParser:
     def main_error(message: str) -> None:
         """Custom error handler to catch common config command mistakes."""
         config_flags = {"enable", "disable", "set", "unset"}
-        if _try_suggest_config_command(message, config_flags):
+        if try_suggest_config_command(message, config_flags):
             sys.exit(2)
         original_error(message)
 
@@ -1075,11 +989,12 @@ def create_parser() -> argparse.ArgumentParser:
     BarnacleParserBuilder(subparsers).build()
     _add_status_parser(subparsers)
     _add_doctor_parser(subparsers)
-    _add_config_parser(subparsers)
+    add_config_parser(subparsers)
     _add_help_parser(subparsers)
     _add_init_parser(subparsers)
     _add_agent_parser(subparsers)
     _add_hooks_parser(subparsers)
+    _add_hook_parser(subparsers)
     _add_gang_parser(subparsers)
     _add_audit_parser(subparsers)
     SchemaParserBuilder(subparsers).build()
@@ -1098,6 +1013,20 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _disable_tty_stdout() -> None:
+    """Wrap stdout so it reports non-TTY, and disable color output."""
+    os.environ["NO_COLOR"] = "1"
+
+    class _NT:
+        def isatty(self) -> bool:
+            return False
+
+        def __getattr__(self, n: str, _o: Any = sys.stdout) -> Any:
+            return getattr(_o, n)
+
+    sys.stdout = _NT()  # type: ignore[assignment]
+
+
 def main(args: Optional[List[str]] = None) -> int:
     """Main entry point for sm CLI."""
     from slopmop import MissingDependencyError
@@ -1113,6 +1042,7 @@ def main(args: Optional[List[str]] = None) -> int:
         cmd_doctor,
         cmd_gang,
         cmd_help,
+        cmd_hook,
         cmd_init,
         cmd_refit,
         cmd_sail,
@@ -1151,16 +1081,7 @@ def main(args: Optional[List[str]] = None) -> int:
     parsed_args = parser.parse_args(raw)
 
     if no_tty or getattr(parsed_args, "no_tty", False):
-        os.environ["NO_COLOR"] = "1"
-
-        class _NT:
-            def isatty(self) -> bool:
-                return False
-
-            def __getattr__(self, n: str, _o: Any = sys.stdout) -> Any:
-                return getattr(_o, n)
-
-        sys.stdout = _NT()  # type: ignore[assignment]
+        _disable_tty_stdout()
 
     # Setup logging
     if hasattr(parsed_args, "verbose") and parsed_args.verbose:
@@ -1191,6 +1112,7 @@ def main(args: Optional[List[str]] = None) -> int:
             cmd_audit=cmd_audit,
             cmd_commit_hooks=cmd_commit_hooks,
             cmd_gang=cmd_gang,
+            cmd_hook=cmd_hook,
         )
     except MissingDependencyError as exc:
         print(f"❌ {exc}", file=sys.stderr)
@@ -1238,6 +1160,8 @@ def _dispatch(
         return handlers["cmd_agent"](parsed_args)
     elif parsed_args.verb == "commit-hooks":
         return handlers["cmd_commit_hooks"](parsed_args)
+    elif parsed_args.verb == "hook":
+        return handlers["cmd_hook"](parsed_args)
     elif parsed_args.verb == "gang":
         return handlers["cmd_gang"](parsed_args)
     elif parsed_args.verb == "audit":

--- a/tests/unit/test_precommit_hook.py
+++ b/tests/unit/test_precommit_hook.py
@@ -9,6 +9,7 @@ Covers:
 
 import argparse
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import yaml
@@ -97,7 +98,7 @@ class TestOnboardedDelegation:
 class TestManifest:
     """The .pre-commit-hooks.yaml manifest this repo exports."""
 
-    def _manifest(self):
+    def _manifest(self) -> list[dict[str, Any]]:
         manifest_path = REPO_ROOT / ".pre-commit-hooks.yaml"
         assert manifest_path.exists(), ".pre-commit-hooks.yaml missing from repo root"
         return yaml.safe_load(manifest_path.read_text())

--- a/tests/unit/test_precommit_hook.py
+++ b/tests/unit/test_precommit_hook.py
@@ -1,0 +1,151 @@
+"""Tests for the pre-commit framework hook entry point (sm hook).
+
+Covers:
+  - onboard-status gating: fresh / init_done repos warn and exit 0
+  - onboarded repos delegate to the real validation verb
+  - exit code propagation from the delegated run
+  - .pre-commit-hooks.yaml manifest shape
+"""
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from slopmop.cli.precommit_hook import cmd_hook
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _hook_args(verb: str, project_root: Path) -> argparse.Namespace:
+    return argparse.Namespace(hook_verb=verb, project_root=str(project_root))
+
+
+class TestOnboardGating:
+    def test_fresh_repo_warns_and_passes(self, tmp_path, capsys):
+        exit_code = cmd_hook(_hook_args("swab", tmp_path))
+
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "not onboarded" in out
+        assert "sm init" in out
+
+    def test_init_done_repo_warns_and_passes(self, tmp_path, capsys):
+        (tmp_path / ".sb_config.json").write_text("{}")
+
+        exit_code = cmd_hook(_hook_args("swab", tmp_path))
+
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "not onboarded" in out
+        # init already ran — remedy should not tell them to re-run it
+        assert "sm refit --start" in out
+
+    def test_scour_verb_also_gated(self, tmp_path, capsys):
+        exit_code = cmd_hook(_hook_args("scour", tmp_path))
+
+        assert exit_code == 0
+        assert "not onboarded" in capsys.readouterr().out
+
+    def test_unknown_verb_rejected(self, tmp_path):
+        exit_code = cmd_hook(_hook_args("buff", tmp_path))
+
+        assert exit_code == 2
+
+
+class TestOnboardedDelegation:
+    def _onboard(self, tmp_path: Path) -> None:
+        (tmp_path / ".sb_config.json").write_text("{}")
+        (tmp_path / ".slopmop").mkdir()
+
+    def test_swab_delegates_with_porcelain_and_no_timeout(self, tmp_path):
+        self._onboard(tmp_path)
+
+        with patch("slopmop.sm.main", return_value=0) as sm_main:
+            exit_code = cmd_hook(_hook_args("swab", tmp_path))
+
+        assert exit_code == 0
+        argv = sm_main.call_args.args[0]
+        assert argv[0] == "swab"
+        assert "--porcelain" in argv
+        assert "--swabbing-timeout" in argv
+        assert argv[argv.index("--swabbing-timeout") + 1] == "0"
+        assert str(tmp_path) in argv
+
+    def test_scour_delegates_without_swab_timeout(self, tmp_path):
+        self._onboard(tmp_path)
+
+        with patch("slopmop.sm.main", return_value=0) as sm_main:
+            exit_code = cmd_hook(_hook_args("scour", tmp_path))
+
+        assert exit_code == 0
+        argv = sm_main.call_args.args[0]
+        assert argv[0] == "scour"
+        assert "--porcelain" in argv
+        assert "--swabbing-timeout" not in argv
+
+    def test_failure_exit_code_propagates(self, tmp_path):
+        self._onboard(tmp_path)
+
+        with patch("slopmop.sm.main", return_value=1):
+            exit_code = cmd_hook(_hook_args("swab", tmp_path))
+
+        assert exit_code == 1
+
+
+class TestManifest:
+    """The .pre-commit-hooks.yaml manifest this repo exports."""
+
+    def _manifest(self):
+        manifest_path = REPO_ROOT / ".pre-commit-hooks.yaml"
+        assert manifest_path.exists(), ".pre-commit-hooks.yaml missing from repo root"
+        return yaml.safe_load(manifest_path.read_text())
+
+    def test_exports_swab_and_scour_hooks(self):
+        hooks = {h["id"]: h for h in self._manifest()}
+        assert "slopmop-swab" in hooks
+        assert "slopmop-scour" in hooks
+
+    def test_swab_runs_at_commit_scour_at_push(self):
+        hooks = {h["id"]: h for h in self._manifest()}
+        assert hooks["slopmop-swab"]["stages"] == ["pre-commit"]
+        assert hooks["slopmop-scour"]["stages"] == ["pre-push"]
+
+    def test_entries_use_gated_hook_verb(self):
+        # Hooks must go through `sm hook` (onboard-gated), never bare verbs.
+        for hook in self._manifest():
+            assert hook["entry"].startswith("sm hook "), hook["id"]
+
+    def test_hooks_run_whole_repo_not_filenames(self):
+        for hook in self._manifest():
+            assert hook["pass_filenames"] is False, hook["id"]
+            assert hook["always_run"] is True, hook["id"]
+
+
+class TestCliWiring:
+    """sm hook is reachable through the real parser."""
+
+    def test_parser_accepts_hook_verb(self):
+        from slopmop.sm import create_parser
+
+        parser = create_parser()
+        parsed = parser.parse_args(["hook", "swab"])
+        assert parsed.verb == "hook"
+        assert parsed.hook_verb == "swab"
+
+    def test_parser_rejects_invalid_hook_verb(self):
+        import pytest
+
+        from slopmop.sm import create_parser
+
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["hook", "buff"])
+
+    def test_main_dispatches_hook_to_cmd_hook(self, tmp_path):
+        from slopmop.sm import main
+
+        # Fresh tmp repo → onboard gate trips → exit 0 without running gates
+        exit_code = main(["hook", "swab", "--project-root", str(tmp_path)])
+        assert exit_code == 0


### PR DESCRIPTION
## Summary

New adoption vector: slop-mop is now consumable directly from any `.pre-commit-config.yaml` via the [pre-commit framework](https://pre-commit.com), putting it in front of every Python developer who browses the hooks directory while setting up a project.

- **`.pre-commit-hooks.yaml`** exports two hooks:
  - `slopmop-swab` — full swab suite at the `pre-commit` stage (every commit)
  - `slopmop-scour` — full PR-readiness suite at the `pre-push` stage (the last local checkpoint before opening a PR)
- **New `sm hook <swab|scour>` entry point** gates on onboarding status:
  - Onboarded repos (`.slopmop/` present) run the real verb with `--porcelain` and no swab time budget (hooks must be deterministic)
  - Fresh/init_done repos print a one-line onboarding nudge and **exit 0** — adding the hooks to a shared team config never blocks a contributor who hasn't adopted slop-mop yet. The warning itself becomes the adoption nudge.
- README gains a "Use with pre-commit" section; PENETRATION_EFFORTS gains the vector with directory-submission TODOs
- Sprawl housekeeping: config parser + suggestion helper moved to `parser_builders.py`, `_disable_tty_stdout` extracted from `main()`

## Consumer usage

```yaml
repos:
  - repo: https://github.com/ScienceIsNeato/slop-mop
    rev: v2.3.1
    hooks:
      - id: slopmop-swab
      - id: slopmop-scour
```

## Test plan

- [x] 14 new unit tests: onboard gating (fresh/init_done/onboarded), delegation argv, exit-code propagation, manifest shape, parser wiring
- [x] `pre-commit validate-manifest .pre-commit-hooks.yaml` passes
- [x] Live smoke test: `sm hook swab` in a non-onboarded dir warns and exits 0
- [x] Full swab passes (it ran as this branch's own commit hook)

## Follow-up (post-merge)

- Cut a release tag so consumers have a `rev:` containing the manifest
- Submit the repo to the pre-commit.com hooks directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pre-commit Framework Integration
Adds first-class pre-commit support via .pre-commit-hooks.yaml exporting two hooks: slopmop-swab (pre-commit) and slopmop-scour (pre-push). Hooks call sm hook <swab|scour>, always_run: true, pass_filenames: false, minimum_pre_commit_version: "3.2.0", and are no-ops (warn + pass) until a repo is onboarded.

## CLI Changes
New command: sm hook <swab|scour> implemented as cmd_hook:
- Rejects unknown verbs with exit code 2.
- For non-onboarded repos prints a one-line onboarding remedy and exits 0 (non-blocking).
- For onboarded repos delegates to slopmop.sm.main with --porcelain and --project-root; for swab adds --swabbing-timeout 0 to make hook runs deterministic.

## Refactoring & Parser
- Extracted config parser logic and suggestion helper into slopmop/cli/parser_builders.py (add_config_parser, try_suggest_config_command).
- _disable_tty_stdout refactor and parser error handling adjusted.
- Exported cmd_hook via slopmop/cli/__init__.py and registered the hook verb in capabilities.

## Version sync & tooling
scripts/sync_version.py now manages README and .pre-commit-hooks.yaml rev mentions to keep them in sync with slopmop/_version.py.

## Docs & Distribution
- README: added "Use with pre-commit" instructions and example.
- DOCS/DISTRIBUTION_EFFORTS.md updated with pre-commit channel guidance and release/registry TODOs.

## Tests & Validation
Adds tests/unit/test_precommit_hook.py covering onboarding gating, delegation argv and exit-code propagation, manifest shape, and CLI wiring. pre-commit manifest validates; changes include test-enforced version sync. Approximately 14 new unit tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->