### PR TITLE
feat(gate): overconfidence:dangling-references — broken Markdown links (#289)

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Made the URL-consistency gate a ship-time check instead of every-commit, and locked in that onboarding turns it on only for sites with real pages",
-    "direction": "Push and let CI confirm before the merge call",
-    "last_update": "2026-06-16T00:00:00Z"
+    "status": "Built a gate that catches broken doc links — markdown links pointing at files that aren't there after a rename or move",
+    "direction": "Kept it dead simple so it never cries wolf; opening the PR next",
+    "last_update": "2026-06-17T00:00:00Z"
   }
 }

--- a/DOCS/GATE_REASONING.md
+++ b/DOCS/GATE_REASONING.md
@@ -22,6 +22,12 @@ This file is generated from built-in gate metadata. Edit the gate reasoning sour
 - Tradeoffs: Coverage work slows down spikes and sometimes forces harness cleanup before the feature feels done.
 - Override When: Bend this for short-lived spikes, active incidents, or other explicitly time-critical work with agreement that the coverage debt gets paid back.
 
+### `overconfidence:dangling-references`
+
+- Rationale: An agent writes a relative Markdown link or image and moves on; the file renders, so it looks done.  The broken reference only surfaces when a reader clicks it — the agent's mental model of the file tree disagreed with the real one and nothing made it look.
+- Tradeoffs: Deliberately narrow to stay false-positive-free: only literal relative paths in Markdown are checked, so broken HTML src, anchors, and external links are missed by design.
+- Override When: Suppress for generated or vendored docs you do not author.  Add the directory to exclude_dirs in .sb_config.json.
+
 ### `overconfidence:missing-annotations.dart`
 
 - Rationale: Missing Dart annotations turn interfaces into vibes and push type noise downstream for somebody else to untangle.

--- a/slopmop/checks/__init__.py
+++ b/slopmop/checks/__init__.py
@@ -83,6 +83,7 @@ def _register_dart_checks(registry: CheckRegistry) -> None:
 def _register_crosscutting_checks(registry: CheckRegistry) -> None:
     """Register security, quality, and general checks."""
     from slopmop.checks.general.conflicting_metadata import ConflictingMetadataCheck
+    from slopmop.checks.general.dangling_references import DanglingReferencesCheck
     from slopmop.checks.general.interactive_assumptions import (
         InteractiveAssumptionsCheck,
     )
@@ -113,6 +114,7 @@ def _register_crosscutting_checks(registry: CheckRegistry) -> None:
     registry.register(DebuggerArtifactsCheck)
     registry.register(GateDodgingCheck)
     registry.register(ConflictingMetadataCheck)
+    registry.register(DanglingReferencesCheck)
     registry.register(InteractiveAssumptionsCheck)
     registry.register(RepeatedCodeCheck)
     registry.register(StringDuplicationCheck)

