### PR TITLE
feat(hooks): run sm scour at pre-push to catch scour-only failures locally

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Added --global flag to commit-hooks install so it wires up machine-wide git hooks via core.hooksPath — PR #298",
-    "direction": "Get PR #298 reviewed and merge, then dogfood with sm commit-hooks install --global",
-    "last_update": "2026-06-19T12:00:00Z"
+    "status": "PR #298 clean — scour on push + --global install, all CI green and review resolved",
+    "direction": "Ready to merge; after merge, dogfood with sm commit-hooks install --global",
+    "last_update": "2026-06-19T14:08:00Z"
   }
 }

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Wiring releases so they automatically keep the GitHub Action pointed at the just-shipped version — no more manual bumps, no more stale install caches",
-    "direction": "Land this so the next release bumps the action on its own",
-    "last_update": "2026-06-17T00:00:00Z"
+    "status": "Making the push hook run the full check suite locally, so people stop discovering in CI that something failed — and it reuses the quick-check results so it stays fast",
+    "direction": "Land it, keep an eye on whether the caching really saves the repeat work",
+    "last_update": "2026-06-19T00:00:00Z"
   }
 }

--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Making the push hook run the full check suite locally, so people stop discovering in CI that something failed — and it reuses the quick-check results so it stays fast",
-    "direction": "Land it, keep an eye on whether the caching really saves the repeat work",
-    "last_update": "2026-06-19T00:00:00Z"
+    "status": "Added --global flag to commit-hooks install so it wires up machine-wide git hooks via core.hooksPath — PR #298",
+    "direction": "Get PR #298 reviewed and merge, then dogfood with sm commit-hooks install --global",
+    "last_update": "2026-06-19T12:00:00Z"
   }
 }

--- a/README.md
+++ b/README.md
@@ -130,8 +130,14 @@ adopted slop-mop: in a repo that hasn't been onboarded (`sm init` +
 blocking the commit.
 
 If you prefer raw git hooks without the pre-commit framework,
-`sm commit-hooks install` does the same job with sm-managed scripts. Those
-hooks also carry a **merged/deleted-branch guard**: the pre-commit hook
+`sm commit-hooks install` does the same job with sm-managed scripts: swab on
+every commit, and the full **`sm scour`** on push — the same validation CI
+runs, so scour-only failures are caught before you push instead of on a red
+build. The push scour reuses the swab results from cache (keyed per gate), so
+only scour-only and changed gates run fresh; bypass once with
+`git push --no-verify`.
+
+Those hooks also carry a **merged/deleted-branch guard**: the pre-commit hook
 refuses a commit when the current branch has already been merged (a merged
 PR, the remote head deleted, or HEAD already contained in a moved-on default
 branch) so you don't pile work onto a branch that's closed out and would have

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -434,6 +434,17 @@ def _hooks_status(project_root: Path, hooks_dir: Path) -> int:
 
     print_project_header(str(project_root))
     print(f"📁 Hooks dir: {hooks_dir}")
