### PR TITLE
feat(gates): external-dependency contract + actionlint gate (doctor manifest groundwork)

### DIFF
--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -582,7 +582,7 @@ class Requirement:
             "name": self.name,
             "version": self.version,
             "optional": self.optional,
-            "alternatives": list(self.alternatives),
+            "alternatives": sorted(self.alternatives),
             "reason": self.reason,
         }
 

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -531,6 +531,86 @@ STANDARD_CONFIG_FIELDS = [
 ]
 
 
+# ── Gate external-dependency contract ────────────────────────────────
+#
+# Gates that shell out to external tools declare what they need here so a
+# single authority — ``sm doctor`` and, downstream, the GitHub Action — can
+# enumerate and install dependencies from one source of truth instead of each
+# gate detecting tools ad hoc (the scattered ``shutil.which`` problem).
+#
+# The manifest these produce is a CONSUMED CONTRACT (doctor reads it; the
+# Action installs from it), so its shape is versioned. Bump the schema version
+# on any breaking change to the serialized field set.
+REQUIREMENTS_MANIFEST_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """A single external dependency an enabled gate needs to run.
+
+    ``optional`` encodes the distinction that matters for a CI merge gate:
+
+    - **required** (``optional=False``) — the gate *cannot run* without it.
+      A missing required tool must surface a visible, non-green
+      "could-not-run" state, never a silent pass. (See
+      :meth:`BaseCheck.requirement_block_result`.)
+    - **optional** (``optional=True``) — the gate degrades but still runs;
+      a missing optional tool is reported (so doctor can recommend it) but
+      does not block.
+
+    ``version`` is an EXACT pin (e.g. ``"1.7.5"``), never a floor. The pin is
+    part of the gate definition — bumping a scanner can change findings — so it
+    is bumped deliberately via a reviewed change, not floated at install time.
+    ``None`` means "any present version is acceptable" (e.g. system ``git``).
+
+    ``alternatives`` lists interchangeable names that also satisfy the
+    requirement (any one present is enough) — for tools resolvable under more
+    than one binary name / install path.
+    """
+
+    kind: str  # "system" | "python" | "npm" | "env"
+    name: str
+    version: Optional[str] = None  # exact pin; None = any present version
+    reason: str = ""
+    optional: bool = False
+    alternatives: tuple[str, ...] = ()
+
+    def to_manifest(self) -> Dict[str, Any]:
+        """Serialize to the deterministic manifest shape doctor/the Action read."""
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "version": self.version,
+            "optional": self.optional,
+            "alternatives": list(self.alternatives),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class Requirements:
+    """The set of external dependencies a gate needs given its current config."""
+
+    items: tuple[Requirement, ...] = ()
+
+    def to_manifest(self) -> List[Dict[str, Any]]:
+        """Manifest entries, sorted by (kind, name) so output is byte-stable."""
+        ordered = sorted(self.items, key=lambda r: (r.kind, r.name))
+        return [r.to_manifest() for r in ordered]
+
+
+def build_requirements_document(requirements: "Requirements") -> Dict[str, Any]:
+    """Wrap requirement entries in a schema-versioned manifest document.
+
+    This is the unit doctor emits and the Action consumes. The
+    ``schema_version`` is mandatory and load-bearing: consumers pin on it.
+    """
+    return {
+        "schema_version": REQUIREMENTS_MANIFEST_SCHEMA_VERSION,
+        "requirements": requirements.to_manifest(),
+    }
+
+
 class BaseCheck(ABC):
     """Abstract base class for all quality gate checks.
 
@@ -751,6 +831,72 @@ class BaseCheck(ABC):
             List of all ConfigField definitions (standard + check-specific)
         """
         return STANDARD_CONFIG_FIELDS + self.config_schema