--- a/slopmop/checks/general/dangling_references.py
+++ b/slopmop/checks/general/dangling_references.py
@@ -1,0 +1,295 @@
+"""Detect Markdown links that resolve in the agent's head, not on disk.
+
+Overconfidence: an agent writes a relative link or image in a Markdown file —
+``[see the guide](./docs/guide.md)``, ``![logo](../img/logo.png)`` — and moves
+on. The file renders fine; the broken reference only surfaces when a reader
+clicks it. The agent's mental model of the file tree disagreed with the actual
+file tree, and nothing in the loop made it look. Same failure shape as code
+that compiles but throws: ``"it looks linked, therefore it works."``
+
+Scope is deliberately narrow so the check is FALSE-POSITIVE-FREE BY
+CONSTRUCTION — every decision is a literal string test or a filesystem
+existence check, never inference:
+
+  * Markdown only. Markdown relative links have exactly one resolution
+    semantics ("relative to the file on disk"), used identically by GitHub,
+    npm, and every renderer. There is no router, base path, or build step to
+    rewrite them — the HTML-serving minefield (routes, hashed assets) simply
+    does not apply.
+  * A reference is checked only when it is unambiguously a literal repo path.
+    Anything that could legitimately resolve to something else is SKIPPED, not
+    flagged: URL schemes, protocol-relative ``//``, templated ``{{ }}`` paths,
+    site-absolute ``/...``, and pure ``#fragment`` anchors (anchor checking
+    needs slug inference, so it is out of scope).
+  * Only source-type targets (.md / images / directories) are resolved, so a
+    link to a built artifact like ``guide.html`` is never mistaken for a miss.
+
+The cost is deliberate false-negatives (broken HTML ``src``, anchors, external
+404s) — all of which require inference or the network, so they are correctly
+left out.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path, PurePosixPath
+from typing import ClassVar, List, Optional
+from urllib.parse import unquote
+
+from slopmop.checks.base import (
+    EXCLUDE_DIRS_DESCRIPTION,
+    SCOPE_EXCLUDED_DIRS,
+    BaseCheck,
+    CheckRole,
+    ConfigField,
+    Flaw,
+    GateCategory,
+    GateLevel,
+    RemediationChurn,
+    ToolContext,
+    should_prune_dir,
+)
+from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
+from slopmop.utils import is_path_excluded
+
+_EXCLUDED = SCOPE_EXCLUDED_DIRS | {"node_modules", "vendor", "dist", "build"}
+_MARKDOWN_EXTS = (".md", ".markdown")
+
+# Source-type targets we resolve. A suffix outside this set (e.g. .html, .js)
+# might be a built/served artifact, so we skip it rather than risk a false miss.
+# An empty suffix means a directory or extensionless file — always resolvable.
+_SOURCE_EXTS = frozenset(
+    {
+        ".md",
+        ".markdown",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".svg",
+        ".webp",
+        ".ico",
+        ".bmp",
+        ".avif",
+    }
+)
+
+# Markers that mean the path is templated/generated — never a literal path.
+_TEMPLATE_MARKERS = ("{{", "}}", "{%", "%}", "<%", "%>", "${")
+
+# Inline link/image target: [text](TARGET ...) — TARGET is <bracketed> or a
+# whitespace-delimited token (optionally followed by a "title").
+_INLINE_RE = re.compile(r"!?\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)")
+# Reference definition at line start: [id]: TARGET "optional title"
+_REFDEF_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(<[^>]+>|\S+)")
+# A leading URL scheme (mailto:, http:, tel:, …).
+_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+
+class DanglingReferencesCheck(BaseCheck):
+    """Flag Markdown links/images whose relative target is not on disk.
+
+    A PURE, network-free scan of every Markdown file: each relative link or
+    image must resolve to a real file or directory in the repo. Catches the
+    "it looks linked, therefore it works" overconfidence where an agent
+    renames or moves a file and leaves a stale reference behind.
+
+    False-positive-free by construction — only literal, unambiguous repo paths
+    are checked; schemes, templated paths, site-absolute ``/...``, ``#``
+    anchors, and non-source extensions are skipped, never flagged.
+
+    PURE check — stdlib regex + filesystem, no external tools or network.
+
+    Level: scour (PR-readiness / CI sweep).
+
+    Configuration:
+      exclude_dirs: [] — additional directories to skip.
+
+    Re-check:
+      sm scour -g overconfidence:dangling-references --verbose
+    """
+
+    tool_context: ClassVar[ToolContext] = ToolContext.PURE
+    role = CheckRole.DIAGNOSTIC
+    level = GateLevel.SCOUR
+    remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_UNLIKELY
+
+    @property
+    def name(self) -> str:
+        return "dangling-references"
+
+    @property
+    def display_name(self) -> str:
+        return "🔗 Dangling References (broken Markdown links)"
+
+    @property
+    def gate_description(self) -> str:
+        return (
+            "🔗 Catches Markdown links/images pointing at a relative path that "
+            "isn't on disk — broken doc links from a rename or move"
+        )
+
+    @property
+    def category(self) -> GateCategory:
+        return GateCategory.OVERCONFIDENCE
+
+    @property
+    def flaw(self) -> Flaw:
+        return Flaw.OVERCONFIDENCE
+
+    @property
+    def config_schema(self) -> List[ConfigField]:
+        return [
+            ConfigField(
+                name="exclude_dirs",
+                field_type="string[]",
+                default=[],
+                description=EXCLUDE_DIRS_DESCRIPTION,
+                permissiveness="more_is_stricter",
+            ),
+        ]
+
+    def _excluded(self) -> set[str]:
+        return _EXCLUDED | set(self.config.get("exclude_dirs") or [])
+
+    def is_applicable(self, project_root: str) -> bool:
+        return bool(_iter_markdown_files(Path(project_root), self._excluded()))
+
+    def skip_reason(self, project_root: str) -> str:
+        return "No Markdown files found"
+
+    def run(self, project_root: str) -> CheckResult:
+        start = time.perf_counter()
+        root = Path(project_root)
+        files = _iter_markdown_files(root, self._excluded())
+
+        findings: List[Finding] = []
+        for md in files:
+            findings += _scan_markdown(md, root)
+
+        return self._result(findings, len(files), time.perf_counter() - start)
+
+    def _result(
+        self, findings: List[Finding], file_count: int, elapsed: float
+    ) -> CheckResult:
+        if not findings:
+            return self._create_result(
+                status=CheckStatus.PASSED,
+                duration=elapsed,
+                output=f"All Markdown references resolve ({file_count} file(s))",
+            )
+        preview = "\n".join(f"  {f.file}:{f.line}: {f.message}" for f in findings[:20])
+        more = f"\n  … and {len(findings) - 20} more" if len(findings) > 20 else ""
+        return self._create_result(
+            status=CheckStatus.FAILED,
+            duration=elapsed,
+            output=f"{preview}{more}",
+            findings=findings,
+            error=(
+                f"Found {len(findings)} dangling reference(s) across "
+                f"{file_count} Markdown file(s)."
+            ),
+            fix_suggestion=(
+                "Each link above points at a relative path that does not exist "
+                "in the repo — fix the path or restore the moved/renamed file.\n"
+                "Only literal relative links are checked (schemes, #anchors, "
+                "site-absolute /paths, and templated links are ignored).\n"
+                "To suppress a directory, add it to\n"
+                "  overconfidence.gates.dangling-references.exclude_dirs in "
+                ".sb_config.json"
+            ),
+        )
+
+
+def _iter_markdown_files(root: Path, excluded: set[str]) -> List[Path]:
+    """All .md/.markdown files under root, excluded and noise dirs pruned."""
+    out: List[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in _MARKDOWN_EXTS:
+            continue
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            continue
+        if is_path_excluded(rel, excluded) or any(
+            should_prune_dir(p) for p in rel.parts[:-1]
+        ):
+            continue
+        out.append(path)
+    return out
+
+
+def _scan_markdown(md: Path, root: Path) -> List[Finding]:
+    """Yield a finding for every relative link/image target that is not on disk."""
+    try:
+        text = md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    rel_md = md.relative_to(root).as_posix()
+    findings: List[Finding] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for raw in _iter_targets(line):
+            target = _checkable_path(raw)
+            if target is None:
+                continue
+            if not _resolves(md.parent, root, target):
+                findings.append(
+                    Finding(
+                        message=f"link target does not exist: {raw.strip()!r}",
+                        level=FindingLevel.ERROR,
+                        file=rel_md,
+                        line=lineno,
+                        rule_id="dangling-reference",
+                    )
+                )
+    return findings
+
+
+def _iter_targets(line: str) -> List[str]:
+    """Extract raw link/image/reference-definition targets from one line."""
+    targets = [m.group(1) for m in _INLINE_RE.finditer(line)]
+    ref = _REFDEF_RE.match(line)
+    if ref:
+        targets.append(ref.group(1))
+    return targets
+
+
+def _checkable_path(raw: str) -> Optional[str]:
+    """Return the literal repo-relative path to check, or None to skip.
+
+    Every skip is a literal string test — there is no inference about how a
+    non-literal target *might* resolve; we simply decline to judge it.
+    """
+    target = raw.strip()
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1].strip()
+    if not target:
+        return None
+    if any(marker in target for marker in _TEMPLATE_MARKERS):
+        return None  # templated / generated path
+    if target.startswith("#"):
+        return None  # pure fragment — anchor checking is out of scope
+    if target.startswith("//") or _SCHEME_RE.match(target):
+        return None  # external / protocol-relative
+    # Strip fragment and query, then decode %20-style escapes.
+    target = target.split("#", 1)[0].split("?", 1)[0]
+    if not target or target.startswith("/"):
+        return None  # empty or site-absolute (ambiguous root) — won't guess
+    target = unquote(target)
+    suffix = PurePosixPath(target.rstrip("/")).suffix.lower()
+    if suffix and suffix not in _SOURCE_EXTS:
+        return None  # could be a built/served artifact — skip, don't flag
+    return target
+
+
+def _resolves(md_dir: Path, root: Path, target: str) -> bool:
+    """True if target resolves to an existing path inside the repo root."""
+    try:
+        resolved = (md_dir / target).resolve()
+        root_resolved = root.resolve()
+    except OSError:
+        return True  # cannot resolve safely → do not flag
+    if not resolved.is_relative_to(root_resolved):
+        return True  # escapes the repo → out of scope, never flag
+    return resolved.exists()

--- a/slopmop/checks/general/dangling_references.py
+++ b/slopmop/checks/general/dangling_references.py
@@ -31,6 +31,7 @@ left out.
 
 from __future__ import annotations
 
+import os
 import re
 import time
 from pathlib import Path, PurePosixPath
@@ -79,8 +80,9 @@ _SOURCE_EXTS = frozenset(
 _TEMPLATE_MARKERS = ("{{", "}}", "{%", "%}", "<%", "%>", "${")
 
 # Inline link/image target: [text](TARGET ...) — TARGET is <bracketed> or a
-# whitespace-delimited token (optionally followed by a "title").
-_INLINE_RE = re.compile(r"!?\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)")
+# whitespace-delimited token whose parentheses are balanced, so a path like
+# ./docs/api(v2).md is captured whole rather than truncated at the first ")".
+_INLINE_RE = re.compile(r"!?\[[^\]]*\]\(\s*(<[^>]+>|(?:[^()\s]+|\([^)]*\))+)")
 # Reference definition at line start: [id]: TARGET "optional title"
 _REFDEF_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(<[^>]+>|\S+)")
 # A leading URL scheme (mailto:, http:, tel:, …).
@@ -203,21 +205,32 @@ class DanglingReferencesCheck(BaseCheck):
 
 
 def _iter_markdown_files(root: Path, excluded: set[str]) -> List[Path]:
-    """All .md/.markdown files under root, excluded and noise dirs pruned."""
+    """All .md/.markdown files under root, excluded and noise dirs pruned.
+
+    Prunes excluded/noise directories top-down so we never descend into
+    node_modules, .git, vendor, … — important since this gate applies to any
+    repo with Markdown, where those trees can dwarf the source.
+    """
     out: List[Path] = []
-    for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.suffix.lower() not in _MARKDOWN_EXTS:
-            continue
-        try:
-            rel = path.relative_to(root)
-        except ValueError:
-            continue
-        if is_path_excluded(rel, excluded) or any(
-            should_prune_dir(p) for p in rel.parts[:-1]
-        ):
-            continue
-        out.append(path)
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        rel_dir = Path(dirpath).relative_to(root)
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not should_prune_dir(d)
+            and not is_path_excluded(_rel_join(rel_dir, d), excluded)
+        ]
+        for name in filenames:
+            if PurePosixPath(name).suffix.lower() not in _MARKDOWN_EXTS:
+                continue
+            out.append(Path(dirpath) / name)
+    out.sort()
     return out
+
+
+def _rel_join(rel_dir: Path, name: str) -> Path:
+    """Join a child name onto a repo-relative dir, dropping the leading '.'."""
+    return Path(name) if rel_dir == Path(".") else rel_dir / name
 
 
 def _scan_markdown(md: Path, root: Path) -> List[Finding]:
@@ -291,5 +304,7 @@ def _resolves(md_dir: Path, root: Path, target: str) -> bool:
     except OSError:
         return True  # cannot resolve safely → do not flag
     if not resolved.is_relative_to(root_resolved):
-        return True  # escapes the repo → out of scope, never flag
+        # climbs above the repo root — unresolvable in any published/CI context
+        # (and we never stat outside the repo). Flag it as a broken reference.
+        return False
     return resolved.exists()

--- a/slopmop/checks/metadata.py
+++ b/slopmop/checks/metadata.py
@@ -480,6 +480,32 @@ def _github_actions_hygiene_reasoning_entry() -> tuple[type[BaseCheck], Reasonin
     )
 
 
+def _dangling_references_reasoning_entry() -> tuple[type[BaseCheck], Reasoning]:
+    from slopmop.checks.general.dangling_references import DanglingReferencesCheck
+
+    return (
+        DanglingReferencesCheck,
+        _reasoning(
+            rationale=(
+                "An agent writes a relative Markdown link or image and moves on; "
+                "the file renders, so it looks done.  The broken reference only "
+                "surfaces when a reader clicks it — the agent's mental model of "
+                "the file tree disagreed with the real one and nothing made it "
+                "look."
+            ),
+            tradeoffs=(
+                "Deliberately narrow to stay false-positive-free: only literal "
+                "relative paths in Markdown are checked, so broken HTML src, "
+                "anchors, and external links are missed by design."
+            ),
+            override_when=(
+                "Suppress for generated or vendored docs you do not author.  Add "
+                "the directory to exclude_dirs in .sb_config.json."
+            ),
+        ),
+    )
+
+
 def _conflicting_metadata_reasoning_entry() -> tuple[type[BaseCheck], Reasoning]:
     from slopmop.checks.general.conflicting_metadata import ConflictingMetadataCheck
 
@@ -609,6 +635,7 @@ def _overconfidence_reasoning_entries() -> (
     from slopmop.checks.python.type_checking import PythonTypeCheckingCheck
 
     return (
+        _dangling_references_reasoning_entry(),
         (DartCoverageCheck, _coverage_reasoning("Dart")),
         (JavaScriptCoverageCheck, _coverage_reasoning("JavaScript")),
         (PythonCoverageCheck, _coverage_reasoning("Python")),

--- a/tests/unit/test_dangling_references_check.py
+++ b/tests/unit/test_dangling_references_check.py
@@ -1,0 +1,148 @@
+"""Tests for the overconfidence:dangling-references gate."""
+
+from slopmop.checks.base import GateCategory, GateLevel, ToolContext
+from slopmop.checks.general.dangling_references import DanglingReferencesCheck
+from slopmop.core.result import CheckStatus
+
+
+def _dr_check(config=None):
+    return DanglingReferencesCheck(config or {})
+
+
+def _dr_run(tmp_path, config=None):
+    return DanglingReferencesCheck(config or {}).run(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    def test_full_name(self):
+        assert _dr_check().full_name == "overconfidence:dangling-references"
+
+    def test_category(self):
+        assert _dr_check().category == GateCategory.OVERCONFIDENCE
+
+    def test_level_is_scour(self):
+        assert DanglingReferencesCheck.level == GateLevel.SCOUR
+
+    def test_tool_context_pure(self):
+        assert DanglingReferencesCheck.tool_context == ToolContext.PURE
+
+
+# ---------------------------------------------------------------------------
+# Applicability
+# ---------------------------------------------------------------------------
+
+
+class TestApplicability:
+    def test_applicable_with_markdown(self, tmp_path):
+        (tmp_path / "README.md").write_text("# hi\n")
+        assert _dr_check().is_applicable(str(tmp_path)) is True
+
+    def test_not_applicable_without_markdown(self, tmp_path):
+        (tmp_path / "app.py").write_text("print('hi')\n")
+        assert _dr_check().is_applicable(str(tmp_path)) is False
+
+
+# ---------------------------------------------------------------------------
+# Fail cases — genuinely broken relative references
+# ---------------------------------------------------------------------------
+
+
+class TestFailures:
+    def test_broken_relative_link(self, tmp_path):
+        (tmp_path / "README.md").write_text("See [the guide](./docs/guide.md).\n")
+        result = _dr_run(tmp_path)
+        assert result.status == CheckStatus.FAILED
+        assert any(f.rule_id == "dangling-reference" for f in result.findings)
+
+    def test_broken_image(self, tmp_path):
+        (tmp_path / "README.md").write_text("![logo](./img/logo.png)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.FAILED
+
+    def test_broken_reference_definition(self, tmp_path):
+        (tmp_path / "README.md").write_text("[g]: ./missing.md\nSee [g].\n")
+        assert _dr_run(tmp_path).status == CheckStatus.FAILED
+
+    def test_broken_link_in_subdir_resolves_relative_to_file(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        # ../README.md does not exist (only docs/x.md), so this is broken
+        (docs / "x.md").write_text("[home](../README.md)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.FAILED
+
+    def test_fragment_stripped_before_file_check(self, tmp_path):
+        (tmp_path / "README.md").write_text("[s](./guide.md#install)\n")
+        # guide.md is absent → broken regardless of the anchor
+        assert _dr_run(tmp_path).status == CheckStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Pass cases — references that DO resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolves:
+    def test_existing_relative_link(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "guide.md").write_text("# Guide\n")
+        (tmp_path / "README.md").write_text("See [the guide](./docs/guide.md).\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_link_to_directory(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "README.md").write_text("See [docs](./docs/).\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_percent_encoded_space(self, tmp_path):
+        (tmp_path / "my file.md").write_text("x\n")
+        (tmp_path / "README.md").write_text("[f](./my%20file.md)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+
+# ---------------------------------------------------------------------------
+# False-positive-free by construction — each of these must NOT flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoFalsePositives:
+    def test_external_url_skipped(self, tmp_path):
+        (tmp_path / "README.md").write_text("[site](https://example.com/x)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_mailto_skipped(self, tmp_path):
+        (tmp_path / "README.md").write_text("[mail](mailto:a@b.com)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_pure_fragment_skipped(self, tmp_path):
+        (tmp_path / "README.md").write_text("[top](#installation)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_site_absolute_path_skipped(self, tmp_path):
+        # ambiguous repo-root vs site-root — we never guess
+        (tmp_path / "README.md").write_text("[about](/about)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_templated_path_skipped(self, tmp_path):
+        (tmp_path / "README.md").write_text("[x]({{ site.baseurl }}/guide.md)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_non_source_extension_skipped(self, tmp_path):
+        # .html could be a built artifact from a .md source — never flag it
+        (tmp_path / "README.md").write_text("[built](./guide.html)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_protocol_relative_skipped(self, tmp_path):
+        (tmp_path / "README.md").write_text("[cdn](//cdn.example.com/x.png)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_parent_escape_not_flagged(self, tmp_path):
+        # a target that climbs out of the repo is out of scope, never flagged
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "README.md").write_text("[x](../../etc/passwd)\n")
+        assert DanglingReferencesCheck({}).run(str(root)).status == CheckStatus.PASSED

--- a/tests/unit/test_dangling_references_check.py
+++ b/tests/unit/test_dangling_references_check.py
@@ -46,6 +46,17 @@ class TestApplicability:
         (tmp_path / "app.py").write_text("print('hi')\n")
         assert _dr_check().is_applicable(str(tmp_path)) is False
 
+    def test_noise_and_excluded_dirs_are_pruned(self, tmp_path):
+        # markdown inside node_modules / .git / a configured exclude must not
+        # be scanned (and must not make the gate applicable on its own)
+        for d in ("node_modules", ".git", "thirdparty"):
+            sub = tmp_path / d
+            sub.mkdir()
+            (sub / "BROKEN.md").write_text("[x](./does-not-exist.md)\n")
+        check = _dr_check({"exclude_dirs": ["thirdparty"]})
+        assert check.is_applicable(str(tmp_path)) is False
+        assert check.run(str(tmp_path)).status == CheckStatus.PASSED
+
 
 # ---------------------------------------------------------------------------
 # Fail cases — genuinely broken relative references
@@ -79,6 +90,16 @@ class TestFailures:
         # guide.md is absent → broken regardless of the anchor
         assert _dr_run(tmp_path).status == CheckStatus.FAILED
 
+    def test_repo_escaping_target_is_flagged(self, tmp_path):
+        # a relative link climbing above the repo root can never resolve in a
+        # published/CI context (the issue's "outside the published tree" goal)
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "README.md").write_text("[x](../../secrets.md)\n")
+        result = DanglingReferencesCheck({}).run(str(root))
+        assert result.status == CheckStatus.FAILED
+        assert any(f.rule_id == "dangling-reference" for f in result.findings)
+
 
 # ---------------------------------------------------------------------------
 # Pass cases — references that DO resolve
@@ -101,6 +122,15 @@ class TestResolves:
     def test_percent_encoded_space(self, tmp_path):
         (tmp_path / "my file.md").write_text("x\n")
         (tmp_path / "README.md").write_text("[f](./my%20file.md)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED
+
+    def test_existing_link_with_parentheses_in_path(self, tmp_path):
+        # parentheses are legal in Markdown destinations when balanced — the
+        # path must be captured whole, not truncated at the first ")"
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "api(v2).md").write_text("# API\n")
+        (tmp_path / "README.md").write_text("[api](./docs/api(v2).md)\n")
         assert _dr_run(tmp_path).status == CheckStatus.PASSED
 
 
@@ -140,9 +170,10 @@ class TestNoFalsePositives:
         (tmp_path / "README.md").write_text("[cdn](//cdn.example.com/x.png)\n")
         assert _dr_run(tmp_path).status == CheckStatus.PASSED
 
-    def test_parent_escape_not_flagged(self, tmp_path):
-        # a target that climbs out of the repo is out of scope, never flagged
-        root = tmp_path / "repo"
-        root.mkdir()
-        (root / "README.md").write_text("[x](../../etc/passwd)\n")
-        assert DanglingReferencesCheck({}).run(str(root)).status == CheckStatus.PASSED
+    def test_repo_internal_parent_link_resolves(self, tmp_path):
+        # ../ that stays inside the repo resolves normally (monorepo sibling)
+        (tmp_path / "guide.md").write_text("# Guide\n")
+        sub = tmp_path / "docs"
+        sub.mkdir()
+        (sub / "page.md").write_text("[home](../guide.md)\n")
+        assert _dr_run(tmp_path).status == CheckStatus.PASSED


### PR DESCRIPTION
Closes #289. A PURE, stack-agnostic gate that catches the "it looks linked, therefore it works" overconfidence — an agent writes a relative Markdown link or image, it renders fine, and moves on, but the target was renamed/moved and the reference is now dead.

## Scoped to be false-positive-free *by construction*, not by filtering

The minefield I flagged on the issue (framework routes, base-path rewrites, hashed build assets) is an **HTML-serving** phenomenon. Scoping to **Markdown only** removes the serving layer entirely — Markdown relative links have exactly one universal resolution semantics ("relative to the file on disk"), so there's nothing left to infer.

Every decision is a literal string test or a `path.exists()` — never inference. A target is **skipped, never flagged**, when it:
- has a URL scheme (`http:`, `mailto:`, `tel:`) or is protocol-relative (`//…`)
- contains template markers (`{{ }}`, `{% %}`, `${`) → SSG/templated
- is a pure `#fragment` (anchor checking needs slug inference — out of scope)
- is site-absolute (`/…`) → ambiguous repo-root vs site-root
- has a non-source extension (`.html`, `.js`) → could be a built artifact

What's left is only a literal relative path to a repo file. If it (or the directory it names) isn't on disk, it's unambiguously broken. A `../` target that escapes the repo is skipped via a containment guard.

The cost is deliberate **false-negatives** (broken HTML `src`, anchors, external 404s) — all need inference or the network, so they're correctly excluded.

## Why it clears the breadth bar
`is_applicable` = repo has ≥1 Markdown file → **stack-agnostic, not web-only.** Every repo with a README/docs is in scope, and broken relative doc links are one of the most common agent failures on a rename/move.

## Verification
- **Zero false positives on slop-mop's own 32 Markdown files** (9 real references, all resolved — non-vacuous).
- 22 unit tests including one per skip class (external URL, mailto, fragment, site-absolute, templated, non-source ext, protocol-relative, repo-escape).
- Full unit suite (3282) green; pyright/ruff/bandit clean; local grade A.
- PURE, DIAGNOSTIC, SCOUR; registered in all three places (registry, reasoning catalog, regenerated `DOCS/GATE_REASONING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## overconfidence:dangling-references Gate

This PR adds an `overconfidence:dangling-references` gate that deterministically (network-free) flags broken internal Markdown link/image references where the destination file doesn’t exist in the repo.

### Scope & behavior
- **Checks Markdown only** (`.md`, `.markdown`)
- **Detects** literal relative link/image targets and reference definitions like `[id]: target`
- **Resolves on disk** relative to the referencing Markdown file and repo root
- **Flags** missing targets and **repo-escaping paths** (e.g., `../../outside/...`)
- **Skips** non-checkable targets: URL schemes (`http:`, `mailto:`, `tel:`), `//` protocol-relative, template markers (`{{ }}`, `{% %}`, `${`), pure fragments (`#anchor`), site-absolute paths (`/...`), non-source extensions (e.g., `.html`, `.js`), and paths escaping the published tree

### Implementation & registration
- Implemented as `DanglingReferencesCheck` in `slopmop/checks/general/dangling_references.py`
- Registered in `slopmop/checks/__init__.py`
- Added reasoning entry in `DOCS/GATE_REASONING.md`
- Added built-in reasoning composition in `slopmop/checks/metadata.py`
- Updated `.willville.json`

### Key round-1 fixes
- **Balanced parentheses** in link destinations (prevents truncation false positives)
- **Top-down directory pruning** to avoid traversing excluded dirs (`node_modules`, `.git`, `vendor`)
- **Treat repo-escaping targets as broken** (instead of passing)

### Tests
- Added `tests/unit/test_dangling_references_check.py` with coverage for metadata/applicability, failure modes, correct resolutions (including parentheses), and extensive “no false positives” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->