### PR TITLE
feat: hull ratings — deterministic A+ to F grades for swab/scour

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Building pre-commit framework hooks so teams can adopt slop-mop straight from their pre-commit config",
-    "direction": "Land the hooks, then submit slop-mop to the pre-commit.com directory for organic discovery",
-    "last_update": "2026-06-12T00:00:00Z"
+    "status": "Hull ratings are in — swab and scour now grade the repo A+ through F with matching boat names",
+    "direction": "Land the grading PR, then build toward the GitHub Action that surfaces the grade",
+    "last_update": "2026-06-12T21:00:00Z"
   }
 }

--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ write code -> sm swab -> commit -> sm scour -> push/open PR -> sm buff watch -> 
 Not sure where you are in that loop? `sm sail` figures it out for you.
 Full state machine: [DOCS/WORKFLOW.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/WORKFLOW.md).
 
+## Hull Ratings
+
+Every full `sm swab` or `sm scour` run grades the repo's hull — a
+deterministic rating computed from how many gates are failing:
+
+| Grade | Hull | Meaning |
+| --- | --- | --- |
+| A+ | shipshape | All gates green |
+| A | seaworthy | All green, with warnings |
+| B | serviceable | 1 gate failing |
+| C | weathered | 2 gates failing |
+| D | fouled | 3 gates failing |
+| F | scuttled | 4+ gates failing |
+| N/A | dry-dock | Repo never initialized |
+
+The rating appears in the console summary, porcelain output, and the
+JSON artifact (`hull_grade` in the data payload) for CI consumers.
+Skipped or not-applicable gates never count toward the grade; if any
+applicable gate was skipped (missing tool, fail-fast, time budget) the
+rating is marked *provisional*. Partial runs (`-g`) don't grade — you
+can't rate a hull you only half inspected.
+
 <figure>
   <img src="https://raw.githubusercontent.com/ScienceIsNeato/slop-mop/main/assets/sm-swab-human-readable.png" alt="Human-readable sm swab output showing grouped quality gates and a no slop detected summary" />
   <figcaption>

--- a/slopmop/reporting/adapters.py
+++ b/slopmop/reporting/adapters.py
@@ -96,6 +96,9 @@ class JsonAdapter:
         if cache:
             output["cache"] = cache
 
+        if report.hull_grade is not None:
+            output["hull_grade"] = report.hull_grade.to_dict()
+
         return output
 
     @staticmethod
@@ -199,6 +202,8 @@ class PorcelainAdapter:
     def render(report: RunReport) -> str:
         """Return a compact line-oriented validation summary."""
         lines = [PorcelainAdapter._summary_line(report)]
+        if report.hull_grade is not None:
+            lines.append(f"grade: {report.hull_grade.label}")
         for result in report.actionable:
             lines.append(result.name)
             detail = PorcelainAdapter._detail_line(result)
@@ -315,6 +320,8 @@ class ConsoleAdapter:
         else:
             print(header)
 
+        self._render_hull_grade()
+
         cache_line = r.cache_summary()
         if cache_line:
             print(f"   {cache_line}")
@@ -355,6 +362,8 @@ class ConsoleAdapter:
             print(f"   {' · '.join(counts)}{duration}")
         else:
             print(header)
+
+        self._render_hull_grade()
 
         cache_line = r.cache_summary()
         if cache_line:
@@ -454,6 +463,13 @@ class ConsoleAdapter:
             + str(cache["refresh_command"])
             + "` if you need uncached results."
         )
+
+    def _render_hull_grade(self) -> None:
+        """Print the hull rating line for full-suite runs."""
+        grade = self.report.hull_grade
+        if grade is None:
+            return
+        print(f"   ⚓ hull rating: {grade.label}")
 
     def _render_baseline_filter_note(self) -> None:
         """Print a short note when baseline filtering was applied."""

