### PR TITLE
chore: bump version to 2.4.1 for PyPI release

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "displayName": "slop-mop",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Wraps pytest, black, mypy, gh, and every other tool behind a single `sm` CLI with caching, ordering, and directed remediation built in.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: slop-mop version
       description: "Output of `sm --version` (or the PyPI version installed)."
-      placeholder: "2.4.0"
+      placeholder: "2.4.1"
     validations:
       required: true
   - type: textarea

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 #
 #   repos:
 #     - repo: https://github.com/ScienceIsNeato/slop-mop
-#       rev: v2.4.0  # use the latest tag
+#       rev: v2.4.1  # use the latest tag
 #       hooks:
 #         - id: slopmop-swab
 #         - id: slopmop-scour

--- a/DOCS/MACHINE_INTERFACE.md
+++ b/DOCS/MACHINE_INTERFACE.md
@@ -185,7 +185,7 @@ sm capabilities
   "status": "info",
   "exit_code": 0,
   "data": {
-    "version": "2.4.0",
+    "version": "2.4.1",
     "verbs": [
       { "name": "swab", "summary": "…", "level": "core",
         "formats": ["human", "json", "porcelain", "sarif"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is purposefully opinionated, as structure begets adherence to best practices.
 
 ## Project Status
 
-slop-mop is at version 2.4.0. The current public policy surface for release and
+slop-mop is at version 2.4.1. The current public policy surface for release and
 stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)
@@ -137,7 +137,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/ScienceIsNeato/slop-mop
-    rev: v2.4.0  # use the latest release tag
+    rev: v2.4.1  # use the latest release tag
     hooks:
       - id: slopmop-swab    # quick gates on every commit
       - id: slopmop-scour   # full PR-readiness suite on push

--- a/slopmop/_version.py
+++ b/slopmop/_version.py
@@ -11,4 +11,4 @@ automatically. Everything else derives from it:
   from this value, so a mismatch can never be merged.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"


### PR DESCRIPTION
Release 2.4.0 -> 2.4.1.

This PR was created by the Release workflow. After checks pass, the workflow merges it into main; the protected main-branch push then runs the publish path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Version Bump to 2.4.1

This PR bumps the project version from 2.4.0 to 2.4.1 across all relevant files in preparation for a PyPI release:

- **Version source**: `slopmop/_version.py` (`__version__: "2.4.0"` → `"2.4.1"`)
- **Plugin manifest**: `.cursor-plugin/plugin.json`
- **Pre-commit configuration**: `.pre-commit-hooks.yaml` and `README.md` example
- **Documentation**: `DOCS/MACHINE_INTERFACE.md` example output
- **Issue template**: `.github/ISSUE_TEMPLATE/bug_report.yml` placeholder

All changes are routine version references (6 files, +6/-6 lines). Created by the Release workflow; will be merged to trigger the publish workflow upon check completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->