### PR TITLE
fix: merge duplicate with: keys that broke workflow parsing on main

### DIFF
--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -93,7 +93,6 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
-        with:
           # diff-cover and gate-dodging need history to compare
           # against the base branch.  Shallow clone (the default)
           # breaks both with cryptic "unknown revision" errors.
@@ -318,7 +317,6 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
-        with:
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/slopmop.yml
+++ b/.github/workflows/slopmop.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
-        with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Main's CI is currently dead — every push fails instantly with `Invalid workflow file: .github/workflows/slopmop.yml#L1 ... 'with' is already defined` (visible on the #278 merge push).

Root cause: the `persist-credentials: false` insertion in #277 keyed off the `uses:` line's indentation. Correct for `- uses:` list-item steps (release.yml), wrong for `- name: … / uses: …` steps where the existing `with:` sits at the same indent as `uses:` — the script concluded there was no `with:` block and emitted a second one. PyYAML silently tolerates duplicate mapping keys (last wins), so local validation passed while GitHub's stricter parser rejects the file.

Three duplicated blocks merged into single `with:` blocks (keeping `persist-credentials: false` alongside the original keys):
- `slopmop.yml` — PR head checkout
- `slopmop-sarif.yml` — two checkout steps

## Verification

- All three workflows re-validated with a duplicate-key-**rejecting** YAML loader (the strictness the original check lacked)
- release.yml confirmed clean (its checkouts were the `- uses:` form)

This PR's own CI run is the live proof — it's the first push since the merge that can even parse the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes duplicate `with:` keys in workflow files

Resolves duplicate YAML mapping keys that broke workflow parsing on GitHub. A previous script that inserted `persist-credentials: false` created redundant `with:` blocks when processing steps with both `name:` and `uses:` fields.

**Changes:**
- Merged duplicate `with:` blocks in `.github/workflows/slopmop.yml` (1 checkout step)
- Merged duplicate `with:` blocks in `.github/workflows/slopmop-sarif.yml` (2 checkout steps)

The fixes consolidate `persist-credentials`, `ref`, and `fetch-depth` settings into single `with:` blocks, resolving the GitHub workflow validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->