### PR TITLE
docs: drop the version mention from the README

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Copy-edited the README intro and trimmed ~90 lines of repeated walkthrough out of the body",
-    "direction": "Land the README cleanup through develop, then back to the hull-grade action",
-    "last_update": "2026-06-13T00:00:00Z"
+    "status": "Pulling the version mention out of the README and retiring the bit of release tooling that enforced it",
+    "direction": "Land this, then cut a clean 2.5.0 release now that hull ratings are in",
+    "last_update": "2026-06-13T01:00:00Z"
   }
 }

--- a/README.md
+++ b/README.md
@@ -328,8 +328,7 @@ so failed filings are retryable without reconstructing context.
 
 ## Project Documentation
 
-slop-mop is at version 2.4.0. The public policy surface for release and
-stability expectations lives here:
+The public policy surface for release and stability expectations lives here:
 
 - [DOCS/COMPATIBILITY.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/COMPATIBILITY.md)
 - [DOCS/MIGRATIONS.md](https://github.com/ScienceIsNeato/slop-mop/blob/main/DOCS/MIGRATIONS.md)

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -54,11 +54,6 @@ class Target:
 # mention(s) in that file.
 TARGETS: Tuple[Target, ...] = (
     Target(
-        "README.md",
-        r"slop-mop is at version (\d+\.\d+\.\d+)",
-        "README project-status line",
-    ),
-    Target(
         "DOCS/MACHINE_INTERFACE.md",
         r'"version": "(\d+\.\d+\.\d+)"',
         "sm capabilities example envelope",

--- a/tests/unit/test_sync_version.py
+++ b/tests/unit/test_sync_version.py
@@ -111,7 +111,12 @@ def test_main_check_passes_on_real_repo(capsys):
 
 def test_main_check_fails_on_drift(tmp_path, monkeypatch, capsys):
     _make_repo(tmp_path, "1.2.3")
-    (tmp_path / "README.md").write_text("slop-mop is at version 9.9.9\n")
+    # Use a real remaining target (the Cursor plugin manifest) as the drift
+    # fixture; the README project-status line is no longer managed.
+    (tmp_path / ".cursor-plugin").mkdir()
+    (tmp_path / ".cursor-plugin" / "plugin.json").write_text(
+        '{"version": "9.9.9"}\n', encoding="utf-8"
+    )
     monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
     assert sync.main(["--check"]) == 1
     assert "drift" in capsys.readouterr().err.lower()
@@ -119,13 +124,14 @@ def test_main_check_fails_on_drift(tmp_path, monkeypatch, capsys):
 
 def test_main_apply_syncs_then_reports_already_in_sync(tmp_path, monkeypatch, capsys):
     _make_repo(tmp_path, "2.2.2")
-    readme = tmp_path / "README.md"
-    readme.write_text("slop-mop is at version 1.1.1\n")
+    (tmp_path / ".cursor-plugin").mkdir()
+    manifest = tmp_path / ".cursor-plugin" / "plugin.json"
+    manifest.write_text('{"version": "1.1.1"}\n', encoding="utf-8")
     monkeypatch.setattr(sync, "REPO_ROOT", tmp_path)
 
     assert sync.main([]) == 0
     assert "Synced" in capsys.readouterr().out
-    assert "version 2.2.2" in readme.read_text()
+    assert '"version": "2.2.2"' in manifest.read_text()
 
     assert sync.main([]) == 0
     assert "Already in sync" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Per feedback: there's no reason for the README to state the current version — it only creates a sync obligation. Removes the `slop-mop is at version X` sentence from the **Project Documentation** section and retires the matching `scripts/sync_version.py` target.

- README: version sentence gone; the doc-links list stays
- `sync_version.py`: dropped the "README project-status line" target
- `test_sync_version.py`: the two CLI-surface tests that used that README line as their drift/apply fixture now use the still-managed `.cursor-plugin/plugin.json` target

Other version-managed surfaces are untouched and still enforced: pre-commit `rev:` examples (README + `.pre-commit-hooks.yaml`), the `sm capabilities` envelope in `DOCS/MACHINE_INTERFACE.md`, the bug-report placeholder, and the Cursor plugin manifest.

## Test plan

- [x] `python scripts/sync_version.py --check` → in sync
- [x] `test_sync_version.py` + `test_version_consistency.py` (15) pass
- [x] Local swab clean (`A — seaworthy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes the version mention from README's "Project Documentation" section and retires the corresponding `scripts/sync_version.py` target that synced the version string to that location.

## Changes

- **README.md**: Removed "slop-mop is at version X" statement; kept stability expectations text
- **scripts/sync_version.py**: Removed README.md target from `TARGETS` list; version syncing no longer updates this file
- **tests/unit/test_sync_version.py**: Updated CLI test fixtures to use `.cursor-plugin/plugin.json` (Cursor plugin manifest) instead of README.md for drift/apply tests
- **.willville.json**: Updated agent metadata (status, direction, timestamp)

All other version-managed surfaces remain unchanged (pre-commit examples, `sm capabilities` envelope, bug-report placeholder, Cursor plugin manifest).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->