+
+    def requirements(self) -> Requirements:
+        """External tools/packages this gate needs to run, given its config.
+
+        The default is none. Gates that shell out to external tools (linters,
+        scanners, npm CLIs, ``gh``) override this so a single authority can
+        enumerate dependencies instead of each gate detecting tools ad hoc.
+
+        Return value is CONFIG-DEPENDENT: a gate whose tool is gated behind a
+        config flag should return an empty :class:`Requirements` when that flag
+        is off, so the manifest reflects only what *this* repo's config needs.
+        """
+        return Requirements()
+
+    def missing_requirements(self, project_root: str) -> List[Requirement]:
+        """Return the declared requirements whose tool can't be resolved.
+
+        Only ``system`` requirements are resolved in-process (via
+        :func:`find_tool`, honouring ``alternatives``); ``python``/``npm``/
+        ``env`` kinds are enumerated for doctor/the Action but not probed here
+        (that resolution belongs to the installing layer, not the gate).
+        """
+        missing: List[Requirement] = []
+        for req in self.requirements().items:
+            if req.kind != "system":
+                continue
+            candidates = (req.name, *req.alternatives)
+            if not any(find_tool(name, project_root) for name in candidates):
+                missing.append(req)
+        return missing
+
+    def requirement_block_result(
+        self, project_root: str, duration: float = 0.0
+    ) -> Optional[CheckResult]:
+        """Return an ERROR result if a REQUIRED tool is missing, else ``None``.
+
+        This is the "could-not-run" state: a required dependency that isn't
+        installed means the gate cannot do its job, and the run must be visibly
+        non-green rather than silently passing. ``ERROR`` fails the overall
+        verdict (``all_passed`` counts errors), so branch protection is not
+        bypassed by a broken environment.
+
+        Missing *optional* requirements return ``None`` here — the gate runs in
+        a degraded mode and reports the absence elsewhere (doctor recommends
+        the tool); they never block.
+
+        A gate that shells out to a required tool calls this at the top of
+        ``run()`` and returns the result if it is not ``None``.
+        """
+        required_missing = [
+            r for r in self.missing_requirements(project_root) if not r.optional
+        ]
+        if not required_missing:
+            return None
+        names = ", ".join(sorted(r.name for r in required_missing))
+        return self._create_result(
+            status=CheckStatus.ERROR,
+            duration=duration,
+            output=(
+                f"Cannot run {self.name}: required tool(s) not installed: "
+                f"{names}. Run `sm doctor` for the exact install commands, then "
+                f"re-run. (This is an environment failure, not a code failure — "
+                f"the gate did not run.)"
+            ),
+            error=f"missing required tools: {names}",
+        )
 
     def init_config(self, project_root: str) -> Dict[str, Any]:
         """Return init-time config overrides discovered by this gate.

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -845,20 +845,38 @@ class BaseCheck(ABC):
         """
         return Requirements()
 
+    def resolve_requirement_path(
+        self, req: Requirement, project_root: str
+    ) -> Optional[str]:
+        """Resolve a ``system`` requirement to an executable path, or ``None``.
+
+        Tries the declared name and every ``alternatives`` entry (any one
+        satisfies it), via the venv-aware :func:`find_tool`. This is the SINGLE
+        resolution path: both :meth:`missing_requirements` (what doctor reports)
+        and a gate's own tool lookup (what the gate runs) go through it, so
+        "declared as present" and "the gate found it" can never disagree.
+        """
+        if req.kind != "system":
+            return None
+        for candidate in (req.name, *req.alternatives):
+            path = find_tool(candidate, project_root)
+            if path:
+                return path
+        return None
+
     def missing_requirements(self, project_root: str) -> List[Requirement]:
         """Return the declared requirements whose tool can't be resolved.
 
         Only ``system`` requirements are resolved in-process (via
-        :func:`find_tool`, honouring ``alternatives``); ``python``/``npm``/
-        ``env`` kinds are enumerated for doctor/the Action but not probed here
-        (that resolution belongs to the installing layer, not the gate).
+        :meth:`resolve_requirement_path`, honouring ``alternatives``);
+        ``python``/``npm``/``env`` kinds are enumerated for doctor/the Action
+        but not probed here (that resolution belongs to the installing layer).
         """
         missing: List[Requirement] = []
         for req in self.requirements().items:
             if req.kind != "system":
                 continue
-            candidates = (req.name, *req.alternatives)
-            if not any(find_tool(name, project_root) for name in candidates):
+            if self.resolve_requirement_path(req, project_root) is None:
                 missing.append(req)
         return missing
 

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import re
-import shutil
 import time
 from pathlib import Path
 from typing import ClassVar, Iterable, Iterator, List, Optional, cast
