### PR TITLE
ci: cancel superseded runs to cut Actions spend

### DIFF
--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -78,6 +78,12 @@ permissions:
   security-events: write
   actions: read
 
+# Cancel a superseded run when a newer commit lands on the same ref, so rapid
+# pushes don't stack up redundant runs (the main Actions-budget drain).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     name: Primary Code Scanning Gate (blocking)


### PR DESCRIPTION
## Why

The GitHub Actions budget was getting drained. Measured on a sibling repo (ganglia-core): ~649 billable minutes across 45 runs in 43 hours, and the single biggest cause was workflows with no concurrency block — every push to an open PR started a fresh full run while the previous in-flight run kept going to completion.

## Change

Add a concurrency group to the PR/CI workflow(s):
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
Keyed on workflow + ref, so a new commit cancels the now-stale run on the same branch. During iterative work this typically cuts 30–50% of CI minutes with no downside — the cancelled run was about to be discarded anyway.

Release / deploy / build-and-push workflows were intentionally left untouched (cancelling those mid-run can corrupt a publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds concurrency configuration to PR/CI workflows to cancel superseded runs when new commits are pushed, reducing GitHub Actions spend. The concurrency group is set to `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` enabled.

Modified workflows:
- `.github/workflows/action-dogfood.yml`
- `.github/workflows/slopmop-sarif.yml`
- `.github/workflows/slopmop.yml`
- `tools/.github/workflows/github-ci.yml`

Release, deploy, and build-and-push workflows were intentionally excluded to prevent artifact corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->