### PR TITLE
fix(output): quiet disabled-gate spam + pretty-print JSON artifacts

### DIFF
--- a/slopmop/cli/validate.py
+++ b/slopmop/cli/validate.py
@@ -558,8 +558,9 @@ def _run_validation_locked(
             json_output = JsonAdapter.render(report)
             json_path = Path(json_file)
             json_path.parent.mkdir(parents=True, exist_ok=True)
+            # Files are read by humans and archived as artifacts — pretty-print.
             json_path.write_text(
-                json.dumps(json_output, separators=(",", ":")),
+                json.dumps(json_output, indent=2),
                 encoding="utf-8",
             )
 
@@ -579,12 +580,14 @@ def _run_validation_locked(
 
         if json_mode:
             output = JsonAdapter.render(report)
-            json_payload = json.dumps(output, separators=(",", ":"))
             if output_file and not sarif_requested:
-                # Mirror JSON to disk for archival, but keep stdout payload
-                # so callers can consume it directly in pipelines.
-                Path(output_file).write_text(json_payload, encoding="utf-8")
-            print(json_payload)
+                # Mirror JSON to disk for archival — pretty-printed for humans.
+                Path(output_file).write_text(
+                    json.dumps(output, indent=2), encoding="utf-8"
+                )
+            # Keep the stdout payload compact so callers can consume it
+            # directly in pipelines.
+            print(json.dumps(output, separators=(",", ":")))
         elif porcelain_mode:
             print(PorcelainAdapter.render(report))
         else:

--- a/slopmop/core/executor.py
+++ b/slopmop/core/executor.py
@@ -284,7 +284,10 @@ class CheckExecutor:
                 if self._on_check_disabled:
                     self._on_check_disabled(check.full_name)
                 else:
-                    logger.info(f"Disabled — {check.full_name}: {reason}")
+                    # Disabled gates already show as SKIPPED in the summary; keep
+                    # the per-gate reason at debug so scour/CI output isn't buried
+                    # under a wall of "Disabled —" lines.
+                    logger.debug(f"Disabled — {check.full_name}: {reason}")
 
         # Propagate: if a dependency is disabled, disable its dependents too
         changed = True
@@ -298,7 +301,7 @@ class CheckExecutor:
                             if self._on_check_disabled:
                                 self._on_check_disabled(check.full_name)
                             else:
-                                logger.info(
+                                logger.debug(
                                     f"Disabled — {check.full_name}: "
                                     f"dependency {dep} is disabled"
                                 )

--- a/tests/unit/test_sm_cli.py
+++ b/tests/unit/test_sm_cli.py
@@ -931,7 +931,8 @@ class TestValidateJsonOutputFile:
         mock_print,
         tmp_path,
     ):
-        """--json with --output-file writes payload to file and stdout."""
+        """--json with --output-file writes pretty JSON to the file and a
+        compact payload to stdout (same data, different formatting)."""
         from slopmop.cli.validate import _run_validation
 
         mock_executor = MagicMock()
@@ -962,7 +963,11 @@ class TestValidateJsonOutputFile:
 
         assert result == 0
         assert output_file.exists()
-        assert output_file.read_text(encoding="utf-8") == '{"ok":true}'
+        # File is pretty-printed (multi-line, indent=2) for human/artifact use.
+        file_text = output_file.read_text(encoding="utf-8")
+        assert file_text == '{\n  "ok": true\n}'
+        assert json.loads(file_text) == {"ok": True}
+        # stdout stays compact for pipeline consumers.
         mock_print.assert_called_once_with('{"ok":true}')
 
 


### PR DESCRIPTION
Two readability fixes for scour / CI output (from real CI logs that were a wall of disabled-gate lines followed by a single-line JSON blob).

- **Quiet the disabled-gate spam.** The per-gate `Disabled — <gate>: <reason>` lines move from `info` to `debug`. Disabled gates already appear as `SKIPPED` in the summary, so normal scour/CI output is no longer buried under ~25 of these (they still show with `--verbose`).
- **Pretty-print JSON result files.** `--json-file` and `--output-file` (in json mode) now write `indent=2` instead of minified — these files are read by humans and archived as CI artifacts. stdout `--json` stays compact for pipeline consumers.

Verified: a scour with `--json-file` writes a multi-line, parseable file and emits zero `Disabled —` lines at default verbosity. Full suite (3294) green; updated the one test that encoded the old "file == compact stdout" assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves readability of scour and CI output by making two changes:

1. **Log level reduction**: Demotes per-gate "Disabled — <gate>: <reason>" messages from `info` to `debug` level, preventing ~25 repeated lines from obscuring normal output. Messages remain visible with `--verbose`.

2. **JSON file formatting**: Changes `--json-file` and `--output-file` (in JSON mode) to write pretty-printed JSON with `indent=2` instead of minified single-line output. Stdout `--json` output remains compact for pipeline automation tools.

**Changes:**
- `slopmop/cli/validate.py`: Updated JSON serialization to use `indent=2` for files, `separators=(",", ":")` for stdout
- `slopmop/core/executor.py`: Changed log level from `info` to `debug` for disabled gate messages (2 locations)
- `tests/unit/test_sm_cli.py`: Updated test expectations for multi-line JSON file output

All 3294 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->