--- a/slopmop/reporting/grading.py
+++ b/slopmop/reporting/grading.py
@@ -1,0 +1,115 @@
+"""Hull grade: the deterministic quality rating for a full validation run.
+
+Every full swab/scour run rates the repo's hull — the nautical answer to
+"what grade is this codebase?" Two surfaces, one scale: a traditional
+letter grade (the universal API, e.g. for CI annotations and badges) and
+the boat-condition name (the brand):
+
+    A+   shipshape    0 failing, 0 warnings
+    A    seaworthy    0 failing, 1+ warnings
+    B    serviceable  1 gate failing
+    C    weathered    2 gates failing
+    D    fouled       3 gates failing
+    F    scuttled     4+ gates failing
+    N/A  dry-dock     repo never initialized (no slop-mop config)
+
+Determinism contract:
+
+- "Failing" counts FAILED and ERROR gates among the gates that ran.
+  SKIPPED and NOT_APPLICABLE gates never count toward the grade.
+- The grade is computed only for full-suite runs (``sm swab`` /
+  ``sm scour`` without ``-g``) — partial runs can't rate the hull.
+- Any operational skip (missing tool, fail-fast, time budget) marks the
+  grade ``provisional``: the same commit could grade differently on a
+  machine where those gates ran. A non-provisional grade is a pure
+  function of (commit content, gate config).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Union
+
+#: (grade, level) in best-to-worst order. The index is the number of
+#: failing gates that earns the entry (beyond index 3, everything is F).
+_GRADE_BY_FAILING = (
+    ("A+", "shipshape"),  # 0 failing, no warnings (A if warned)
+    ("B", "serviceable"),  # 1 failing
+    ("C", "weathered"),  # 2 failing
+    ("D", "fouled"),  # 3 failing
+    ("F", "scuttled"),  # 4+ failing
+)
+
+
+@dataclass(frozen=True)
+class HullGrade:
+    """A computed hull rating for one validation run."""
+
+    grade: str  # "A+", "A", "B", "C", "D", "F", "N/A"
+    level: str  # "shipshape" ... "scuttled", "dry-dock"
+    failing: int
+    warned: int
+    provisional: bool = False
+
+    @property
+    def label(self) -> str:
+        """Human-facing one-liner, e.g. ``B — serviceable``."""
+        suffix = " (provisional)" if self.provisional else ""
+        return f"{self.grade} — {self.level}{suffix}"
+
+    def to_dict(self) -> Dict[str, Union[str, int, bool]]:
+        return {
+            "grade": self.grade,
+            "level": self.level,
+            "failing": self.failing,
+            "warned": self.warned,
+            "provisional": self.provisional,
+        }
+
+
+def compute_hull_grade(
+    failing: int, warned: int, provisional: bool = False
+) -> HullGrade:
+    """Map failing/warned gate counts onto the grade scale."""
+    if failing <= 0:
+        grade, level = ("A", "seaworthy") if warned > 0 else ("A+", "shipshape")
+    else:
+        grade, level = _GRADE_BY_FAILING[min(failing, 4)]
+    return HullGrade(
+        grade=grade,
+        level=level,
+        failing=max(failing, 0),
+        warned=max(warned, 0),
+        provisional=provisional,
+    )
+
+
+def dry_dock_grade() -> HullGrade:
+    """The not-yet-initialized rating — the boat isn't in the water."""
+    return HullGrade(
+        grade="N/A", level="dry-dock", failing=0, warned=0, provisional=False
+    )
+
+
+def is_repo_initialized(project_root: str) -> bool:
+    """True when the repo has adopted slop-mop configuration.
+
+    Either an ``.sb_config.json`` (written by ``sm init``) or a committed
+    ``[tool.slopmop]`` section in pyproject.toml counts — both are real
+    adoption signals. Repos with neither grade as dry-dock rather than
+    being scuttled by default-gate failures they never opted into.
+    """
+    root = Path(project_root)
+    if (root / ".sb_config.json").exists():
+        return True
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+            if re.search(r"^\s*\[tool\.slopmop[.\]]", content, re.MULTILINE):
+                return True
+        except OSError:
+            pass
+    return False