@@ -17,7 +16,10 @@ from slopmop.checks.base import (
     GateCategory,
     GateLevel,
     RemediationChurn,
+    Requirement,
+    Requirements,
     ToolContext,
+    find_tool,
 )
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -264,6 +266,40 @@ class GitHubActionsHygieneCheck(BaseCheck):
             ),
         ]
 
+    def requirements(self) -> Requirements:
+        """actionlint, declared so doctor/the Action can offer to install it.
+
+        Optional: the gate's native workflow-hygiene checks run regardless;
+        actionlint adds deeper syntax linting. Config-gated — when
+        ``run_actionlint`` is off, this repo needs nothing here.
+        """
+        if not self.config.get("run_actionlint", True):
+            return Requirements()
+        return Requirements(
+            items=(
+                Requirement(
+                    kind="system",
+                    name="actionlint",
+                    reason=(
+                        "lints GitHub Actions workflow syntax beyond "
+                        "slop-mop's native checks"
+                    ),
+                    optional=True,  # native checks still run without it
+                ),
+            )
+        )
+
+    def _actionlint_path(self, project_root: str) -> Optional[str]:
+        """Resolve the actionlint executable via the declared requirement.
+
+        Single detection path (venv-aware ``find_tool``) instead of an inline
+        ``shutil.which`` — so "what the gate looks for" and "what the gate
+        declares" can never drift.
+        """
+        if not self.config.get("run_actionlint", True):
+            return None
+        return find_tool("actionlint", project_root)
+
     def is_applicable(self, project_root: str) -> bool:
         root = Path(project_root)
         workflow_dirs = self.config.get("workflow_dirs") or [".github/workflows"]
@@ -294,7 +330,7 @@ class GitHubActionsHygieneCheck(BaseCheck):
             findings.extend(self._workflow_findings(workflow, rel_path, lines))
             findings.extend(self._actionlint_findings(path, root))
             actionlint_available = (
-                actionlint_available or shutil.which("actionlint") is not None
+                actionlint_available or self._actionlint_path(str(root)) is not None
             )
 
         elapsed = time.perf_counter() - start
@@ -448,11 +484,10 @@ class GitHubActionsHygieneCheck(BaseCheck):
         return findings
 
     def _actionlint_findings(self, path: Path, root: Path) -> list[Finding]:
-        if not self.config.get("run_actionlint", True) or not shutil.which(
-            "actionlint"
-        ):
+        actionlint = self._actionlint_path(str(root))
+        if not actionlint:
             return []
-        result = self._runner.run(["actionlint", str(path)], cwd=str(root), timeout=30)
+        result = self._runner.run([actionlint, str(path)], cwd=str(root), timeout=30)
         if result.returncode == 0:
             return []
         findings: list[Finding] = []

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -314,7 +314,8 @@ class GitHubActionsHygieneCheck(BaseCheck):
         workflow_dirs = self.config.get("workflow_dirs") or [".github/workflows"]
         workflows = _workflow_files(root, workflow_dirs)
         findings: list[Finding] = []
-        actionlint_available = False
+        # Resolve actionlint once per run, not once per workflow file.
+        actionlint_path = self._actionlint_path(str(root))
 
         for path in workflows:
             rel_path = _rel(path, root)
@@ -328,16 +329,13 @@ class GitHubActionsHygieneCheck(BaseCheck):
                 continue
 
             findings.extend(self._workflow_findings(workflow, rel_path, lines))
-            findings.extend(self._actionlint_findings(path, root))
-            actionlint_available = (
-                actionlint_available or self._actionlint_path(str(root)) is not None
-            )
+            findings.extend(self._actionlint_findings(path, root, actionlint_path))
 
         elapsed = time.perf_counter() - start
         if not findings:
             note = (
                 "actionlint checked"
-                if actionlint_available
+                if actionlint_path is not None
                 else "actionlint not installed"
             )
             return self._create_result(
@@ -483,8 +481,9 @@ class GitHubActionsHygieneCheck(BaseCheck):
                 )
         return findings
 
