### PR TITLE
ci: dogfood the published slop-mop-action @v1

### DIFF
--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dogfood:
     name: slop-mop-action @v1
@@ -28,6 +32,11 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           persist-credentials: false
+          # Full history: git-aware gates (diff coverage, gate-dodging)
+          # resolve origin/main, matching the primary scour workflow. A
+          # shallow clone makes them skip, which both diverges this grade
+          # from the real gate and inflates "provisional".
+          fetch-depth: 0
 
       - id: sm
         uses: ScienceIsNeato/slop-mop-action@v1
@@ -37,6 +46,10 @@ jobs:
           upload-sarif: "false"
 
       - name: Report hull grade
+        env:
+          GRADE: ${{ steps.sm.outputs.grade }}
+          HULL: ${{ steps.sm.outputs.hull }}
+          PROVISIONAL: ${{ steps.sm.outputs.provisional }}
         run: |
-          echo "Hull grade: ${{ steps.sm.outputs.grade }} — ${{ steps.sm.outputs.hull }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "grade=${{ steps.sm.outputs.grade }} hull=${{ steps.sm.outputs.hull }} provisional=${{ steps.sm.outputs.provisional }}"
+          echo "Hull grade: $GRADE — $HULL" >> "$GITHUB_STEP_SUMMARY"
+          echo "grade=$GRADE hull=$HULL provisional=$PROVISIONAL"

--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -1,0 +1,42 @@
+# Dogfood the published Marketplace action against slop-mop itself.
+#
+# This runs ScienceIsNeato/slop-mop-action@v1 — the exact ref consumers
+# use — so we find out immediately if a slopmop release breaks the
+# action's grade/SARIF/output contract. It is intentionally NOT pinned to
+# a SHA: the whole point is to validate what `@v1` resolves to today.
+#
+# Advisory by design. The repo's own gates (slopmop-sarif.yml) own
+# enforcement; this job only fails if the action itself breaks, not on
+# scour findings (fail-on-failure: false). SARIF upload is left to the
+# primary gate to avoid duplicate Code Scanning alerts.
+name: Action Dogfood
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dogfood:
+    name: slop-mop-action @v1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+
+      - id: sm
+        uses: ScienceIsNeato/slop-mop-action@v1
+        with:
+          command: scour
+          fail-on-failure: "false"
+          upload-sarif: "false"
+
+      - name: Report hull grade
+        run: |
+          echo "Hull grade: ${{ steps.sm.outputs.grade }} — ${{ steps.sm.outputs.hull }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "grade=${{ steps.sm.outputs.grade }} hull=${{ steps.sm.outputs.hull }} provisional=${{ steps.sm.outputs.provisional }}"


### PR DESCRIPTION
## Summary

Adds a permanent advisory CI job that runs [`ScienceIsNeato/slop-mop-action@v1`](https://github.com/ScienceIsNeato/slop-mop-action/releases/tag/v1.0.0) against slop-mop itself — the same `@v1` ref consumers use. If a future slopmop release breaks the action's grade / SARIF / output contract, this job catches it here instead of in users' repos.

**Design choices**
- **Unpinned `@v1`** — intentional. The point is to validate what `@v1` resolves to today, i.e. the real consumer experience. (Our own action, internal dogfood; the supply-chain SHA-pinning from #277 was about third-party actions.)
- **Advisory** — `fail-on-failure: false`, so it doesn't double-gate the repo; `slopmop-sarif.yml` remains the enforcing gate. The job still goes **red if the action itself breaks**, which is the dogfood signal.
- **`upload-sarif: false`** — the primary gate already uploads the authoritative SARIF; this avoids duplicate Code Scanning alerts.
- Surfaces the hull grade in the job summary.

## Background

The action was validated end-to-end on a throwaway branch before tagging v1.0.0 (grade `B — serviceable`, all steps green, SARIF upload + outputs + minimum-grade enforcement confirmed against published slopmop 2.5.0). This makes that validation continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a new GitHub Actions workflow (Action Dogfood) that runs the published ScienceIsNeato/slop-mop-action@v1 against this repository as an advisory dogfood check. Runs on pull_request, push to main, and workflow_dispatch. The job is advisory (fail-on-failure: false), disables SARIF upload, records the action outputs (grade, hull, provisional) via environment variables, appends the hull grade to GITHUB_STEP_SUMMARY, and exposes a grade/hull/provisional key-value line. The workflow uses contents: read permission, a full checkout (fetch-depth: 0) so git-aware gates resolve origin/main correctly, and a concurrency block (grouped by workflow+ref, cancel-in-progress: true) to cancel superseded runs.

## Changes

- .github/workflows/action-dogfood.yml: New workflow file (+55/-0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->