### PR TITLE
ci(release): auto-bump slop-mop-action's slopmop pin on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,3 +468,60 @@ jobs:
             --target "$TARGET" \
             --title "$TAG" \
             --notes-file release_body.md
+
+  bump-action-pin:
+    name: Bump slop-mop-action pin
+    needs:
+      - release-context
+      - github-release
+    if: needs.release-context.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Keep the published slop-mop-action pinned to the freshly released
+      # version so its install cache stays deterministic and current. Opens a
+      # PR (reviewable) rather than pushing to main. Best-effort: the release
+      # is already published, so a failure here never blocks shipping.
+      - name: Open PR to bump the action's slopmop-version pin
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          VERSION: ${{ needs.release-context.outputs.version }}
+          ACTION_REPO: ScienceIsNeato/slop-mop-action
+        run: |
+          set -uo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::RELEASE_PR_TOKEN not set — bump slopmop-version to ==${VERSION} in ${ACTION_REPO} manually."
+            exit 0
+          fi
+
+          workdir="$(mktemp -d)"
+          if ! git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${ACTION_REPO}.git" \
+            "$workdir" 2>/dev/null; then
+            echo "::warning::Could not clone ${ACTION_REPO} (token may lack access) — bump slopmop-version to ==${VERSION} manually."
+            exit 0
+          fi
+          cd "$workdir"
+
+          # Replace the default of the slopmop-version input only (the sed
+          # range is bounded to that input block).
+          sed -i -E \
+            "/^[[:space:]]*slopmop-version:/,/default:/ s|^([[:space:]]*)default:.*|\\1default: \"==${VERSION}\"|" \
+            action.yml
+
+          if git diff --quiet; then
+            echo "${ACTION_REPO} already pinned to ==${VERSION}; nothing to do."
+            exit 0
+          fi
+
+          branch="chore/bump-slopmop-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git commit -am "chore: bump slopmop-version pin to ==${VERSION}"
+          git push --force-with-lease origin "$branch"
+          gh pr create --repo "$ACTION_REPO" \
+            --title "chore: bump slopmop-version pin to ==${VERSION}" \
+            --body "Automated bump from the Slop-Mop ${VERSION} release. Keeps the action's default pin (and install cache) aligned with the latest release." \
+            --base main --head "$branch" \
+            || echo "::warning::Could not open PR (it may already exist for ${branch})."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,9 +519,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
           git commit -am "chore: bump slopmop-version pin to ==${VERSION}"
-          git push --force-with-lease origin "$branch"
+          if ! git push --force-with-lease origin "$branch"; then
+            echo "::warning::Failed to push ${branch} to ${ACTION_REPO} (token may lack write access) — bump slopmop-version to ==${VERSION} manually."
+            exit 0
+          fi
           gh pr create --repo "$ACTION_REPO" \
             --title "chore: bump slopmop-version pin to ==${VERSION}" \
             --body "Automated bump from the Slop-Mop ${VERSION} release. Keeps the action's default pin (and install cache) aligned with the latest release." \
             --base main --head "$branch" \
-            || echo "::warning::Could not open PR (it may already exist for ${branch})."
+            || echo "::warning::Push succeeded but PR creation failed — a PR for ${branch} may already exist, or the token lacks PR scope. Open it manually if needed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,6 +519,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
           git commit -am "chore: bump slopmop-version pin to ==${VERSION}"
+          # The shallow clone has no remote-tracking ref for the bump branch, so
+          # --force-with-lease would fail on a rerun where the branch already
+          # exists remotely. Fetch the ref first so the lease has a reference
+          # point (no-op on the first run where the branch doesn't exist yet).
+          git fetch --depth 1 origin \
+            "refs/heads/${branch}:refs/remotes/origin/${branch}" 2>/dev/null || true
           if ! git push --force-with-lease origin "$branch"; then
             echo "::warning::Failed to push ${branch} to ${ACTION_REPO} (token may lack write access) — bump slopmop-version to ==${VERSION} manually."
             exit 0

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Making release notes mandatory — releases now fail unless the changelog has a section for the version being cut, and that section becomes the release writeup",
-    "direction": "Land this, then cut 2.6.0 with the two new gates",
+    "status": "Wiring releases so they automatically keep the GitHub Action pointed at the just-shipped version — no more manual bumps, no more stale install caches",
+    "direction": "Land this so the next release bumps the action on its own",
     "last_update": "2026-06-17T00:00:00Z"
   }
 }


### PR DESCRIPTION
Completes the "tie the pin to the release flow" plan. The companion change in [slop-mop-action#2](https://github.com/ScienceIsNeato/slop-mop-action/pull/2) pins `slopmop-version` by default (so the install cache is deterministic); this keeps that pin current automatically.

## What it does
A `bump-action-pin` job runs after the GitHub release is published and opens a PR on `ScienceIsNeato/slop-mop-action` setting its `slopmop-version` default to the just-released version.

- **Precise edit:** a range-bounded `sed` updates only the `slopmop-version` input's default — verified locally that every other input's `default:` is untouched and the result is valid YAML.
- **Reviewable:** opens a PR, never pushes to the action's main.
- **Best-effort, never blocks a release:** `continue-on-error` plus guards. By the time this job runs the release is already on PyPI and GitHub, so a missing/again-scoped `RELEASE_PR_TOKEN` or a clone failure just logs a warning.

## Dependency to be aware of
The job needs `RELEASE_PR_TOKEN` to have **write/PR access to `slop-mop-action`** (it already creates the release PR in this repo; this adds a second repo). If the token is scoped to slop-mop only, the job will warn and no-op — you'd bump the action manually that one time, or widen the token scope.

## Sequencing
Merge this before cutting 2.6.0 so that release auto-bumps the action from `==2.5.0` to `==2.6.0`.

Workflow YAML validated; GitHub-Actions hygiene gate passes (the new job uses only `run:` steps, no actions to pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Automatic Version Pinning for `slop-mop-action`

Adds a `bump-action-pin` job to the release workflow (runs after `github-release` when `release-context.outputs.should_release` is `true`) to open a reviewable PR on `ScienceIsNeato/slop-mop-action` updating the `action.yml` input default `slopmop-version` to the newly released `VERSION`.

The job uses a bounded `sed` edit to update only the `slopmop-version` default (preserving the rest of the YAML), and is best-effort: it no-ops with warnings if the token is missing/insufficient, cloning fails, the edit produces no diff, or pushing fails. It creates/updates `chore/bump-slopmop-${VERSION}`, pushes the branch, and then attempts `gh pr create` against `main` (PR-creation failures are tolerated). The job is marked `continue-on-error` so release failures aren’t blocked.

Error-handling improvements from review:
- Explicit `git push` failure detection with a targeted warning (e.g., likely token write access on the target repo) instead of masking the root cause behind `gh pr create` errors.
- Fix for reruns with shallow clones by fetching the remote tracking ref before pushing so `--force-with-lease` behaves correctly and diagnostics remain accurate.

**Files changed:**
- `.github/workflows/release.yml`: Added `bump-action-pin` job (+66 lines)
- `.willville.json`: Updated agent release metadata (+2/-2 lines)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->