+
+    # Surface the global install state so the user knows which hooks are active.
+    global_dir = _global_hooks_dir()
+    current_hooks_path = subprocess.run(
+        ["git", "config", "--global", "--get", "core.hooksPath"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if current_hooks_path == str(global_dir) and global_dir.exists():
+        print(f"🌐 Global install active: {global_dir}")
+        print("   Git runs hooks from the global dir; per-repo hooks are shadowed.")
     print()
 
     if not hooks_dir.exists():
@@ -499,6 +510,28 @@ def _hooks_install(
 
     # Per-repo installs must not clobber a hook we don't own. The global dir is
     # slopmop-owned, so foreign hooks there can't exist — skip the check.
+    if not global_install:
+        # Warn if machine-wide hooks are already active: local hooks written to
+        # .git/hooks won't run while core.hooksPath shadows them.
+        current_hooks_path = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if current_hooks_path == str(_global_hooks_dir()):
+            print(
+                "⚠️  Machine-wide hooks are active (core.hooksPath → "
+                f"{current_hooks_path})."
+            )
+            print(
+                "   Per-repo hooks written to .git/hooks won't run while global "
+                "hooks shadow them."
+            )
+            print(
+                "   Run 'sm commit-hooks uninstall --global' first, or use "
+                "'sm commit-hooks install --global' to update the global hooks."
+            )
+            print()
     if not global_install:
         for existing, label, fix in (
             (hook_file, "pre-commit", "Manually add 'sm swab' to your existing hook"),

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -43,7 +43,7 @@ def _global_preamble(hook_name: str, *, capture_stdin: bool) -> str:
 _sm_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 {grab_stdin}# Run the repo's own {hook_name} too — a global hooksPath shadows
 # .git/hooks, so we delegate to keep other tools' hooks working.
-_sm_local="$_sm_root/.git/hooks/{hook_name}"
+_sm_local="$(git rev-parse --git-dir 2>/dev/null)/hooks/{hook_name}"
 if [ -x "$_sm_local" ] && ! grep -q "{SB_HOOK_MARKER}" "$_sm_local" 2>/dev/null; then
     {delegate_run}
 fi
@@ -495,10 +495,21 @@ def _hooks_install(
     )
 
     if global_install:
-        subprocess.run(
-            ["git", "config", "--global", "core.hooksPath", str(target_dir)],
-            check=True,
-        )
+        existing_path = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if existing_path and existing_path != str(target_dir):
+            print(f"⚠️  Replacing existing global core.hooksPath: {existing_path}")
+        try:
+            subprocess.run(
+                ["git", "config", "--global", "core.hooksPath", str(target_dir)],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Failed to set global core.hooksPath: {e}")
+            return 1
 
     print()
     print(

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -56,6 +56,47 @@ fi
 """
 
 
+# Client-side hooks that should get passthrough delegation when global hooks
+# are installed. We exclude pre-commit and pre-push (managed by us) and all
+# server-side hooks (post-receive, pre-receive, update, post-update).
+_GLOBAL_PASSTHROUGH_HOOKS = [
+    "applypatch-msg",
+    "commit-msg",
+    "post-applypatch",
+    "post-checkout",
+    "post-commit",
+    "post-merge",
+    "post-rewrite",
+    "pre-applypatch",
+    "pre-auto-gc",
+    "pre-merge-commit",
+    "pre-rebase",
+    "prepare-commit-msg",
+    "push-to-checkout",
+]
+
+
+def _generate_passthrough_hook(hook_name: str) -> str:
+    """Generate a delegation-only hook for types we don't manage.
+
+    When ``core.hooksPath`` is set git resolves ALL hook types from that
+    directory, not each repo's ``.git/hooks``.  For the hook types we don't
+    manage (commit-msg, post-checkout, …) we still need a script in the
+    global dir — otherwise those hooks are silently skipped for every repo.
+    This script simply forwards to the repo-local hook if one exists.
+    """
+    return f"""#!/bin/sh
+{SB_HOOK_MARKER}
+# Command: passthrough-delegation for {hook_name}
+# Forwards to the repo's own {hook_name} hook so other tools keep working.
+_sm_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+_sm_local="$(git rev-parse --git-dir 2>/dev/null)/hooks/{hook_name}"
+if [ -x "$_sm_local" ]; then
+    exec "$_sm_local" "$@"
+fi
+"""
+
+
 def _get_git_hooks_dir(project_root: Path) -> Optional[Path]:
     """Find the .git/hooks directory for a project."""
     git_dir = project_root / ".git"
@@ -495,6 +536,16 @@ def _hooks_install(
     )
 
     if global_install:
+        # Write passthrough delegation scripts for hook types we don't manage.
+        # core.hooksPath shadows ALL hook types — without these, commit-msg,
+        # post-checkout, prepare-commit-msg, etc. would be silently skipped.
+        for pt_hook in _GLOBAL_PASSTHROUGH_HOOKS:
+            pt_file = target_dir / pt_hook
+            pt_file.write_text(_generate_passthrough_hook(pt_hook))
+            pt_file.chmod(
+                pt_file.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            )
+
         existing_path = subprocess.run(
             ["git", "config", "--global", "--get", "core.hooksPath"],
             capture_output=True,
@@ -564,7 +615,7 @@ def _hooks_uninstall(
         return 0
 
     removed: list[str] = []
-    hook_types = ["pre-commit", "pre-push", "commit-msg"]
+    hook_types = ["pre-commit", "pre-push"] + _GLOBAL_PASSTHROUGH_HOOKS
 
     for hook_type in hook_types:
         hook_file = target_dir / hook_type

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -191,22 +191,30 @@ exit 0
 
 
 def _generate_pre_push_hook_script() -> str:
-    """Generate a pre-push hook that blocks pushes from merged branches.
+    """Generate a pre-push hook: merged-branch guard, then a full scour.
 
-    Git feeds the refs actually being pushed on stdin (one line per ref:
-    ``<local ref> <local sha> <remote ref> <remote sha>``). The guard reads
-    those rather than ``HEAD`` so a push like
-    ``git push origin merged-feature:merged-feature`` from another checkout is
-    still inspected. For each pushed branch it asks GitHub whether that branch
-    name has an already-merged PR; if yes, pushing it is almost always
-    accidental follow-up work on a branch that should have been retired.
+    Two things run before a push is allowed:
+
+    1. Merged-branch guard. Git feeds the refs actually being pushed on stdin
+       (one line per ref: ``<local ref> <local sha> <remote ref> <remote
+       sha>``). The guard reads those rather than ``HEAD`` so a push like
+       ``git push origin merged-feature:merged-feature`` from another checkout
+       is still inspected. For each pushed branch it asks GitHub whether that
+       branch name has an already-merged PR; if yes, pushing it is almost
+       always accidental follow-up on a branch that should have been retired.
+
+    2. ``sm scour``. The thorough validation CI runs, executed locally so
+       scour-only failures surface here instead of on a red build. swab-level
+       results from the pre-commit hook are reused from the cache (keyed
+       per-gate by a fingerprint), so only scour-only and changed gates run
+       fresh — a cached scour is dramatically faster than a cold one.
     """
 
     return f"""#!/bin/sh
 {SB_HOOK_MARKER}
 #
 # Pre-push hook managed by slop-mop
-# Command: merged-branch-guard
+# Command: merged-branch-guard + sm scour
 # To remove: sm commit-hooks uninstall
 #
 
@@ -264,6 +272,31 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         exit 1
     fi
 done
+
+# Merged-branch guard passed for every pushed ref. Now run the full scour so
+# scour-only failures are caught here instead of in CI. swab-level gate results
+# from the pre-commit hook are reused from cache; only scour-only and changed
+# gates run fresh, so this is fast on an unchanged tree.
+if ! command -v sm >/dev/null 2>&1; then
+    echo "❌ sm not found on PATH"
+    echo "   Install: pipx install slopmop"
+    exit 1
+fi
+
+mkdir -p .slopmop
+echo "🧽 slop-mop: running scour before push (cached swab results are reused)…"
+sm scour --porcelain --json-file .slopmop/last_scour.json
+scour_result=$?
+
+if [ $scour_result -ne 0 ]; then
+    echo ""
+    echo "❌ Push blocked by slop-mop scour"
+    echo "   Structured results: .slopmop/last_scour.json"
+    echo "   This is the same scour CI runs — fix it here to avoid a red build."
+    echo "   Bypass once (not recommended): git push --no-verify"
+    echo ""
+    exit 1
+fi
 
 exit 0
 {SB_HOOK_END_MARKER}
@@ -396,13 +429,18 @@ def _hooks_install(project_root: Path, hooks_dir: Path, verb: str) -> int:
     print_project_header(str(project_root))
     print(f"📄 Hook: {hook_file}")
     print(f"📄 Hook: {pre_push_file}")
-    print(f"🎯 Command: sm {verb}")
-    print("🎯 Guard: block commits/pushes on an already-merged or deleted branch")
+    print(f"🎯 Pre-commit: sm {verb} + merged/deleted-branch guard")
+    print("🎯 Pre-push:   merged-branch guard + sm scour")
     print()
     print(f"The pre-commit hook runs 'sm {verb}' before each commit and first")
     print("refuses the commit if the branch is already merged or deleted (so")
-    print("you don't pile work onto a dead branch). The pre-push guard is the")
-    print("push-time backstop. Commits are also blocked if quality gates fail.")
+    print("you don't pile work onto a dead branch).")
+    print()
+    print("The pre-push hook runs the full 'sm scour' — the same validation CI")
+    print("runs — so scour-only failures are caught before you push, not on a red")
+    print("build. swab results from the commit hook are reused from cache, so")
+    print("only scour-only and changed gates run fresh. Bypass once with")
+    print("'git push --no-verify'.")
     print()
     print("To remove: sm commit-hooks uninstall")
     print()

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -615,7 +615,7 @@ def _hooks_uninstall(
         return 0
 
     removed: list[str] = []
-    hook_types = ["pre-commit", "pre-push"] + _GLOBAL_PASSTHROUGH_HOOKS
+    hook_types = ["pre-commit", "pre-push", *_GLOBAL_PASSTHROUGH_HOOKS]
 
     for hook_type in hook_types:
         hook_file = target_dir / hook_type

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -3,12 +3,57 @@
 import argparse
 import re
 import stat
+import subprocess
 from pathlib import Path
 from typing import Any, Optional
 
 # Hook markers
 SB_HOOK_MARKER = "# MANAGED BY SLOP-MOP"
 SB_HOOK_END_MARKER = "# END SLOP-MOP HOOK"
+
+
+def _global_hooks_dir() -> Path:
+    """Machine-wide hooks dir wired in via ``git config --global core.hooksPath``."""
+    return Path.home() / ".slopmop" / "git-hooks"
+
+
+def _global_preamble(hook_name: str, *, capture_stdin: bool) -> str:
+    """Preamble for a GLOBAL hook (one installed via ``core.hooksPath``).
+
+    A global ``core.hooksPath`` makes git look ONLY at that dir, shadowing every
+    repo's own ``.git/hooks``. Two things keep that non-destructive:
+
+    1. Delegate to the repo's local hook (if any, and not one of ours) so other
+       tools' hooks — husky, custom scripts — keep firing.
+    2. Only run slop-mop where the repo is onboarded (``.sb_config.json`` or a
+       ``[tool.slopmop]`` table); otherwise exit 0 so non-slop-mop repos are
+       untouched.
+
+    ``capture_stdin`` is for pre-push, which receives the pushed refs on stdin:
+    we slurp them once so both the delegated hook and our own guard can read
+    them.
+    """
+    grab_stdin = "_sm_stdin=$(cat)\n" if capture_stdin else ""
+    delegate_run = (
+        'printf \'%s\\n\' "$_sm_stdin" | "$_sm_local" "$@" || exit $?'
+        if capture_stdin
+        else '"$_sm_local" "$@" || exit $?'
+    )
+    return f"""# --- slop-mop global hook (installed via core.hooksPath) ---
+_sm_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+{grab_stdin}# Run the repo's own {hook_name} too — a global hooksPath shadows
+# .git/hooks, so we delegate to keep other tools' hooks working.
+_sm_local="$_sm_root/.git/hooks/{hook_name}"
+if [ -x "$_sm_local" ] && ! grep -q "{SB_HOOK_MARKER}" "$_sm_local" 2>/dev/null; then
+    {delegate_run}
+fi
+# Only act in onboarded repos so every other repo is left alone.
+if [ ! -f "$_sm_root/.sb_config.json" ] \\
+    && ! grep -q '^\\[tool.slopmop\\]' "$_sm_root/pyproject.toml" 2>/dev/null; then
+    exit 0
+fi
+# --- end slop-mop global preamble ---
+"""
 
 
 def _get_git_hooks_dir(project_root: Path) -> Optional[Path]:
@@ -135,7 +180,7 @@ _sm_merged_branch_guard
 # --- end merged/deleted-branch guard ---"""
 
 
-def _generate_hook_script(verb: str) -> str:
+def _generate_hook_script(verb: str, *, global_install: bool = False) -> str:
     """Generate the pre-commit hook script content.
 
     The hook assumes ``sm`` is on PATH — ``pipx install slopmop``
@@ -152,20 +197,29 @@ def _generate_hook_script(verb: str) -> str:
 
     Args:
         verb: The validation command to run ("swab" or "scour").
+        global_install: When True, prepend the global preamble (delegate to a
+            repo-local hook, then act only in onboarded repos) so the hook is
+            safe to fire in every repo via ``core.hooksPath``.
     """
 
     json_file = f".slopmop/last_{verb}.json"
     guard = _generate_merged_branch_guard()
+    scope = " (global)" if global_install else ""
+    preamble = (
+        _global_preamble("pre-commit", capture_stdin=False) + "\n"
+        if global_install
+        else ""
+    )
     return f"""#!/bin/sh
 {SB_HOOK_MARKER}
 #
-# Pre-commit hook managed by slop-mop
+# Pre-commit hook managed by slop-mop{scope}
 # Command: sm {verb} --porcelain
 # Guard: refuse commits on an already-merged or deleted branch
 # To remove: sm commit-hooks uninstall
 #
 
-{guard}
+{preamble}{guard}
 
 if ! command -v sm >/dev/null 2>&1; then
     echo "❌ sm not found on PATH"
@@ -190,7 +244,7 @@ exit 0
 """
 
 
-def _generate_pre_push_hook_script() -> str:
+def _generate_pre_push_hook_script(*, global_install: bool = False) -> str:
     """Generate a pre-push hook: merged-branch guard, then a full scour.
 
     Two things run before a push is allowed:
@@ -210,15 +264,27 @@ def _generate_pre_push_hook_script() -> str:
        fresh — a cached scour is dramatically faster than a cold one.
     """
 
+    scope = " (global)" if global_install else ""
+    preamble = (
+        _global_preamble("pre-push", capture_stdin=True) + "\n"
+        if global_install
+        else ""
+    )
+    # Per-repo reads the pushed refs straight from stdin; the global hook
+    # already slurped them into $_sm_stdin (so it could also feed a delegated
+    # hook), so the guard loop reads them back from a here-doc instead.
+    refs_redirect = (
+        "" if not global_install else " <<SLOPMOP_REFS\n$_sm_stdin\nSLOPMOP_REFS"
+    )
     return f"""#!/bin/sh
 {SB_HOOK_MARKER}
 #
-# Pre-push hook managed by slop-mop
+# Pre-push hook managed by slop-mop{scope}
 # Command: merged-branch-guard + sm scour
 # To remove: sm commit-hooks uninstall
 #
 
-if ! command -v gh >/dev/null 2>&1; then
+{preamble}if ! command -v gh >/dev/null 2>&1; then
     echo "❌ gh not found on PATH"
     echo "   This guard checks whether the branch already has a merged PR."
     echo "   Install GitHub CLI: https://cli.github.com/"
@@ -271,7 +337,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo ""
         exit 1
     fi
-done
+done{refs_redirect}
 
 # Merged-branch guard passed for every pushed ref. Now run the full scour so
 # scour-only failures are caught here instead of in CI. swab-level gate results
@@ -374,46 +440,53 @@ def _hooks_status(project_root: Path, hooks_dir: Path) -> int:
     return 0
 
 
-def _hooks_install(project_root: Path, hooks_dir: Path, verb: str) -> int:
-    """Install managed pre-commit + pre-push hooks."""
-    hooks_dir.mkdir(parents=True, exist_ok=True)
-    hook_file = hooks_dir / "pre-commit"
-    pre_push_file = hooks_dir / "pre-push"
+def _hooks_install(
+    project_root: Path, hooks_dir: Path, verb: str, *, global_install: bool = False
+) -> int:
+    """Install managed pre-commit + pre-push hooks.
 
-    if hook_file.exists():
-        content = hook_file.read_text()
-        if SB_HOOK_MARKER in content:
-            print("ℹ️  Updating existing slopmop hook...")
-        else:
-            print(f"⚠️  Existing pre-commit hook found at: {hook_file}")
-            print("   This hook is not managed by slopmop.")
-            print()
-            print("Options:")
-            print("   1. Back up your existing hook and run install again")
-            print("   2. Manually add 'sm swab' to your existing hook")
-            print()
-            return 1
+    Per-repo (default): write to this repo's ``.git/hooks``. Machine-wide
+    (``global_install``): write to ``~/.slopmop/git-hooks`` and point
+    ``git config --global core.hooksPath`` at it so the hooks apply to every
+    repo (the generated scripts delegate to repo-local hooks and only act in
+    onboarded repos, so other repos are left alone).
+    """
+    target_dir = _global_hooks_dir() if global_install else hooks_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    hook_file = target_dir / "pre-commit"
+    pre_push_file = target_dir / "pre-push"
 
-    if pre_push_file.exists():
-        content = pre_push_file.read_text()
-        if SB_HOOK_MARKER in content:
-            print("ℹ️  Updating existing slopmop pre-push guard...")
-        else:
-            print(f"⚠️  Existing pre-push hook found at: {pre_push_file}")
-            print("   This hook is not managed by slopmop.")
-            print()
-            print("Options:")
-            print("   1. Back up your existing hook and run install again")
-            print(
-                "   2. Manually add the merged-branch guard from sm commit-hooks output"
-            )
-            print()
-            return 1
+    # Per-repo installs must not clobber a hook we don't own. The global dir is
+    # slopmop-owned, so foreign hooks there can't exist — skip the check.
+    if not global_install:
+        for existing, label, fix in (
+            (hook_file, "pre-commit", "Manually add 'sm swab' to your existing hook"),
+            (
+                pre_push_file,
+                "pre-push",
+                "Manually add the merged-branch guard from sm commit-hooks output",
+            ),
+        ):
+            if existing.exists() and SB_HOOK_MARKER not in existing.read_text():
+                print(f"⚠️  Existing {label} hook found at: {existing}")
+                print("   This hook is not managed by slopmop.")
+                print()
+                print("Options:")
+                print("   1. Back up your existing hook and run install again")
+                print(f"   2. {fix}")
+                print()
+                return 1
 
-    hook_content = _generate_hook_script(verb)
-    hook_file.write_text(hook_content)
-    pre_push_content = _generate_pre_push_hook_script()
-    pre_push_file.write_text(pre_push_content)
+    if any(
+        f.exists() and SB_HOOK_MARKER in f.read_text()
+        for f in (hook_file, pre_push_file)
+    ):
+        print("ℹ️  Updating existing slopmop hook...")
+
+    hook_file.write_text(_generate_hook_script(verb, global_install=global_install))
+    pre_push_file.write_text(
+        _generate_pre_push_hook_script(global_install=global_install)
+    )
     hook_file.chmod(
         hook_file.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
@@ -421,17 +494,36 @@ def _hooks_install(project_root: Path, hooks_dir: Path, verb: str) -> int:
         pre_push_file.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
-    print()
-    print("✅ Pre-commit hook installed!")
-    print("=" * 60)
-    from slopmop.reporting import print_project_header
+    if global_install:
+        subprocess.run(
+            ["git", "config", "--global", "core.hooksPath", str(target_dir)],
+            check=True,
+        )
 
-    print_project_header(str(project_root))
+    print()
+    print(
+        "✅ Machine-wide hooks installed!"
+        if global_install
+        else "✅ Pre-commit hook installed!"
+    )
+    print("=" * 60)
+    if not global_install:
+        from slopmop.reporting import print_project_header
+
+        print_project_header(str(project_root))
     print(f"📄 Hook: {hook_file}")
     print(f"📄 Hook: {pre_push_file}")
     print(f"🎯 Pre-commit: sm {verb} + merged/deleted-branch guard")
     print("🎯 Pre-push:   merged-branch guard + sm scour")
     print()
+    if global_install:
+        print("These hooks now apply to EVERY git repo on this machine via")
+        print("'git config --global core.hooksPath'. In each repo they:")
+        print("  • delegate to that repo's own .git/hooks first (other tools keep")
+        print("    working), then")
+        print("  • run slop-mop only if the repo is onboarded (.sb_config.json or")
+        print("    [tool.slopmop]) — every other repo is passed through untouched.")
+        print()
     print(f"The pre-commit hook runs 'sm {verb}' before each commit and first")
     print("refuses the commit if the branch is already merged or deleted (so")
     print("you don't pile work onto a dead branch).")
@@ -442,14 +534,21 @@ def _hooks_install(project_root: Path, hooks_dir: Path, verb: str) -> int:
     print("only scour-only and changed gates run fresh. Bypass once with")
     print("'git push --no-verify'.")
     print()
-    print("To remove: sm commit-hooks uninstall")
+    print(
+        "To remove: sm commit-hooks uninstall --global"
+        if global_install
+        else "To remove: sm commit-hooks uninstall"
+    )
     print()
     return 0
 
 
-def _hooks_uninstall(_project_root: Path, hooks_dir: Path) -> int:
-    """Remove all sm-managed hooks."""
-    if not hooks_dir.exists():
+def _hooks_uninstall(
+    _project_root: Path, hooks_dir: Path, *, global_install: bool = False
+) -> int:
+    """Remove all sm-managed hooks (per-repo, or machine-wide with global)."""
+    target_dir = _global_hooks_dir() if global_install else hooks_dir
+    if not target_dir.exists():
         print("ℹ️  No hooks directory found")
         return 0
 
@@ -457,18 +556,34 @@ def _hooks_uninstall(_project_root: Path, hooks_dir: Path) -> int:
     hook_types = ["pre-commit", "pre-push", "commit-msg"]
 
     for hook_type in hook_types:
-        hook_file = hooks_dir / hook_type
+        hook_file = target_dir / hook_type
         if hook_file.exists():
             content = hook_file.read_text()
             if SB_HOOK_MARKER in content:
                 hook_file.unlink()
                 removed.append(hook_type)
 
+    if global_install:
+        # Only unset core.hooksPath if it still points at our dir, so we don't
+        # clobber a hooksPath the user set to something else.
+        current = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if current == str(target_dir):
+            subprocess.run(
+                ["git", "config", "--global", "--unset", "core.hooksPath"],
+                check=False,
+            )
+
     print()
     if removed:
         print("✅ Removed slopmop-managed hooks:")
         for hook_type in removed:
             print(f"   • {hook_type}")
+        if global_install:
+            print("   • global core.hooksPath (unset)")
     else:
         print("ℹ️  No slopmop-managed hooks found")
     print()
@@ -478,23 +593,31 @@ def _hooks_uninstall(_project_root: Path, hooks_dir: Path) -> int:
 def cmd_commit_hooks(args: argparse.Namespace) -> int:
     """Handle the commit-hooks command."""
     project_root = Path(args.project_root).resolve()
+    global_install = bool(getattr(args, "global_install", False))
 
     if not args.hooks_action:
         args.hooks_action = "status"
 
     hooks_dir = _get_git_hooks_dir(project_root)
 
-    if not hooks_dir:
+    # Global install/uninstall targets ~/.slopmop/git-hooks via core.hooksPath,
+    # so it doesn't need to run inside a git repo. Per-repo actions do.
+    if not hooks_dir and not (
+        global_install and args.hooks_action in ("install", "uninstall")
+    ):
         print(f"❌ Not a git repository: {project_root}")
         print("   Initialize git first: git init")
         return 1
+    target = hooks_dir if hooks_dir is not None else _global_hooks_dir()
 
     if args.hooks_action == "status":
-        return _hooks_status(project_root, hooks_dir)
+        return _hooks_status(project_root, target)
     elif args.hooks_action == "install":
-        return _hooks_install(project_root, hooks_dir, args.hook_verb)
+        return _hooks_install(
+            project_root, target, args.hook_verb, global_install=global_install
+        )
     elif args.hooks_action == "uninstall":
-        return _hooks_uninstall(project_root, hooks_dir)
+        return _hooks_uninstall(project_root, target, global_install=global_install)
     else:
         print(f"❌ Unknown action: {args.hooks_action}")
         return 1

--- a/slopmop/sm.py
+++ b/slopmop/sm.py
@@ -602,6 +602,16 @@ def _add_hooks_parser(
         default=".",
         help=PROJECT_ROOT_HELP,
     )
+    hooks_install.add_argument(
+        "--global",
+        dest="global_install",
+        action="store_true",
+        help=(
+            "Install machine-wide via git's global core.hooksPath (applies to "
+            "every repo) instead of just this one. Delegates to repo-local "
+            "hooks and only acts in onboarded repos."
+        ),
+    )
 
     # commit-hooks uninstall
     hooks_uninstall = hooks_subparsers.add_parser(
@@ -613,6 +623,12 @@ def _add_hooks_parser(
         type=str,
         default=".",
         help=PROJECT_ROOT_HELP,
+    )
+    hooks_uninstall.add_argument(
+        "--global",
+        dest="global_install",
+        action="store_true",
+        help="Remove the machine-wide install and unset global core.hooksPath.",
     )
 
 

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -12,8 +12,17 @@ from slopmop.cli.hooks import (
     _generate_merged_branch_guard,
     _generate_pre_push_hook_script,
     _get_git_hooks_dir,
+    _global_hooks_dir,
     _parse_hook_info,
 )
+
+
+def _is_posix_sh(script: str) -> bool:
+    import tempfile
+
+    p = Path(tempfile.mktemp(suffix=".sh"))
+    p.write_text(script)
+    return subprocess.run(["sh", "-n", str(p)], capture_output=True).returncode == 0
 
 
 class TestGitHooksFunctions:
@@ -297,3 +306,42 @@ sm swab
         content = "#!/bin/sh\necho hello"
         result = _parse_hook_info(content)
         assert result is None
+
+
+class TestGlobalHooks:
+    """Machine-wide (core.hooksPath) hook generation."""
+
+    def test_global_dir_is_under_slopmop_home(self):
+        assert _global_hooks_dir() == Path.home() / ".slopmop" / "git-hooks"
+
+    def test_per_repo_hooks_have_no_global_preamble(self):
+        # Per-repo hooks run in their own repo — no delegation/onboarding guard.
+        assert "core.hooksPath" not in _generate_hook_script("swab")
+        assert "git rev-parse --show-toplevel" not in _generate_hook_script("swab")
+        assert "git rev-parse --show-toplevel" not in _generate_pre_push_hook_script()
+
+    def test_global_pre_commit_delegates_then_guards_onboarding(self):
+        script = _generate_hook_script("swab", global_install=True)
+        # Delegates to the repo-local hook so other tools keep working...
+        assert '"$_sm_local" "$@" || exit $?' in script
+        assert '_sm_local="$_sm_root/.git/hooks/pre-commit"' in script
+        # ...and only runs slop-mop in onboarded repos (else exit 0).
+        assert ".sb_config.json" in script and "tool.slopmop" in script
+        assert _is_posix_sh(script)
+
+    def test_global_pre_push_captures_stdin_and_feeds_guard(self):
+        script = _generate_pre_push_hook_script(global_install=True)
+        # stdin is slurped once, then fed to the delegated hook AND the guard.
+        assert "_sm_stdin=$(cat)" in script
+        assert 'printf \'%s\\n\' "$_sm_stdin" | "$_sm_local"' in script
+        # The merged-branch guard loop reads the refs back from a here-doc.
+        assert "done <<SLOPMOP_REFS" in script
+        # scour still runs, and the whole thing is valid POSIX sh.
+        assert "sm scour --porcelain" in script
+        assert _is_posix_sh(script)
+
+    def test_global_hook_marker_lets_delegation_skip_our_own_hooks(self):
+        # The delegation guard skips a local hook that is itself slop-mop's, so
+        # a per-repo install under a global install won't double-run.
+        script = _generate_hook_script("swab", global_install=True)
+        assert '! grep -q "# MANAGED BY SLOP-MOP" "$_sm_local"' in script

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -373,7 +373,7 @@ class TestGlobalHooks:
         for hook_name in _GLOBAL_PASSTHROUGH_HOOKS:
             script = _generate_passthrough_hook(hook_name)
             assert "# MANAGED BY SLOP-MOP" in script
-            assert f"/hooks/{hook_name}" in script
+            assert f"$(git rev-parse --git-dir 2>/dev/null)/hooks/{hook_name}" in script
             assert 'exec "$_sm_local" "$@"' in script
             assert _is_posix_sh(script), f"sh -n failed for passthrough {hook_name}"
 
@@ -397,9 +397,9 @@ class TestGlobalHooks:
         global_dir = fake_home / ".slopmop" / "git-hooks"
         assert (global_dir / "pre-commit").exists()
         assert (global_dir / "pre-push").exists()
-        # Passthrough hooks for other types should also be present.
-        assert (global_dir / "commit-msg").exists()
-        assert (global_dir / "prepare-commit-msg").exists()
+        # All passthrough hooks must be present.
+        for hook_name in _GLOBAL_PASSTHROUGH_HOOKS:
+            assert (global_dir / hook_name).exists(), f"missing global hook {hook_name}"
         out = capsys.readouterr().out
         assert "Machine-wide hooks installed" in out
         assert "core.hooksPath" in out

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -4,6 +4,7 @@ Covers pre-commit/pre-push hook script generation, the merged/deleted-branch
 guard's detection logic, and hook-info parsing.
 """
 
+import argparse
 import subprocess
 from pathlib import Path
 
@@ -14,15 +15,25 @@ from slopmop.cli.hooks import (
     _get_git_hooks_dir,
     _global_hooks_dir,
     _parse_hook_info,
+    cmd_commit_hooks,
 )
 
 
 def _is_posix_sh(script: str) -> bool:
     import tempfile
 
-    p = Path(tempfile.mktemp(suffix=".sh"))
-    p.write_text(script)
-    return subprocess.run(["sh", "-n", str(p)], capture_output=True).returncode == 0
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as tmp:
+        tmp.write(script)
+        p = Path(tmp.name)
+    try:
+        return (
+            subprocess.run(
+                ["sh", "-n", str(p)], capture_output=True, check=False
+            ).returncode
+            == 0
+        )
+    finally:
+        p.unlink(missing_ok=True)
 
 
 class TestGitHooksFunctions:
@@ -324,7 +335,10 @@ class TestGlobalHooks:
         script = _generate_hook_script("swab", global_install=True)
         # Delegates to the repo-local hook so other tools keep working...
         assert '"$_sm_local" "$@" || exit $?' in script
-        assert '_sm_local="$_sm_root/.git/hooks/pre-commit"' in script
+        assert (
+            '_sm_local="$(git rev-parse --git-dir 2>/dev/null)/hooks/pre-commit"'
+            in script
+        )
         # ...and only runs slop-mop in onboarded repos (else exit 0).
         assert ".sb_config.json" in script and "tool.slopmop" in script
         assert _is_posix_sh(script)
@@ -345,3 +359,80 @@ class TestGlobalHooks:
         # a per-repo install under a global install won't double-run.
         script = _generate_hook_script("swab", global_install=True)
         assert '! grep -q "# MANAGED BY SLOP-MOP" "$_sm_local"' in script
+
+    def test_global_worktree_delegation_uses_git_dir(self):
+        # The local hook path must use `git rev-parse --git-dir` so linked
+        # worktrees (where .git is a file, not a dir) resolve correctly.
+        script = _generate_hook_script("swab", global_install=True)
+        assert "$(git rev-parse --git-dir 2>/dev/null)/hooks/pre-commit" in script
+
+    def test_global_install_writes_hooks_and_sets_hooksPath(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """cmd_commit_hooks --global writes hooks and sets core.hooksPath."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        args = argparse.Namespace(
+            project_root=str(tmp_path),
+            hooks_action="install",
+            hook_verb="swab",
+            global_install=True,
+        )
+        result = cmd_commit_hooks(args)
+
+        assert result == 0
+        global_dir = fake_home / ".slopmop" / "git-hooks"
+        assert (global_dir / "pre-commit").exists()
+        assert (global_dir / "pre-push").exists()
+        out = capsys.readouterr().out
+        assert "Machine-wide hooks installed" in out
+        assert "core.hooksPath" in out
+        # Verify git actually recorded the path.
+        cfg = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert cfg.returncode == 0
+        assert cfg.stdout.strip() == str(global_dir)
+
+    def test_global_uninstall_removes_hooks_and_unsets_hooksPath(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """cmd_commit_hooks --global uninstall removes hooks and unsets core.hooksPath."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        # Install first so there's something to uninstall.
+        install_args = argparse.Namespace(
+            project_root=str(tmp_path),
+            hooks_action="install",
+            hook_verb="swab",
+            global_install=True,
+        )
+        assert cmd_commit_hooks(install_args) == 0
+        capsys.readouterr()  # discard install output
+
+        # Now uninstall.
+        uninstall_args = argparse.Namespace(
+            project_root=str(tmp_path),
+            hooks_action="uninstall",
+            global_install=True,
+        )
+        result = cmd_commit_hooks(uninstall_args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "global core.hooksPath" in out
+        # core.hooksPath should be gone.
+        cfg = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert cfg.returncode != 0  # key not found → exit 1

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -55,7 +55,7 @@ class TestGitHooksFunctions:
     def test_generate_pre_push_hook_script(self):
         """Generates pre-push merged-branch guard hook script."""
         script = _generate_pre_push_hook_script()
-        assert "# Command: merged-branch-guard" in script
+        assert "# Command: merged-branch-guard + sm scour" in script
         assert "gh pr list" in script
         assert "--state merged" in script
         assert "You're missing some context." in script
@@ -67,6 +67,19 @@ class TestGitHooksFunctions:
         # Deletions (all-zero local sha) write nothing and must be skipped.
         assert "0000000000000000000000000000000000000000" in script
         assert "git symbolic-ref" not in script
+
+    def test_pre_push_hook_runs_scour_after_guard(self):
+        """The pre-push hook runs a cached scour, after the merged-branch guard."""
+        script = _generate_pre_push_hook_script()
+        # scour runs, and reuses the swab cache (no --no-cache).
+        assert "sm scour --porcelain --json-file .slopmop/last_scour.json" in script
+        assert "--no-cache" not in script
+        # The guard's stdin loop must finish before scour starts, so the merged
+        # check happens first and scour doesn't consume the pushed refs.
+        assert script.index("\ndone\n") < script.index("sm scour --porcelain")
+        # A failing scour blocks the push, with the standard bypass.
+        assert "Push blocked by slop-mop scour" in script
+        assert "git push --no-verify" in script
 
     def test_precommit_hook_embeds_merged_branch_guard(self):
         """The pre-commit hook guards a merged/deleted branch before swab runs."""

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -9,8 +9,10 @@ import subprocess
 from pathlib import Path
 
 from slopmop.cli.hooks import (
+    _GLOBAL_PASSTHROUGH_HOOKS,
     _generate_hook_script,
     _generate_merged_branch_guard,
+    _generate_passthrough_hook,
     _generate_pre_push_hook_script,
     _get_git_hooks_dir,
     _global_hooks_dir,
@@ -366,6 +368,15 @@ class TestGlobalHooks:
         script = _generate_hook_script("swab", global_install=True)
         assert "$(git rev-parse --git-dir 2>/dev/null)/hooks/pre-commit" in script
 
+    def test_passthrough_hook_delegates_and_is_valid_posix_sh(self):
+        # Each passthrough hook should forward to the local hook and be POSIX sh.
+        for hook_name in _GLOBAL_PASSTHROUGH_HOOKS:
+            script = _generate_passthrough_hook(hook_name)
+            assert "# MANAGED BY SLOP-MOP" in script
+            assert f"/hooks/{hook_name}" in script
+            assert 'exec "$_sm_local" "$@"' in script
+            assert _is_posix_sh(script), f"sh -n failed for passthrough {hook_name}"
+
     def test_global_install_writes_hooks_and_sets_hooksPath(
         self, tmp_path, monkeypatch, capsys
     ):
@@ -386,6 +397,9 @@ class TestGlobalHooks:
         global_dir = fake_home / ".slopmop" / "git-hooks"
         assert (global_dir / "pre-commit").exists()
         assert (global_dir / "pre-push").exists()
+        # Passthrough hooks for other types should also be present.
+        assert (global_dir / "commit-msg").exists()
+        assert (global_dir / "prepare-commit-msg").exists()
         out = capsys.readouterr().out
         assert "Machine-wide hooks installed" in out
         assert "core.hooksPath" in out

--- a/tests/unit/test_sm_cli.py
+++ b/tests/unit/test_sm_cli.py
@@ -293,8 +293,11 @@ class TestCmdCommitHooks:
         pre_push_text = pre_push_file.read_text()
         assert "sm swab --porcelain" in pre_commit_text
         assert "--json-file .slopmop/last_swab.json" in pre_commit_text
-        assert "# Command: merged-branch-guard" in pre_push_text
+        assert "# Command: merged-branch-guard + sm scour" in pre_push_text
         assert "gh pr list" in pre_push_text
+        assert "sm scour --porcelain --json-file .slopmop/last_scour.json" in (
+            pre_push_text
+        )
 
     def test_uninstall_hook(self, tmp_path, capsys):
         """Uninstall removes managed pre-commit and pre-push hooks."""


### PR DESCRIPTION
\"I keep getting to CI only to find the scour failed.\" This PR has two parts:

## Part 1: scour on push

The native pre-push hook (`sm commit-hooks install`) now runs the full `sm scour` after the merged-branch guard — the same validation CI runs — so scour-only failures surface before the push, not on a red build.

### Why it's fast (the key concern)
The pre-commit swab already writes per-gate results to the cache, keyed by a per-gate fingerprint. The push scour **reuses** those, so only scour-only and changed gates run fresh. Measured on a sample repo:

| | wall-clock |
|---|---|
| cached scour (after swab) | **135 ms** |
| `--no-cache` scour | 3,647 ms |

≈ **27× faster**. Verified the full cycle: first scour after swab showed `6/38 cached` (swab gates reused), a second scour caches everything, and editing a file invalidates only the gates that touch it.

## Part 2: machine-wide install (`--global`)

Native git hooks are per-clone, not version-controlled — you'd have to re-run `sm commit-hooks install` in every repo. The `--global` flag fixes that:

```
sm commit-hooks install --global   # wires every repo on this machine
sm commit-hooks uninstall --global # removes it
```

Under the hood this writes hooks to `~/.slopmop/git-hooks/` and sets `git config --global core.hooksPath` to point there. The global hooks:
- **Delegate first** — if the repo already has a `.git/hooks/<name>` that isn't slopmop-managed, it runs that first so other tools' hooks are preserved.
- **Skip non-onboarded repos** — repos without `.sb_config.json` or `[tool.slopmop]` in `pyproject.toml` get `exit 0`; slopmop never touches them.
- **Prevent double-runs** — the delegation check skips slopmop-managed local hooks, so if you also have a per-repo install the hook doesn't fire twice.
- **Capture stdin correctly** — the pre-push variant slurps stdin once and feeds it to both the delegated hook and the merged-branch guard.

Both actions work outside a git repo (they target `~/.slopmop/git-hooks/`, not `.git/hooks/`).

## Behavior (pre-push hook)
- Merged-branch guard runs first (its stdin loop finishes before scour starts, so scour never consumes the pushed refs).
- A failing scour blocks the push with the structured results path and `git push --no-verify` to bypass once.
- Brings the **native git hooks to parity** with the pre-commit-framework path, which already ran `slopmop-scour` at the `pre-push` stage.

Generated POSIX-sh validated (`sh -n`); full suite (3300) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Native `pre-push` now runs the full `sm scour` validation after the merged/deleted-branch guard, reusing pre-commit swab cache so scour-only/changed gates are fast. Cached scour is ~135ms vs ~3,647ms uncached (~27×). A failing scour blocks pushes (one-time bypass: `git push --no-verify`). Behavior is aligned with the pre-commit framework.

Adds machine-wide installation via `sm commit-hooks install --global` / `uninstall --global`, using git `core.hooksPath` with global hook delegation to repo-local hooks for onboarded repos (skipping slopmop for non-onboarded repos). Includes safety/fixups: passthrough delegation for all hook types, worktree-safe hook paths, warning before overwriting non-slopmop `core.hooksPath`, friendlier global `git config` errors, and POSIX `sh -n` validation using race-free temp files.

## Changes

- `slopmop/cli/hooks.py`: refactors `pre-push` (guard → cached `sm scour`, writes `.slopmop/last_scour.json`) and implements `--global` hook install/uninstall with delegation/preamble.
- `slopmop/sm.py`: adds `commit-hooks install --global` and `commit-hooks uninstall --global`.
- `README.md`: updates documented commit/push flow, cache behavior, guard behavior, and `--no-verify`.
- `tests/unit/test_git_hooks.py`: adds `sh -n` validation, asserts guard→scour ordering and push-block messaging, and adds global hook generation/delegation/install-uninstall coverage.
- `tests/unit/test_sm_cli.py`: updates expected generated `pre-push` script content.
- `.willville.json`: updates agent metadata/timestamps.

All **3,300** tests pass; generated POSIX shell scripts are validated with `sh -n`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->