-    def _actionlint_findings(self, path: Path, root: Path) -> list[Finding]:
-        actionlint = self._actionlint_path(str(root))
+    def _actionlint_findings(
+        self, path: Path, root: Path, actionlint: Optional[str]
+    ) -> list[Finding]:
         if not actionlint:
             return []
         result = self._runner.run([actionlint, str(path)], cwd=str(root), timeout=30)

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -19,7 +19,6 @@ from slopmop.checks.base import (
     Requirement,
     Requirements,
     ToolContext,
-    find_tool,
 )
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -290,15 +289,19 @@ class GitHubActionsHygieneCheck(BaseCheck):
         )
 
     def _actionlint_path(self, project_root: str) -> Optional[str]:
-        """Resolve the actionlint executable via the declared requirement.
+        """Resolve actionlint via the gate's own declared requirement.
 
-        Single detection path (venv-aware ``find_tool``) instead of an inline
-        ``shutil.which`` — so "what the gate looks for" and "what the gate
-        declares" can never drift.
+        Resolves whatever the requirement declares (name + ``alternatives``)
+        through the shared :meth:`BaseCheck.resolve_requirement_path`, so the
+        gate runs exactly the tool ``missing_requirements``/doctor consider
+        satisfied — "what the gate looks for" and "what it declares" can't
+        drift. Returns ``None`` when ``run_actionlint`` is off (no requirement
+        declared) or the tool isn't found.
         """
-        if not self.config.get("run_actionlint", True):
-            return None
-        return find_tool("actionlint", project_root)
+        for req in self.requirements().items:
+            if req.name == "actionlint":
+                return self.resolve_requirement_path(req, project_root)
+        return None
 
     def is_applicable(self, project_root: str) -> bool:
         root = Path(project_root)

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -333,11 +333,12 @@ class GitHubActionsHygieneCheck(BaseCheck):
 
         elapsed = time.perf_counter() - start
         if not findings:
-            note = (
-                "actionlint checked"
-                if actionlint_path is not None
-                else "actionlint not installed"
-            )
+            if not self.config.get("run_actionlint", True):
+                note = "actionlint disabled"
+            elif actionlint_path is not None:
+                note = "actionlint checked"
+            else:
+                note = "actionlint not installed"
             return self._create_result(
                 status=CheckStatus.PASSED,
                 duration=elapsed,

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -1,0 +1,194 @@
+"""Tests for the gate external-dependency contract.
+
+Covers the ``Requirement``/``Requirements`` declaration shape, the manifest
+serialization (schema version + determinism), the in-process detection of
+missing system tools, and the three-state result model: a missing *required*
+tool yields a non-green ``ERROR`` (could-not-run), while a missing *optional*
+tool does not block. The actionlint gate is the first real consumer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from slopmop.checks.base import (
+    REQUIREMENTS_MANIFEST_SCHEMA_VERSION,
+    BaseCheck,
+    CheckRole,
+    Flaw,
+    GateCategory,
+    Requirement,
+    Requirements,
+    ToolContext,
+    build_requirements_document,
+)
+from slopmop.checks.workflow import GitHubActionsHygieneCheck
+from slopmop.core.result import CheckResult, CheckStatus
+
+
+class _ToollessGate(BaseCheck):
+    """Minimal gate that declares no requirements (exercises the default)."""
+
+    tool_context = ToolContext.PURE
+
+    @property
+    def name(self) -> str:
+        return "toolless"
+
+    @property
+    def display_name(self) -> str:
+        return "toolless"
+
+    @property
+    def gate_description(self) -> str:
+        return "no external tools"
+
+    @property
+    def category(self) -> GateCategory:
+        return GateCategory.MYOPIA
+
+    @property
+    def flaw(self) -> Flaw:
+        return Flaw.MYOPIA
+
+    def is_applicable(self, project_root: str) -> bool:
+        return True
+
+    def run(self, project_root: str) -> CheckResult:
+        return self._create_result(status=CheckStatus.PASSED, duration=0.0)
+
+
+class _RequiredToolGate(_ToollessGate):
+    """Gate that hard-requires a tool — exercises the could-not-run path."""
+
+    @property
+    def name(self) -> str:
+        return "needs-frobnicate"
+
+    def requirements(self) -> Requirements:
+        return Requirements(
+            items=(
+                Requirement(
+                    kind="system",
+                    name="frobnicate",
+                    reason="frobnicates the thing",
+                    optional=False,
+                ),
+            )
+        )
+
+    def run(self, project_root: str) -> CheckResult:
+        blocked = self.requirement_block_result(project_root)
+        if blocked is not None:
+            return blocked
+        return self._create_result(status=CheckStatus.PASSED, duration=0.0)
+
+
+class TestRequirementContract:
+    def test_default_requirements_is_empty(self):
+        assert _ToollessGate({}).requirements().items == ()
+
+    def test_actionlint_declared_when_enabled(self):
+        reqs = GitHubActionsHygieneCheck({"run_actionlint": True}).requirements()
+        names = {r.name for r in reqs.items}
+        assert names == {"actionlint"}
+        (req,) = reqs.items
+        assert req.kind == "system"
+        assert req.optional is True  # native checks still run without it
+
+    def test_actionlint_not_declared_when_disabled(self):
+        reqs = GitHubActionsHygieneCheck({"run_actionlint": False}).requirements()
+        assert reqs.items == ()
+
+
+class TestMissingDetection:
+    def test_missing_system_tool_is_reported(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda name, root: None)
+        gate = _RequiredToolGate({})
+        missing = gate.missing_requirements(str(tmp_path))
+        assert [r.name for r in missing] == ["frobnicate"]
+
+    def test_present_system_tool_is_not_reported(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "slopmop.checks.base.find_tool", lambda name, root: f"/usr/bin/{name}"
+        )
+        gate = _RequiredToolGate({})
+        assert gate.missing_requirements(str(tmp_path)) == []
+
+    def test_alternatives_satisfy_requirement(self, monkeypatch, tmp_path):
+        # Only the alternative is present; the requirement is still satisfied.
+        def fake_find(name: str, root: str):
+            return "/usr/bin/podman" if name == "podman" else None
+
+        monkeypatch.setattr("slopmop.checks.base.find_tool", fake_find)
+
+        class _AltGate(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(
+                        Requirement(
+                            kind="system",
+                            name="docker",
+                            alternatives=("podman",),
+                        ),
+                    )
+                )
+
+        assert _AltGate({}).missing_requirements(str(tmp_path)) == []
+
+
+class TestThreeStateResult:
+    def test_missing_required_tool_yields_error_not_pass(self, monkeypatch, tmp_path):
+        # The whole point: a required tool that isn't installed must be a
+        # visible, non-green ERROR — never a silent PASSED.
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda name, root: None)
+        result = _RequiredToolGate({}).run(str(tmp_path))
+        assert result.status == CheckStatus.ERROR
+        # ERROR fails the overall verdict (all_passed counts errors), so branch
+        # protection is not bypassed by a broken environment.
+        assert not result.passed
+        assert "frobnicate" in (result.error or "")
+
+    def test_present_required_tool_lets_gate_run(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "slopmop.checks.base.find_tool", lambda name, root: f"/usr/bin/{name}"
+        )
+        result = _RequiredToolGate({}).run(str(tmp_path))
+        assert result.status == CheckStatus.PASSED
+
+    def test_missing_optional_tool_does_not_block(self, monkeypatch, tmp_path):
+        # actionlint is optional — its absence must NOT produce an ERROR.
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda name, root: None)
+        gate = GitHubActionsHygieneCheck({"run_actionlint": True})
+        assert gate.requirement_block_result(str(tmp_path)) is None
+
+
+class TestManifestDeterminism:
+    def _scrambled(self) -> Requirements:
+        # Deliberately out of (kind, name) order.
+        return Requirements(
+            items=(
+                Requirement(kind="system", name="node"),
+                Requirement(kind="python", name="bandit", version="1.7.5"),
+                Requirement(kind="system", name="actionlint"),
+                Requirement(kind="env", name="GH_TOKEN", optional=False),
+            )
+        )
+
+    def test_manifest_is_sorted_and_stable(self):
+        manifest = self._scrambled().to_manifest()
+        order = [(e["kind"], e["name"]) for e in manifest]
+        assert order == sorted(order)
+        # Byte-stable across repeated serialization (no set/dict ordering leak).
+        first = json.dumps(self._scrambled().to_manifest(), sort_keys=True)
+        second = json.dumps(self._scrambled().to_manifest(), sort_keys=True)
+        assert first == second
+
+    def test_document_carries_schema_version(self):
+        doc = build_requirements_document(self._scrambled())
+        assert doc["schema_version"] == REQUIREMENTS_MANIFEST_SCHEMA_VERSION
+        assert isinstance(doc["requirements"], list)
+        # Pinned version round-trips for the consumer to install exactly.
+        bandit = next(r for r in doc["requirements"] if r["name"] == "bandit")
+        assert bandit["version"] == "1.7.5"

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -10,12 +10,10 @@ tool does not block. The actionlint gate is the first real consumer.
 from __future__ import annotations
 
 import json
