### PR TITLE
chore: bump version to 2.7.0 for PyPI release

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmop",
   "displayName": "slop-mop",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Quality gates for AI-assisted codebases — catch the slop LLMs leave behind. Wraps pytest, black, mypy, gh, and every other tool behind a single `sm` CLI with caching, ordering, and directed remediation built in.",
   "author": {
     "name": "ScienceIsNeato",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: slop-mop version
       description: "Output of `sm --version` (or the PyPI version installed)."
-      placeholder: "2.6.0"
+      placeholder: "2.7.0"
     validations:
       required: true
   - type: textarea

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 #
 #   repos:
 #     - repo: https://github.com/ScienceIsNeato/slop-mop
-#       rev: v2.6.0  # use the latest tag
+#       rev: v2.7.0  # use the latest tag
 #       hooks:
 #         - id: slopmop-swab
 #         - id: slopmop-scour

--- a/DOCS/MACHINE_INTERFACE.md
+++ b/DOCS/MACHINE_INTERFACE.md
@@ -185,7 +185,7 @@ sm capabilities
   "status": "info",
   "exit_code": 0,
   "data": {
-    "version": "2.6.0",
+    "version": "2.7.0",
     "verbs": [
       { "name": "swab", "summary": "…", "level": "core",
         "formats": ["human", "json", "porcelain", "sarif"],

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/ScienceIsNeato/slop-mop
-    rev: v2.6.0  # use the latest release tag
+    rev: v2.7.0  # use the latest release tag
     hooks:
       - id: slopmop-swab    # quick gates on every commit
       - id: slopmop-scour   # full PR-readiness suite on push

--- a/slopmop/_version.py
+++ b/slopmop/_version.py
@@ -11,4 +11,4 @@ automatically. Everything else derives from it:
   from this value, so a mismatch can never be merged.
 """
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"


### PR DESCRIPTION
Release 2.6.0 -> 2.7.0.

This PR was created by the Release workflow. After checks pass, the workflow merges it into main; the protected main-branch push then runs the publish path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Version Bump to 2.7.0

This PR updates the version from 2.6.0 to 2.7.0 across all relevant files:

- **slopmop/_version.py**: Updated `__version__` to `"2.7.0"`
- **.cursor-plugin/plugin.json**: Version field updated
- **DOCS/MACHINE_INTERFACE.md**: Example output version updated
- **README.md**: Pre-commit example configuration updated
- **.pre-commit-hooks.yaml**: Upstream reference updated
- **.github/ISSUE_TEMPLATE/bug_report.yml**: Example placeholder updated

All changes are mechanical version number updates. The Release workflow will automatically merge this PR and trigger the PyPI publish workflow upon successful checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->