--- a/slopmop/reporting/grading.py
+++ b/slopmop/reporting/grading.py
@@ -110,6 +110,8 @@ def is_repo_initialized(project_root: str) -> bool:
             content = pyproject.read_text(encoding="utf-8")
             if re.search(r"^\s*\[tool\.slopmop[.\]]", content, re.MULTILINE):
                 return True
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            # Unreadable/undecodable pyproject — treat as not initialized
+            # rather than crashing report construction.
             pass
     return False

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -32,7 +32,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
+from slopmop.core.result import (
+    CheckResult,
+    CheckStatus,
+    ExecutionSummary,
+    SkipReason,
+)
 from slopmop.reporting.grading import (
     HullGrade,
     compute_hull_grade,
@@ -294,17 +299,30 @@ class RunReport:
         next_step = _compute_next_step(level, sail_mode) if summary.all_passed else None
 
         # Hull grade — full-suite runs only (level is None for -g runs).
-        # Operational skips make the grade provisional: the same commit
-        # could grade differently where those gates actually ran.
+        # Only *operational* skips (fail-fast, missing dep, time budget,
+        # or unknown) make the grade provisional: those gates could have
+        # failed had they run. Config-deterministic skips — disabled in
+        # config (off) or superseded by a more thorough gate (sup) — are
+        # part of the (commit, config) function and don't reduce certainty.
         hull_grade: Optional[HullGrade] = None
         if level is not None:
             if project_root is not None and not is_repo_initialized(project_root):
                 hull_grade = dry_dock_grade()
             else:
+                deterministic_skips = {
+                    SkipReason.DISABLED,
+                    SkipReason.SUPERSEDED,
+                    SkipReason.NOT_APPLICABLE,
+                }
+                operational_skips = [
+                    r
+                    for r in status_buckets[CheckStatus.SKIPPED]
+                    if r.skip_reason not in deterministic_skips
+                ]
                 hull_grade = compute_hull_grade(
                     failing=len(failed) + len(errored),
                     warned=len(warned),
-                    provisional=bool(status_buckets[CheckStatus.SKIPPED]),
+                    provisional=bool(operational_skips),
                 )
 
         return cls(

--- a/slopmop/reporting/report.py
+++ b/slopmop/reporting/report.py
@@ -33,6 +33,12 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
+from slopmop.reporting.grading import (
+    HullGrade,
+    compute_hull_grade,
+    dry_dock_grade,
+    is_repo_initialized,
+)
 
 if TYPE_CHECKING:
     from slopmop.core.registry import CheckRegistry
@@ -228,6 +234,9 @@ class RunReport:
     # next_step is emitted on success to tell the agent what to do now.
     # Computed from the current workflow state + sail mode when available.
     next_step: Optional[str] = None
+    # Hull grade — the deterministic rating for full-suite runs.  None
+    # for partial (-g) runs, which can't rate the whole hull.
+    hull_grade: Optional[HullGrade] = None
 
     @classmethod
     def from_summary(
@@ -284,6 +293,20 @@ class RunReport:
 
         next_step = _compute_next_step(level, sail_mode) if summary.all_passed else None
 
+        # Hull grade — full-suite runs only (level is None for -g runs).
+        # Operational skips make the grade provisional: the same commit
+        # could grade differently where those gates actually ran.
+        hull_grade: Optional[HullGrade] = None
+        if level is not None:
+            if project_root is not None and not is_repo_initialized(project_root):
+                hull_grade = dry_dock_grade()
+            else:
+                hull_grade = compute_hull_grade(
+                    failing=len(failed) + len(errored),
+                    warned=len(warned),
+                    provisional=bool(status_buckets[CheckStatus.SKIPPED]),
+                )
+
         return cls(
             summary=summary,
             level=level,
@@ -298,6 +321,7 @@ class RunReport:
             verify_command=verify,
             first_to_fix=first_blocking.name if first_blocking is not None else None,
             next_step=next_step,
+            hull_grade=hull_grade,
         )
 
     def per_gate_verify_command(self, gate_name: str) -> str:

--- a/slopmop/schemas/v3/data/scour.json
+++ b/slopmop/schemas/v3/data/scour.json
@@ -44,9 +44,43 @@
     },
     "cache": {
       "$ref": "#/$defs/cache"
+    },
+    "hull_grade": {
+      "$ref": "#/$defs/hull_grade"
     }
   },
   "$defs": {
+    "hull_grade": {
+      "description": "Deterministic hull rating for the full run: letter grade plus boat-condition level. Absent on partial (-g) runs. 'provisional' means operational skips (missing tool, fail-fast, time budget) may have hidden failing gates.",
+      "type": "object",
+      "required": [
+        "grade",
+        "level",
+        "failing",
+        "warned",
+        "provisional"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "grade": {
+          "enum": ["A+", "A", "B", "C", "D", "F", "N/A"]
+        },
+        "level": {
+          "enum": ["shipshape", "seaworthy", "serviceable", "weathered", "fouled", "scuttled", "dry-dock"]
+        },
+        "failing": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warned": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "provisional": {
+          "type": "boolean"
+        }
+      }
+    },
     "summary": {
       "type": "object",
       "required": [

--- a/slopmop/schemas/v3/data/swab.json
+++ b/slopmop/schemas/v3/data/swab.json
@@ -27,9 +27,23 @@
       "description": "Present only when a baseline snapshot filtered known failures out of this run.",
       "type": "object"
     },
-    "cache": {"$ref": "#/$defs/cache"}
+    "cache": {"$ref": "#/$defs/cache"},
+    "hull_grade": {"$ref": "#/$defs/hull_grade"}
   },
   "$defs": {
+    "hull_grade": {
+      "description": "Deterministic hull rating for the full run: letter grade plus boat-condition level. Absent on partial (-g) runs. 'provisional' means operational skips (missing tool, fail-fast, time budget) may have hidden failing gates.",
+      "type": "object",
+      "required": ["grade", "level", "failing", "warned", "provisional"],
+      "additionalProperties": false,
+      "properties": {
+        "grade": {"enum": ["A+", "A", "B", "C", "D", "F", "N/A"]},
+        "level": {"enum": ["shipshape", "seaworthy", "serviceable", "weathered", "fouled", "scuttled", "dry-dock"]},
+        "failing": {"type": "integer", "minimum": 0},
+        "warned": {"type": "integer", "minimum": 0},
+        "provisional": {"type": "boolean"}
+      }
+    },
     "summary": {
       "type": "object",
       "required": [

--- a/tests/unit/test_hull_grading.py
+++ b/tests/unit/test_hull_grading.py
@@ -143,7 +143,9 @@ class TestRunReportGrading:
         assert report.hull_grade is None
 
     def test_errors_count_as_failing(self, tmp_path):
-        summary = _statuses_summary(CheckStatus.FAILED, CheckStatus.ERROR, CheckStatus.PASSED)
+        summary = _statuses_summary(
+            CheckStatus.FAILED, CheckStatus.ERROR, CheckStatus.PASSED
+        )
         report = RunReport.from_summary(
             summary, level="scour", project_root=_initialized(tmp_path)
         )
@@ -192,7 +194,9 @@ class TestRunReportGrading:
 class TestAdapterSurfacing:
     def _graded_report(self, tmp_path: Path, *statuses: CheckStatus) -> RunReport:
         return RunReport.from_summary(
-            _statuses_summary(*statuses), level="swab", project_root=_initialized(tmp_path)
+            _statuses_summary(*statuses),
+            level="swab",
+            project_root=_initialized(tmp_path),
         )
 
     def test_json_payload_includes_hull_grade(self, tmp_path):

--- a/tests/unit/test_hull_grading.py
+++ b/tests/unit/test_hull_grading.py
@@ -1,0 +1,261 @@
+"""Tests for the hull grade — the deterministic rating for full runs.
+
+Covers:
+  - compute_hull_grade() boundaries (A+ through F)
+  - dry-dock for uninitialized repos
+  - provisional marking on operational skips
+  - RunReport wiring: full runs grade, partial (-g) runs don't
+  - adapter surfacing: JSON payload, porcelain line, console banner
+"""
+
+from pathlib import Path
+
+from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
+from slopmop.reporting.adapters import ConsoleAdapter, JsonAdapter, PorcelainAdapter
+from slopmop.reporting.grading import (
+    HullGrade,
+    compute_hull_grade,
+    dry_dock_grade,
+    is_repo_initialized,
+)
+from slopmop.reporting.report import RunReport
+
+# ---------------------------------------------------------------------------
+# Pure grading function
+# ---------------------------------------------------------------------------
+
+
+class TestComputeHullGrade:
+    def test_all_green_is_a_plus_shipshape(self):
+        grade = compute_hull_grade(failing=0, warned=0)
+        assert (grade.grade, grade.level) == ("A+", "shipshape")
+
+    def test_warnings_only_is_a_seaworthy(self):
+        grade = compute_hull_grade(failing=0, warned=2)
+        assert (grade.grade, grade.level) == ("A", "seaworthy")
+
+    def test_one_failing_is_b_serviceable(self):
+        grade = compute_hull_grade(failing=1, warned=0)
+        assert (grade.grade, grade.level) == ("B", "serviceable")
+
+    def test_two_failing_is_c_weathered(self):
+        grade = compute_hull_grade(failing=2, warned=0)
+        assert (grade.grade, grade.level) == ("C", "weathered")
+
+    def test_three_failing_is_d_fouled(self):
+        grade = compute_hull_grade(failing=3, warned=0)
+        assert (grade.grade, grade.level) == ("D", "fouled")
+
+    def test_four_failing_is_f_scuttled(self):
+        grade = compute_hull_grade(failing=4, warned=0)
+        assert (grade.grade, grade.level) == ("F", "scuttled")
+
+    def test_many_failing_still_f_scuttled(self):
+        grade = compute_hull_grade(failing=20, warned=5)
+        assert (grade.grade, grade.level) == ("F", "scuttled")
+
+    def test_warnings_do_not_soften_a_failing_grade(self):
+        # Warnings only matter at the A+/A boundary.
+        grade = compute_hull_grade(failing=1, warned=3)
+        assert grade.grade == "B"
+        assert grade.warned == 3
+
+    def test_provisional_flag_carried(self):
+        grade = compute_hull_grade(failing=0, warned=0, provisional=True)
+        assert grade.provisional is True
+        assert "provisional" in grade.label
+
+    def test_label_format(self):
+        assert compute_hull_grade(2, 0).label == "C — weathered"
+
+    def test_to_dict_round_trip(self):
+        d = compute_hull_grade(failing=1, warned=2, provisional=True).to_dict()
+        assert d == {
+            "grade": "B",
+            "level": "serviceable",
+            "failing": 1,
+            "warned": 2,
+            "provisional": True,
+        }
+
+    def test_dry_dock_grade(self):
+        grade = dry_dock_grade()
+        assert (grade.grade, grade.level) == ("N/A", "dry-dock")
+
+
+class TestIsRepoInitialized:
+    def test_fresh_repo_not_initialized(self, tmp_path):
+        assert is_repo_initialized(str(tmp_path)) is False
+
+    def test_sb_config_counts(self, tmp_path):
+        (tmp_path / ".sb_config.json").write_text("{}")
+        assert is_repo_initialized(str(tmp_path)) is True
+
+    def test_pyproject_tool_slopmop_counts(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.slopmop]\n")
+        assert is_repo_initialized(str(tmp_path)) is True
+
+    def test_pyproject_gate_section_counts(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.slopmop.myopia.gates."dependency-risk.py"]\nfoo = 1\n'
+        )
+        assert is_repo_initialized(str(tmp_path)) is True
+
+    def test_pyproject_without_slopmop_does_not_count(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.black]\n")
+        assert is_repo_initialized(str(tmp_path)) is False
+
+
+# ---------------------------------------------------------------------------
+# RunReport wiring
+# ---------------------------------------------------------------------------
+
+
+def _gate_result(name: str, status: CheckStatus) -> CheckResult:
+    return CheckResult(name=name, status=status, duration=0.1)
+
+
+def _statuses_summary(*statuses: CheckStatus) -> ExecutionSummary:
+    results = [_gate_result(f"gate-{i}", s) for i, s in enumerate(statuses)]
+    return ExecutionSummary.from_results(results, duration=1.0)
+
+
+def _initialized(tmp_path: Path) -> str:
+    (tmp_path / ".sb_config.json").write_text("{}")
+    return str(tmp_path)
+
+
+class TestRunReportGrading:
+    def test_full_run_gets_grade(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.PASSED, CheckStatus.PASSED)
+        report = RunReport.from_summary(
+            summary, level="swab", project_root=_initialized(tmp_path)
+        )
+        assert report.hull_grade is not None
+        assert report.hull_grade.grade == "A+"
+
+    def test_partial_run_gets_no_grade(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.PASSED)
+        # level=None is how -g partial runs flow through _run_validation
+        report = RunReport.from_summary(
+            summary, level=None, project_root=_initialized(tmp_path)
+        )
+        assert report.hull_grade is None
+
+    def test_errors_count_as_failing(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.FAILED, CheckStatus.ERROR, CheckStatus.PASSED)
+        report = RunReport.from_summary(
+            summary, level="scour", project_root=_initialized(tmp_path)
+        )
+        assert report.hull_grade is not None
+        assert report.hull_grade.failing == 2
+        assert report.hull_grade.grade == "C"
+
+    def test_skips_make_grade_provisional(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.PASSED, CheckStatus.SKIPPED)
+        report = RunReport.from_summary(
+            summary, level="swab", project_root=_initialized(tmp_path)
+        )
+        assert report.hull_grade is not None
+        assert report.hull_grade.provisional is True
+
+    def test_not_applicable_does_not_mark_provisional(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.PASSED, CheckStatus.NOT_APPLICABLE)
+        report = RunReport.from_summary(
+            summary, level="swab", project_root=_initialized(tmp_path)
+        )
+        assert report.hull_grade is not None
+        assert report.hull_grade.provisional is False
+        assert report.hull_grade.grade == "A+"
+
+    def test_uninitialized_repo_is_dry_dock(self, tmp_path):
+        summary = _statuses_summary(CheckStatus.FAILED, CheckStatus.FAILED)
+        report = RunReport.from_summary(
+            summary, level="swab", project_root=str(tmp_path)
+        )
+        assert report.hull_grade is not None
+        assert report.hull_grade.grade == "N/A"
+        assert report.hull_grade.level == "dry-dock"
+
+    def test_no_project_root_still_grades(self):
+        summary = _statuses_summary(CheckStatus.PASSED)
+        report = RunReport.from_summary(summary, level="swab", project_root=None)
+        assert report.hull_grade is not None
+        assert report.hull_grade.grade == "A+"
+
+
+# ---------------------------------------------------------------------------
+# Adapter surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterSurfacing:
+    def _graded_report(self, tmp_path: Path, *statuses: CheckStatus) -> RunReport:
+        return RunReport.from_summary(
+            _statuses_summary(*statuses), level="swab", project_root=_initialized(tmp_path)
+        )
+
+    def test_json_payload_includes_hull_grade(self, tmp_path):
+        report = self._graded_report(tmp_path, CheckStatus.FAILED, CheckStatus.PASSED)
+        envelope = JsonAdapter.render(report)
+        data = envelope["data"]
+        assert isinstance(data, dict)
+        assert data["hull_grade"] == {
+            "grade": "B",
+            "level": "serviceable",
+            "failing": 1,
+            "warned": 0,
+            "provisional": False,
+        }
+
+    def test_json_payload_omits_grade_on_partial_run(self, tmp_path):
+        report = RunReport.from_summary(
+            _statuses_summary(CheckStatus.PASSED),
+            level=None,
+            project_root=_initialized(tmp_path),
+        )
+        envelope = JsonAdapter.render(report)
+        data = envelope["data"]
+        assert isinstance(data, dict)
+        assert "hull_grade" not in data
+
+    def test_porcelain_includes_grade_line(self, tmp_path):
+        report = self._graded_report(tmp_path, CheckStatus.PASSED)
+        output = PorcelainAdapter.render(report)
+        assert "grade: A+ — shipshape" in output
+
+    def test_console_success_includes_hull_rating(self, tmp_path, capsys):
+        report = self._graded_report(tmp_path, CheckStatus.PASSED)
+        ConsoleAdapter(report).render()
+        assert "⚓ hull rating: A+ — shipshape" in capsys.readouterr().out
+
+    def test_console_failure_includes_hull_rating(self, tmp_path, capsys):
+        report = self._graded_report(
+            tmp_path,
+            CheckStatus.FAILED,
+            CheckStatus.FAILED,
+            CheckStatus.FAILED,
+            CheckStatus.FAILED,
+        )
+        ConsoleAdapter(report).render()
+        assert "⚓ hull rating: F — scuttled" in capsys.readouterr().out
+
+
+class TestHullGradeDeterminism:
+    def test_same_counts_same_grade(self):
+        a = compute_hull_grade(failing=2, warned=1)
+        b = compute_hull_grade(failing=2, warned=1)
+        assert a == b
+
+    def test_frozen(self):
+        import dataclasses
+
+        import pytest
+
+        grade = compute_hull_grade(0, 0)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            grade.grade = "F"  # type: ignore[misc]
+
+    def test_grade_is_hashable_value_object(self):
+        assert isinstance(compute_hull_grade(1, 0), HullGrade)
+        assert len({compute_hull_grade(1, 0), compute_hull_grade(1, 0)}) == 1

--- a/tests/unit/test_hull_grading.py
+++ b/tests/unit/test_hull_grading.py
@@ -10,7 +10,12 @@ Covers:
 
 from pathlib import Path
 
-from slopmop.core.result import CheckResult, CheckStatus, ExecutionSummary
+from slopmop.core.result import (
+    CheckResult,
+    CheckStatus,
+    ExecutionSummary,
+    SkipReason,
+)
 from slopmop.reporting.adapters import ConsoleAdapter, JsonAdapter, PorcelainAdapter
 from slopmop.reporting.grading import (
     HullGrade,
@@ -105,14 +110,22 @@ class TestIsRepoInitialized:
         (tmp_path / "pyproject.toml").write_text("[tool.black]\n")
         assert is_repo_initialized(str(tmp_path)) is False
 
+    def test_undecodable_pyproject_treated_as_not_initialized(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_bytes(b"\xff\xfe[tool.slopmop]\x00\xdc")
+        assert is_repo_initialized(str(tmp_path)) is False
+
 
 # ---------------------------------------------------------------------------
 # RunReport wiring
 # ---------------------------------------------------------------------------
 
 
-def _gate_result(name: str, status: CheckStatus) -> CheckResult:
-    return CheckResult(name=name, status=status, duration=0.1)
+def _gate_result(
+    name: str,
+    status: CheckStatus,
+    skip_reason: "SkipReason | None" = None,
+) -> CheckResult:
+    return CheckResult(name=name, status=status, duration=0.1, skip_reason=skip_reason)
 
 
 def _statuses_summary(*statuses: CheckStatus) -> ExecutionSummary:
@@ -153,13 +166,47 @@ class TestRunReportGrading:
         assert report.hull_grade.failing == 2
         assert report.hull_grade.grade == "C"
 
-    def test_skips_make_grade_provisional(self, tmp_path):
+    def test_operational_skips_make_grade_provisional(self, tmp_path):
+        # Skips with no reason are treated as operational (conservative).
         summary = _statuses_summary(CheckStatus.PASSED, CheckStatus.SKIPPED)
         report = RunReport.from_summary(
             summary, level="swab", project_root=_initialized(tmp_path)
         )
         assert report.hull_grade is not None
         assert report.hull_grade.provisional is True
+
+    def test_time_budget_and_fail_fast_skips_are_provisional(self, tmp_path):
+        for reason in (
+            SkipReason.TIME_BUDGET,
+            SkipReason.FAIL_FAST,
+            SkipReason.FAILED_DEPENDENCY,
+        ):
+            results = [
+                _gate_result("gate-a", CheckStatus.PASSED),
+                _gate_result("gate-b", CheckStatus.SKIPPED, skip_reason=reason),
+            ]
+            summary = ExecutionSummary.from_results(results, duration=1.0)
+            report = RunReport.from_summary(
+                summary, level="swab", project_root=_initialized(tmp_path)
+            )
+            assert report.hull_grade is not None
+            assert report.hull_grade.provisional is True, reason
+
+    def test_config_deterministic_skips_are_not_provisional(self, tmp_path):
+        # Disabled-in-config and superseded gates are part of the
+        # (commit, config) function — they don't reduce grade certainty.
+        for reason in (SkipReason.DISABLED, SkipReason.SUPERSEDED):
+            results = [
+                _gate_result("gate-a", CheckStatus.PASSED),
+                _gate_result("gate-b", CheckStatus.SKIPPED, skip_reason=reason),
+            ]
+            summary = ExecutionSummary.from_results(results, duration=1.0)
+            report = RunReport.from_summary(
+                summary, level="swab", project_root=_initialized(tmp_path)
+            )
+            assert report.hull_grade is not None
+            assert report.hull_grade.provisional is False, reason
+            assert report.hull_grade.grade == "A+"
 
     def test_not_applicable_does_not_mark_provisional(self, tmp_path):
         summary = _statuses_summary(CheckStatus.PASSED, CheckStatus.NOT_APPLICABLE)


### PR DESCRIPTION
## Summary

Every full `sm swab` / `sm scour` run now rates the repo's hull — a deterministic grade with two surfaces on one scale: the traditional letter grade (the universal API for CI annotations and badges) and the boat-condition name (the brand).

| Grade | Hull | Meaning |
| --- | --- | --- |
| A+ | shipshape | All gates green |
| A | seaworthy | All green, with warnings |
| B | serviceable | 1 gate failing |
| C | weathered | 2 gates failing |
| D | fouled | 3 gates failing |
| F | scuttled | 4+ gates failing |
| N/A | dry-dock | Repo never initialized |

## Determinism contract

- Failing = FAILED + ERROR gates among gates that **ran**; SKIPPED / NOT_APPLICABLE never count
- Full-suite runs only — partial `-g` runs don't grade (you can't rate a hull you only half inspected)
- Any operational skip (missing tool, fail-fast, time budget) marks the grade **provisional**: a non-provisional grade is a pure function of (commit content, gate config)
- Repos with no slop-mop config (`.sb_config.json` or `[tool.slopmop]` in pyproject) grade **N/A dry-dock** instead of being scuttled by default gates they never opted into

## Surfaces

- Console: `⚓ hull rating: B — serviceable` in both success and failure banners
- Porcelain: `grade: B — serviceable` after the summary line
- JSON artifact: `hull_grade` object in the data payload — **this is the contract for the planned GitHub Action** (grade + existing SARIF = marketplace action)
- `swab.json` / `scour.json` data schemas updated (strict `additionalProperties: false` envelopes)
- README: new Hull Ratings section

## Implementation

New `slopmop/reporting/grading.py` (pure functions + frozen `HullGrade` value object); computed once in `RunReport.from_summary` so all adapters surface the same grade — consistent with the report/adapter architecture.

## Test plan

- [x] 32 new tests: every scale boundary, dry-dock detection (.sb_config.json + pyproject variants), provisional marking, errors-count-as-failing, partial-run exclusion, all three adapter surfaces, frozen value-object semantics
- [x] Schema conformance + envelope tests pass (62)
- [x] Full unit suite: 3215 passed (6 pre-existing env-dependent failures, fixes already on PR #277)
- [x] Live dogfood: this branch's own commit-hook swab printed `grade: A — seaworthy` for this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hull Ratings: Deterministic Grade Scoring

Adds deterministic hull grades to full `sm swab` / `sm scour` runs, mapping failing gate counts to letter grades (A+ shipshape → F scuttled) and including N/A (dry-dock) for uninitialized repos. Failing gates count FAILED + ERROR; SKIPPED/NOT_APPLICABLE ignored. Partial `-g` runs are excluded. Operational skips (fail-fast, failed-dep, time budget, unknown) mark a grade provisional. Undecodable pyproject.toml is treated as uninitialized.

Surfaces: console banner (`⚓ hull rating: B — serviceable`), porcelain line (`grade: B — serviceable`), and `hull_grade` object in JSON artifacts. `swab.json` / `scour.json` schemas add strict `$defs.hull_grade` with `additionalProperties: false`. README gains a Hull Ratings section.

Implementation: new pure-function module `slopmop/reporting/grading.py` with a frozen `HullGrade` value object and helpers (`compute_hull_grade`, `dry_dock_grade`, `is_repo_initialized`); `RunReport.from_summary` computes and attaches `hull_grade` for full-suite runs so all adapters share the same grade. Minor robustness tweaks: provisional-scope logic refined and `is_repo_initialized` catches `UnicodeDecodeError`.

Tests: 32 new tests covering grade boundaries, dry-dock detection (both config variants), provisional behavior per skip reason, error-as-failing, partial-run exclusion, adapter surfaces, and value-object semantics. Schema and unit suite reported passing locally.

Files changed include the new grading module, adapter/report wiring, schema additions for swab/scour, README, tests, and small metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->