-from typing import List
 
 from slopmop.checks.base import (
     REQUIREMENTS_MANIFEST_SCHEMA_VERSION,
     BaseCheck,
-    CheckRole,
     Flaw,
     GateCategory,
     Requirement,

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -135,6 +135,35 @@ class TestMissingDetection:
 
         assert _AltGate({}).missing_requirements(str(tmp_path)) == []
 
+    def test_path_resolution_and_missing_agree_on_alternatives(
+        self, monkeypatch, tmp_path
+    ):
+        # The gate's own tool lookup and missing_requirements must agree: if an
+        # alternative satisfies the requirement, the gate must resolve it (not
+        # silently skip while doctor reports it present).
+        def fake_find(name: str, root: str):
+            return "/usr/bin/actionlint-bin" if name == "actionlint-bin" else None
+
+        monkeypatch.setattr("slopmop.checks.base.find_tool", fake_find)
+
+        class _AltActionlint(GitHubActionsHygieneCheck):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(
+                        Requirement(
+                            kind="system",
+                            name="actionlint",
+                            alternatives=("actionlint-bin",),
+                            optional=True,
+                        ),
+                    )
+                )
+
+        gate = _AltActionlint({"run_actionlint": True})
+        # Both views agree the requirement is satisfied via the alternative.
+        assert gate.missing_requirements(str(tmp_path)) == []
+        assert gate._actionlint_path(str(tmp_path)) == "/usr/bin/actionlint-bin"
+
 
 class TestThreeStateResult:
     def test_missing_required_tool_yields_error_not_pass(self, monkeypatch, tmp_path):

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -390,7 +390,8 @@ jobs:
         # The pass note must distinguish disabled / checked / not-installed —
         # all three states, not just one (#305 review).
         _write_workflow(tmp_path, "name: CI\non: push\n")
