### PR TITLE
chore(release): add 2.7.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ body, so **a release cannot be published without a matching section here.**
 
 Format: one `## X.Y.Z` section per release, newest first.
 
+## 2.7.0
+
+### Hooks
+
+- **Scour on push** (#298) — native pre-push hook now runs the full `sm scour`
+  after the merged-branch guard. Reuses the swab cache so only scour-only and
+  changed gates run fresh (~135ms cached vs ~3.6s cold, 27× speedup).
+- **Machine-wide install** (#298) — `sm commit-hooks install --global` writes
+  hooks to `~/.slopmop/git-hooks/` and sets `git config --global core.hooksPath`
+  so every repo on the machine gets swab on commit + scour on push. Global hooks
+  delegate to each repo's own `.git/hooks` first (preserving other tools' hooks),
+  skip non-onboarded repos, and write passthrough delegation scripts for all
+  other hook types (commit-msg, prepare-commit-msg, post-checkout, etc.) so
+  `core.hooksPath` doesn't silently swallow them. `--global` also works on
+  install/uninstall.
+- **Status + UX** (#298) — `sm commit-hooks status` now surfaces an active
+  global install; per-repo install warns when global hooks are already shadowing
+  `.git/hooks`.
+
 ## 2.6.0
 
 ### New gates


### PR DESCRIPTION
Adds the `## 2.7.0` section required by the release workflow so the `Release #66` run (or a new dispatch) can complete.

## What's in 2.7.0

- **Scour on push** — native pre-push hook now runs `sm scour` after the merged-branch guard, reusing the swab cache (~135ms cached, 27× speedup vs cold).
- **Machine-wide install** — `sm commit-hooks install --global` sets `core.hooksPath` to `~/.slopmop/git-hooks/`, applying hooks to every repo. Delegates to per-repo hooks, skips non-onboarded repos, and writes passthrough delegation scripts for all other hook types (commit-msg, prepare-commit-msg, post-checkout, …) so `core.hooksPath` doesn't silently drop them.
- **Status + UX** — `sm commit-hooks status` surfaces active global install; per-repo install warns when global hooks are already shadowing `.git/hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a `2.7.0` release section to `CHANGELOG.md` documenting three hook-related features:

1. **Scour on push** — Native pre-push hook executing `sm scour` after merged-branch guard, leveraging swab cache for ~27× performance improvement
2. **Machine-wide install** — `sm commit-hooks install --global` capability setting `core.hooksPath` to `~/.slopmop/git-hooks/` with delegation scripts for other hook types
3. **Status + UX improvements** — New `sm commit-hooks status` command surfacing active global installs, with warnings when global hooks shadow `.git/hooks`

**Changes:** +19 lines to `CHANGELOG.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->