### PR TITLE
chore(release): require release notes via CHANGELOG.md + seed 2.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,14 @@ jobs:
                   )
           PY
 
+      - name: Require CHANGELOG entry for this release
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          # Release notes are mandatory: fail before opening a release PR or
+          # publishing if CHANGELOG.md has no section for this version.
+          python scripts/changelog_section.py "$VERSION" >/dev/null
+
       - name: Create release PR and merge after green checks
         id: release_pr
         if: steps.resolve.outputs.commit_sha == ''
@@ -445,13 +453,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-context.outputs.tag }}
           TARGET: ${{ needs.release-context.outputs.commit_sha }}
+          VERSION: ${{ needs.release-context.outputs.version }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub Release $TAG already exists"
             exit 0
           fi
 
+          # Release body = the human-authored CHANGELOG.md section for this
+          # version (required: this fails if the section is missing).
+          python scripts/changelog_section.py "$VERSION" > release_body.md
+
           gh release create "$TAG" dist/* \
             --target "$TARGET" \
             --title "$TAG" \
-            --generate-notes
+            --notes-file release_body.md

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Built a gate that catches broken doc links — markdown links pointing at files that aren't there after a rename or move",
-    "direction": "Kept it dead simple so it never cries wolf; opening the PR next",
+    "status": "Making release notes mandatory — releases now fail unless the changelog has a section for the version being cut, and that section becomes the release writeup",
+    "direction": "Land this, then cut 2.6.0 with the two new gates",
     "last_update": "2026-06-17T00:00:00Z"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to slopmop are recorded here. The release workflow reads
+the section matching the version being cut and uses it as the GitHub Release
+body, so **a release cannot be published without a matching section here.**
+
+Format: one `## X.Y.Z` section per release, newest first.
+
+## 2.6.0
+
+### New gates
+
+- **`myopia:conflicting-metadata`** (#291) — flags pages that disagree with
+  themselves about their own URL: canonical vs `og:url`, canonical vs the
+  sitemap (trailing-slash / scheme drift, including `sitemapindex` children),
+  and `noindex` pages still listed in the sitemap. PURE, scour-level; auto-skips
+  repos with no HTML.
+- **`overconfidence:dangling-references`** (#289) — flags broken relative
+  Markdown links and images whose target isn't on disk (the classic
+  rename/move leftover). False-positive-free by construction; auto-skips repos
+  with no Markdown.
+
+### Hooks
+
+- **Merged/deleted-branch commit guard** (#287) — the pre-commit hook now
+  refuses commits onto a branch that's already merged or whose remote was
+  deleted, so work doesn't pile onto a closed-out branch.
+
+### CI / infra
+
+- Dogfood the published `slop-mop-action@v1` in CI (#285).
+- Cancel superseded workflow runs to cut Actions spend (#286).
+
+Both new gates are opt-out and applicability-gated: existing projects pick them
+up automatically on the next `sm scour` after upgrading, and only where
+relevant (HTML / Markdown present).

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Extract one version's section from CHANGELOG.md.
+
+The release workflow uses this twice: once to *require* that the version being
+cut has release notes (fail fast otherwise), and once to feed that section to
+``gh release create --notes-file`` as the GitHub Release body.
+
+Usage:
+    python scripts/changelog_section.py <version> [--changelog PATH]
+
+Prints the section body to stdout. Exits non-zero (with a message on stderr)
+when CHANGELOG.md is missing or has no non-empty section for that version, so a
+release can never be published without notes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def extract_section(text: str, version: str) -> Optional[str]:
+    """Return the body under ``## <version>`` (or ``## [<version>]``), or None.
+
+    The body runs from just after the heading to the next ``## `` heading.
+    Surrounding blank lines are stripped; an empty section returns None so it
+    counts as "no notes".
+    """
+    heading = re.compile(r"^##\s+\[?" + re.escape(version) + r"\]?\s*$")
+    next_section = re.compile(r"^##\s+")
+    lines = text.splitlines()
+
+    start: Optional[int] = None
+    for i, line in enumerate(lines):
+        if heading.match(line):
+            start = i + 1
+            break
+    if start is None:
+        return None
+
+    body: list[str] = []
+    for line in lines[start:]:
+        if next_section.match(line):
+            break
+        body.append(line)
+
+    section = "\n".join(body).strip()
+    return section or None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Version to extract, e.g. 2.6.0")
+    parser.add_argument(
+        "--changelog",
+        default="CHANGELOG.md",
+        help="Path to the changelog (default: CHANGELOG.md)",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.changelog)
+    if not path.is_file():
+        print(f"{args.changelog} not found", file=sys.stderr)
+        return 1
+
+    section = extract_section(path.read_text(encoding="utf-8"), args.version)
+    if not section:
+        print(
+            f"No release notes for {args.version} in {args.changelog} — add a "
+            f"'## {args.version}' section before cutting this release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_changelog_section.py
+++ b/tests/unit/test_changelog_section.py
@@ -9,7 +9,8 @@ _SPEC = importlib.util.spec_from_file_location(
     "changelog_section",
     Path(__file__).resolve().parents[2] / "scripts" / "changelog_section.py",
 )
-assert _SPEC and _SPEC.loader
+assert _SPEC is not None
+assert _SPEC.loader is not None
 changelog_section = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(changelog_section)
 
@@ -34,7 +35,8 @@ class TestExtractSection:
     def test_extracts_named_version(self):
         body = extract_section(SAMPLE, "2.6.0")
         assert body is not None
-        assert "thing one" in body and "thing two" in body
+        assert "thing one" in body
+        assert "thing two" in body
         assert "older stuff" not in body  # stops at the next ## heading
 
     def test_extracts_bracketed_version(self):

--- a/tests/unit/test_changelog_section.py
+++ b/tests/unit/test_changelog_section.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/changelog_section.py (release-notes extraction)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "changelog_section",
+    Path(__file__).resolve().parents[2] / "scripts" / "changelog_section.py",
+)
+assert _SPEC and _SPEC.loader
+changelog_section = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(changelog_section)
+
+extract_section = changelog_section.extract_section
+main = changelog_section.main
+
+SAMPLE = """# Changelog
+
+## 2.6.0
+
+### New gates
+- thing one
+- thing two
+
+## 2.5.0
+
+- older stuff
+"""
+
+
+class TestExtractSection:
+    def test_extracts_named_version(self):
+        body = extract_section(SAMPLE, "2.6.0")
+        assert body is not None
+        assert "thing one" in body and "thing two" in body
+        assert "older stuff" not in body  # stops at the next ## heading
+
+    def test_extracts_bracketed_version(self):
+        body = extract_section("## [1.2.3]\n\n- notes\n", "1.2.3")
+        assert body == "- notes"
+
+    def test_missing_version_returns_none(self):
+        assert extract_section(SAMPLE, "9.9.9") is None
+
+    def test_empty_section_counts_as_missing(self):
+        text = "## 2.6.0\n\n## 2.5.0\n- x\n"
+        assert extract_section(text, "2.6.0") is None
+
+    def test_partial_version_does_not_match(self):
+        # "2.6" must not match the "2.6.0" heading
+        assert extract_section(SAMPLE, "2.6") is None
+
+
+class TestCli:
+    def test_exit_zero_and_prints_section(self, tmp_path, capsys):
+        cl = tmp_path / "CHANGELOG.md"
+        cl.write_text(SAMPLE)
+        rc = main(["2.6.0", "--changelog", str(cl)])
+        assert rc == 0
+        assert "thing one" in capsys.readouterr().out
+
+    def test_exit_nonzero_when_missing(self, tmp_path, capsys):
+        cl = tmp_path / "CHANGELOG.md"
+        cl.write_text(SAMPLE)
+        rc = main(["9.9.9", "--changelog", str(cl)])
+        assert rc == 1
+        assert "No release notes for 9.9.9" in capsys.readouterr().err
+
+    def test_exit_nonzero_when_changelog_absent(self, tmp_path, capsys):
+        rc = main(["2.6.0", "--changelog", str(tmp_path / "nope.md")])
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_real_changelog_has_current_release_section(self):
+        # the committed CHANGELOG.md must carry notes for 2.6.0
+        repo_changelog = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+        rc = main(["2.6.0", "--changelog", str(repo_changelog)])
+        assert rc == 0


### PR DESCRIPTION
Makes release notes **mandatory** and reviewed in-repo, replacing today's fully auto-generated GitHub Release body.

## Why CHANGELOG instead of a dispatch field
GitHub `workflow_dispatch` inputs are single-line only — they can't hold multi-paragraph markdown. Sourcing notes from a committed `CHANGELOG.md` gives richer, reviewable notes *and* a stronger guarantee: the release **fails** if the section is missing, where a free-text form field could be filled with anything.

## What changed
- **`CHANGELOG.md`** (new) — Keep-a-Changelog style, seeded with the **2.6.0** section (the two new gates, the merged/deleted-branch commit guard, and the CI changes since v2.5.0).
- **`scripts/changelog_section.py`** (new) — extracts a version's section, exits non-zero when it's missing or empty. Stdlib-only, mirrors `sync_version.py`. 9 unit tests.
- **`release.yml`**:
  - A **"Require CHANGELOG entry"** step runs right after version resolution and fails the whole release early if `## <version>` is absent — before any release PR, build, or publish.
  - The GitHub Release body is now that CHANGELOG section (`--notes-file`) instead of `--generate-notes`.

## Release flow after this lands
1. Land this PR (the 2.6.0 section is already in `CHANGELOG.md`).
2. Run **Release → minor** → produces 2.6.0, validates the section exists, publishes with it as the body.

Full unit suite (3294) green; YAML valid; GitHub-Actions hygiene gate passes; the new CHANGELOG doesn't trip the dangling-references gate.

> Note: I did **not** add a literal required field to the dispatch form — the CHANGELOG requirement enforces "notes required" more strongly. If you'd also like a confirmation input in the form, say so and I'll add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Make release notes mandatory by sourcing from CHANGELOG.md

Requires each release to have a corresponding `CHANGELOG.md` section before publishing, and uses that section as the GitHub Release body (instead of GitHub auto-generated notes).

**Changes:**
- **`CHANGELOG.md`** — New Keep-a-Changelog entry seeded for **2.6.0** (documents the two new gates, the merged/deleted-branch commit guard, and CI workflow updates since 2.5.0).
- **`scripts/changelog_section.py`** — New stdlib-only helper to extract a version section from `CHANGELOG.md`; exits non-zero if the section is missing/empty (with unit tests covering extraction + CLI behavior).
- **`tests/unit/test_changelog_section.py`** — Added tests for section parsing and CLI success/failure modes, including asserting the committed `CHANGELOG.md` contains **2.6.0**.
- **`.github/workflows/release.yml`** — Added an early “Require CHANGELOG entry” step and switched the GitHub Release body to `--notes-file` sourced from the extracted changelog section (skipping if an existing release is detected).
- **`.willville.json`** — Updated agent messaging to reflect the new mandatory changelog requirement.

All tests pass (3294 tests); YAML is valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->