-        find_tool = "slopmop.checks.workflow.github_actions.find_tool"
+        # Resolution flows through the shared base helper now, not the gate.
+        find_tool = "slopmop.checks.base.find_tool"
 
         # 1. Disabled by config → "disabled".
         disabled = GitHubActionsHygieneCheck({"run_actionlint": False}).run(

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -386,13 +386,33 @@ jobs:
         # Config-disabled gates don't resolve actionlint at all.
         assert _check()._actionlint_path(str(tmp_path)) is None
 
-    def test_passed_note_distinguishes_disabled_from_missing(self, tmp_path):
-        # A clean run with actionlint OFF must say "disabled", not "not
-        # installed" — they are different states (#305 review).
+    def test_passed_note_distinguishes_all_three_states(self, tmp_path):
+        # The pass note must distinguish disabled / checked / not-installed —
+        # all three states, not just one (#305 review).
         _write_workflow(tmp_path, "name: CI\non: push\n")
-        result = GitHubActionsHygieneCheck({"run_actionlint": False}).run(str(tmp_path))
-        assert result.status == CheckStatus.PASSED
-        assert "actionlint disabled" in result.output
+        find_tool = "slopmop.checks.workflow.github_actions.find_tool"
+
+        # 1. Disabled by config → "disabled".
+        disabled = GitHubActionsHygieneCheck({"run_actionlint": False}).run(
+            str(tmp_path)
+        )
+        assert disabled.status == CheckStatus.PASSED
+        assert "actionlint disabled" in disabled.output
+
+        # 2. Enabled + resolvable + clean run → "checked".
+        check = GitHubActionsHygieneCheck({"run_actionlint": True})
+        clean = MagicMock(returncode=0, output="")
+        with patch(find_tool, return_value="/usr/bin/actionlint"):
+            with patch.object(check._runner, "run", return_value=clean):
+                checked = check.run(str(tmp_path))
+        assert "actionlint checked" in checked.output
+
+        # 3. Enabled + not resolvable → "not installed".
+        with patch(find_tool, return_value=None):
+            missing = GitHubActionsHygieneCheck({"run_actionlint": True}).run(
+                str(tmp_path)
+            )
+        assert "actionlint not installed" in missing.output
 
     def test_with_repo_relative_file_handles_no_file_and_outside_root(self, tmp_path):
         check = _check()

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -386,6 +386,14 @@ jobs:
         # Config-disabled gates don't resolve actionlint at all.
         assert _check()._actionlint_path(str(tmp_path)) is None
 
+    def test_passed_note_distinguishes_disabled_from_missing(self, tmp_path):
+        # A clean run with actionlint OFF must say "disabled", not "not
+        # installed" — they are different states (#305 review).
+        _write_workflow(tmp_path, "name: CI\non: push\n")
+        result = GitHubActionsHygieneCheck({"run_actionlint": False}).run(str(tmp_path))
+        assert result.status == CheckStatus.PASSED
+        assert "actionlint disabled" in result.output
+
     def test_with_repo_relative_file_handles_no_file_and_outside_root(self, tmp_path):
         check = _check()
         no_file = check._with_repo_relative_file(Finding(message="x"), tmp_path)

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -402,9 +402,11 @@ jobs:
         # 2. Enabled + resolvable + clean run → "checked".
         check = GitHubActionsHygieneCheck({"run_actionlint": True})
         clean = MagicMock(returncode=0, output="")
-        with patch(find_tool, return_value="/usr/bin/actionlint"):
-            with patch.object(check._runner, "run", return_value=clean):
-                checked = check.run(str(tmp_path))
+        with (
+            patch(find_tool, return_value="/usr/bin/actionlint"),
+            patch.object(check._runner, "run", return_value=clean),
+        ):
+            checked = check.run(str(tmp_path))
         assert "actionlint checked" in checked.output
 
         # 3. Enabled + not resolvable → "not installed".

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -346,9 +346,11 @@ jobs:
             output=f"{workflow}:2:5: bad event [syntax-check]\n",
         )
 
