### PR TITLE
chore(release): add 2.8.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ body, so **a release cannot be published without a matching section here.**
 
 Format: one `## X.Y.Z` section per release, newest first.
 
+## 2.8.0
+
+### Workflow
+
+- **`sm sail` drives to green on its own** (#302) — `sm sail` is now autonomous.
+  A single invocation runs the next workflow step (swab → scour → CI watch →
+  review triage) and keeps going until it parks on something only you can do —
+  fix a failing gate, commit, push, open the PR, resolve a review thread — or
+  the PR is ready for human review. It no longer stops after one step, so you
+  run one command instead of re-invoking it between every check. Commit, push,
+  and PR creation stay manual (they need an authored message and body), so sail
+  never mutates git or publishes on its own.
+- **One verb, the rest under the hood** (#302) — the agent-facing surface
+  collapses onto `sm sail`. `swab`, `scour`, and `buff` still exist for surgical
+  work, but the drive-to-green loop, the definition of done (a change isn't done
+  until sail reports *PR ready for human review*), and the command guidance all
+  route through sail. `/sm-sail` is the primary loop; `/sm-buff` is demoted to
+  the under-the-hood triage reference.
+
 ## 2.7.0
 
 ### Hooks


### PR DESCRIPTION
Adds the `## 2.8.0` section the release workflow requires, so the failing `Release #68` run (2.7.0 → 2.8.0) can proceed past **Prepare Release Context**.

## What's in 2.8.0

Covers [#302](https://github.com/ScienceIsNeato/slop-mop/pull/302) — the only feature merged since 2.7.0:

- **`sm sail` drives to green on its own** — a single `sm sail` runs the next workflow step (swab → scour → CI watch → review triage) and keeps going until it parks on something only you can do, or the PR is ready. It no longer stops after one step. Commit/push/PR-creation stay manual, so sail never mutates git or publishes on its own.
- **One verb, the rest under the hood** — the agent-facing surface collapses onto `sm sail`; `/sm-buff` is demoted to the under-the-hood triage reference, and `core.md`'s loop + definition-of-done route through sail.

## Note
Changelog only, matching the 2.7.0 pattern ([#300](https://github.com/ScienceIsNeato/slop-mop/pull/300)). If the release also needs a `pyproject`/version bump, that's the follow-up the release flow handled separately last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds `## 2.8.0` CHANGELOG entry documenting two key changes:

1. **Autonomous `sm sail` workflow** — The command now runs continuously through sequential steps (swab → scour → CI watch → review triage) until reaching a task requiring manual intervention or the PR is ready for merge, replacing the previous step-by-step behavior.

2. **Simplified agent-facing interface** — Collapses surface onto `sm sail`, while retaining `swab`, `scour`, and `buff` for targeted operations and demoting `/sm-buff` to internal triage reference.

This changelog-only change unblocks Release `#68` (2.7.0 → 2.8.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->