-        with patch("shutil.which", return_value="/usr/bin/actionlint"):
-            with patch.object(check._runner, "run", return_value=mock_result):
-                findings = check._actionlint_findings(workflow, tmp_path)
+        # Detection now happens once in run(); the resolved path is passed in.
+        with patch.object(check._runner, "run", return_value=mock_result):
+            findings = check._actionlint_findings(
+                workflow, tmp_path, "/usr/bin/actionlint"
+            )
 
         assert findings[0].rule_id == "actionlint:syntax-check"
         assert findings[0].file == ".github/workflows/ci.yml"
@@ -359,9 +361,10 @@ jobs:
         check = GitHubActionsHygieneCheck({"run_actionlint": True})
         mock_result = MagicMock(returncode=1, output="plain failure")
 
-        with patch("shutil.which", return_value="/usr/bin/actionlint"):
-            with patch.object(check._runner, "run", return_value=mock_result):
-                findings = check._actionlint_findings(workflow, tmp_path)
+        with patch.object(check._runner, "run", return_value=mock_result):
+            findings = check._actionlint_findings(
+                workflow, tmp_path, "/usr/bin/actionlint"
+            )
 
         assert findings[0].rule_id == "actionlint"
         assert findings[0].message == "plain failure"
@@ -371,11 +374,17 @@ jobs:
         check = GitHubActionsHygieneCheck({"run_actionlint": True})
         mock_result = MagicMock(returncode=0, output="")
 
-        with patch("shutil.which", return_value="/usr/bin/actionlint"):
-            with patch.object(check._runner, "run", return_value=mock_result):
-                assert check._actionlint_findings(workflow, tmp_path) == []
+        # Exit 0 → no findings even with actionlint resolved.
+        with patch.object(check._runner, "run", return_value=mock_result):
+            assert (
+                check._actionlint_findings(workflow, tmp_path, "/usr/bin/actionlint")
+                == []
+            )
 
-        assert _check()._actionlint_findings(workflow, tmp_path) == []
+        # No resolved path (unfound/disabled) → no findings, no subprocess.
+        assert check._actionlint_findings(workflow, tmp_path, None) == []
+        # Config-disabled gates don't resolve actionlint at all.
+        assert _check()._actionlint_path(str(tmp_path)) is None
 
     def test_with_repo_relative_file_handles_no_file_and_outside_root(self, tmp_path):
         check = _check()


### PR DESCRIPTION
First step of the "doctor owns what scour needs" plan. Gates declare their external dependencies in a structured, versioned contract so a single authority (`sm doctor`, then the GitHub Action) can enumerate and install them — replacing the scattered `shutil.which` detection that makes "what a gate needs" implicit knowledge.

**Gates-first, by design.** Doctor changes are mechanical *if* gates can speak for themselves; this lands the contract + converts one gate to prove the shape before touching the other 40.

## The contract (`slopmop/checks/base.py`)

- **`Requirement` / `Requirements`** dataclasses. `version` is an **exact pin**, never a floor — a scanner's version is part of the gate definition (bumping bandit changes findings), so it's bumped via a reviewed change, not floated at install time. We explicitly walked back auto-upgrade for this reason.
- **`REQUIREMENTS_MANIFEST_SCHEMA_VERSION` + `build_requirements_document()`** — the manifest is a *consumed contract* (doctor emits it, the Action installs from it), so it's schema-versioned from day one. `to_manifest()` sorts by `(kind, name)` for **byte-stable, cacheable** output (the constraint that keeps Action spend bounded — the Action can cache-key on the manifest).
- **`BaseCheck.requirements()`** (default empty), **`missing_requirements()`** (venv-aware `find_tool`, honours `alternatives`), and **`requirement_block_result()`** — the **three-state model**:
  - required tool missing → **`ERROR`** (could-not-run; fails the verdict — `all_passed` counts errors — so a broken environment can't silently pass a merge gate)
  - optional tool missing → does **not** block
  - not-applicable → unchanged

  This directly fixes the silent-decay risk: today the actionlint path returns `PASSED` when actionlint is absent. The mechanism to make a *required* missing tool non-green now exists.

## First consumer (`github_actions.py`)

The actionlint gate declares actionlint as an **optional, config-gated** requirement and resolves it through **one** `find_tool` path instead of two inline `shutil.which` calls — so "what the gate looks for" and "what it declares" can't drift. Behavior-preserving (actionlint stays optional), but now visible to doctor.

## Tests
`tests/unit/test_gate_requirements.py` — default-empty, config-gated declaration, missing/present/alternatives detection, **required→ERROR vs optional→no-block**, and manifest **determinism + schema version**. Full suite green (3320).

## Follow-ups (not here)
1. Convert the hard cases (`security` multi-scanner, `duplicate_strings` fallback chain) — they shape the API.
2. Convert the rest by category; wire `requirement_block_result` into required-tool gates' `run()`.
3. Registry enforcement test (every gate overrides `requirements()`) — **must land last**, after all 41 are converted.
4. `sm doctor --required-deps` manifest emitter → then the **v2** Action consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Introduces a versioned external-dependency contract for gates (for future `sm doctor` / Action integration) and updates the first consumer: the GitHub Actions hygiene gate’s `actionlint` handling.

### Key changes
- **Dependency contract (`slopmop/checks/base.py`)**: Adds `Requirement`/`Requirements` dataclasses with **exact pinned versions** and a **schema-versioned, byte-stable** `build_requirements_document()` manifest (stable ordering by `(kind, name)` and **sorted `alternatives`** for determinism/caching).
- **Three-state dependency gating**: `BaseCheck` adds `requirements()` (default empty), `missing_requirements(project_root)` (system tools resolved locally with alternatives), and `requirement_block_result()` implementing **missing required → `ERROR` (fail)** vs **missing optional → no-block**.
- **First consumer (`github_actions.py`)**: Declares **`actionlint` as optional and config-gated**; resolves the executable **once per run** via `find_tool()` and threads it into `_actionlint_findings()`. The pass note distinguishes:
  - “actionlint disabled” (config off)
  - “actionlint checked” (resolved)
  - “actionlint not installed” (optional missing)

### Tests
- Adds `tests/unit/test_gate_requirements.py` for default/config-gating, missing/present/alternatives detection, required vs optional semantics, and manifest determinism/schema versioning.
- Updates `tests/unit/test_github_actions_hygiene.py` to validate resolved/disabled/None behavior and the three-state pass note wording (no `shutil.which` patching).
- Full suite passes (**3320 tests**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->