### PR TITLE
feat(gates): convert security + duplicate-strings (hard-case requirements)

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Made `sm sail` drive a change all the way to a green PR on its own, so there's one command to run instead of a handful — PR #302, green",
-    "direction": "Point everyone at that single command and tuck the rest of the tooling behind it",
-    "last_update": "2026-06-19T22:01:00Z"
+    "status": "Teaching each check to declare what tools it needs, so one place can install them — did the two tricky ones (security scanners, duplicate-strings) on PR #306, stacked on #305",
+    "direction": "Convert the rest of the checks the same way, then let doctor read the list and have the GitHub Action install from it",
+    "last_update": "2026-06-20T02:25:00Z"
   }
 }

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -923,7 +923,9 @@ class BaseCheck(ABC):
             names += [alt.replace("-", "_") for alt in req.alternatives]
             return any(_module_available(name) for name in names)
         if probe == "env":
-            return bool(os.environ.get(req.name))
+            # Honour alternatives like binary/import do (e.g. GH_TOKEN with a
+            # GITHUB_TOKEN alternative) — any one set satisfies it.
+            return any(os.environ.get(n) for n in (req.name, *req.alternatives))
         return True  # "none" — defer to the installing layer
 
     def missing_requirements(self, project_root: str) -> List[Requirement]:

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -261,6 +261,22 @@ def find_tool(name: str, project_root: str) -> Optional[str]:
     return shutil.which(name)
 
 
+def _module_available(import_name: str) -> bool:
+    """Return True if a Python module is importable, without importing it.
+
+    Uses ``importlib.util.find_spec`` rather than ``import_module``: importing
+    some packages (e.g. bandit) pulls in stevedore, which enumerates every
+    entry-point plugin and logs a WARNING per failed load. ``find_spec`` probes
+    the import machinery without executing the target package.
+    """
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
 # Non-dot directories to exclude from scope counting (dot-prefixed directories
 # are always excluded automatically via should_prune_dir()).
 SCOPE_EXCLUDED_DIRS = {
@@ -566,14 +582,26 @@ class Requirement:
     ``alternatives`` lists interchangeable names that also satisfy the
     requirement (any one present is enough) — for tools resolvable under more
     than one binary name / install path.
+
+    ``kind`` is the INSTALL channel (how the Action installs it); ``probe`` is
+    how presence is DETECTED — they are orthogonal. A pip-installed tool that's
+    invoked as a binary (e.g. ``semgrep``) is ``kind="python", probe="binary"``.
+    ``probe`` defaults per kind: python→import, system/npm→binary, env→env.
+
+    ``import_name`` is the module to probe when ``probe="import"`` and the
+    install name differs from the import name (e.g. ``detect-secrets`` installs
+    under that name but imports as ``detect_secrets``). Empty ⇒ derive from
+    ``name`` by replacing ``-`` with ``_``.
     """
 
-    kind: str  # "system" | "python" | "npm" | "env"
+    kind: str  # "system" | "python" | "npm" | "env"  — the install channel
     name: str
     version: Optional[str] = None  # exact pin; None = any present version
     reason: str = ""
     optional: bool = False
     alternatives: tuple[str, ...] = ()
+    probe: str = ""  # "" = default by kind; "binary" | "import" | "env" | "none"
+    import_name: str = ""  # for probe="import" when it differs from name
 
     def to_manifest(self) -> Dict[str, Any]:
         """Serialize to the deterministic manifest shape doctor/the Action read."""
@@ -583,6 +611,8 @@ class Requirement:
             "version": self.version,
             "optional": self.optional,
             "alternatives": sorted(self.alternatives),
+            "probe": self.probe,
+            "import_name": self.import_name,
             "reason": self.reason,
         }
 
@@ -845,18 +875,31 @@ class BaseCheck(ABC):
         """
         return Requirements()
 
+    @staticmethod
+    def _effective_probe(req: Requirement) -> str:
+        """How to detect this requirement's presence (``probe`` or kind default)."""
+        if req.probe:
+            return req.probe
+        return {
+            "python": "import",
+            "system": "binary",
+            "npm": "binary",
+            "env": "env",
+        }.get(req.kind, "binary")
+
     def resolve_requirement_path(
         self, req: Requirement, project_root: str
     ) -> Optional[str]:
-        """Resolve a ``system`` requirement to an executable path, or ``None``.
+        """Resolve a binary-probed requirement to an executable path, or ``None``.
 
         Tries the declared name and every ``alternatives`` entry (any one
-        satisfies it), via the venv-aware :func:`find_tool`. This is the SINGLE
-        resolution path: both :meth:`missing_requirements` (what doctor reports)
-        and a gate's own tool lookup (what the gate runs) go through it, so
-        "declared as present" and "the gate found it" can never disagree.
+        satisfies it), via the venv-aware :func:`find_tool`. Only meaningful for
+        binary-probed requirements (a Python import has no path); returns
+        ``None`` otherwise. A gate that needs to *invoke* a tool resolves it
+        here, the same path :meth:`is_requirement_satisfied` checks — so "the
+        gate found it" and "declared satisfied" can never disagree.
         """
-        if req.kind != "system":
+        if self._effective_probe(req) != "binary":
             return None
         for candidate in (req.name, *req.alternatives):
             path = find_tool(candidate, project_root)
@@ -864,21 +907,37 @@ class BaseCheck(ABC):
                 return path
         return None
 
-    def missing_requirements(self, project_root: str) -> List[Requirement]:
-        """Return the declared requirements whose tool can't be resolved.
+    def is_requirement_satisfied(self, req: Requirement, project_root: str) -> bool:
+        """Whether *req* is present, probed the way its ``kind``/``probe`` says.
 
-        Only ``system`` requirements are resolved in-process (via
-        :meth:`resolve_requirement_path`, honouring ``alternatives``);
-        ``python``/``npm``/``env`` kinds are enumerated for doctor/the Action
-        but not probed here (that resolution belongs to the installing layer).
+        - ``binary`` → resolvable on PATH/venv (see resolve_requirement_path)
+        - ``import`` → the module is importable (install-name → import-name)
+        - ``env``    → the named environment variable is set and non-empty
+        - ``none``   → cannot probe in-process; assumed satisfied (installer's job)
         """
-        missing: List[Requirement] = []
-        for req in self.requirements().items:
-            if req.kind != "system":
-                continue
-            if self.resolve_requirement_path(req, project_root) is None:
-                missing.append(req)
-        return missing
+        probe = self._effective_probe(req)
+        if probe == "binary":
+            return self.resolve_requirement_path(req, project_root) is not None
+        if probe == "import":
+            names = [req.import_name or req.name.replace("-", "_")]
+            names += [alt.replace("-", "_") for alt in req.alternatives]
+            return any(_module_available(name) for name in names)
+        if probe == "env":
+            return bool(os.environ.get(req.name))
+        return True  # "none" — defer to the installing layer
+
+    def missing_requirements(self, project_root: str) -> List[Requirement]:
+        """Return the declared requirements that aren't satisfied in-process.
+
+        Each requirement is probed the way its kind/probe dictates
+        (binary/import/env). ``none``-probed requirements are never reported
+        missing here — verifying them belongs to the installing layer.
+        """
+        return [
+            req
+            for req in self.requirements().items
+            if not self.is_requirement_satisfied(req, project_root)
+        ]
 
     def requirement_block_result(
         self, project_root: str, duration: float = 0.0

--- a/slopmop/checks/quality/duplicate_strings.py
+++ b/slopmop/checks/quality/duplicate_strings.py
@@ -24,6 +24,7 @@ from slopmop.checks.base import (
     ScopeInfo,
     ToolContext,
     count_source_scope,
+    find_tool,
     should_prune_dir,
 )
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
@@ -228,7 +229,7 @@ class StringDuplicationCheck(BaseCheck):
         1. The target project's tools/ directory (works for projects
            that vendor the tool, or when sm is pip-installed)
         2. The slopmop package source tree (works in a git checkout)
-        3. Global npm installation via shutil.which
+        3. Global ``find-duplicate-strings`` binary via the shared resolver
 
         Returns the path to index.js, or None if not found.
         """
@@ -246,8 +247,10 @@ class StringDuplicationCheck(BaseCheck):
         if candidate.exists():
             return candidate
 
-        # 3. Global npm: check if find-duplicate-strings is on PATH
-        global_bin = shutil.which("find-duplicate-strings")
+        # 3. Global binary — resolve via the same venv-aware find_tool the
+        # requirements contract uses, so "declared present" and "the gate
+        # found it" can't drift.
+        global_bin = find_tool("find-duplicate-strings", project_root)
         if global_bin:
             return Path(global_bin)
 
@@ -282,11 +285,16 @@ class StringDuplicationCheck(BaseCheck):
         return {**defaults, **self.config}
 
     def _build_command(
-        self, config: dict[str, Any], tool_path: Optional[Path] = None
+        self,
+        config: dict[str, Any],
+        tool_path: Optional[Path] = None,
+        project_root: str = "",
     ) -> list[str]:
         """Build the find-duplicate-strings command."""
         if tool_path is None:
-            tool_path = self._get_tool_path() or Path("find-duplicate-strings")
+            tool_path = self._get_tool_path(project_root) or Path(
+                "find-duplicate-strings"
+            )
         threshold = config.get("threshold", 3)
         include_patterns = config.get("include_patterns", ["**/*.py"])
         ignore_patterns = config.get("ignore_patterns", [])
@@ -308,10 +316,13 @@ class StringDuplicationCheck(BaseCheck):
             else:
                 glob_pattern = include_patterns[0]
 
+        # Resolve node through the same find_tool the requirement uses, so the
+        # runtime the gate invokes matches the one doctor/the contract probe.
+        node = find_tool("node", project_root) or "node"
         cmd: list[str] = (
             # If tool_path points to a .js file, invoke via node;
-            # if it's a global binary (from shutil.which), call directly
-            ["node", str(tool_path)]
+            # if it's a global binary, call it directly.
+            [node, str(tool_path)]
             if str(tool_path).endswith(".js")
             else [str(tool_path)]
         )
@@ -722,7 +733,7 @@ class StringDuplicationCheck(BaseCheck):
         scan_root = tmp_dir if tmp_dir else project_root
 
         try:
-            cmd = self._build_command(effective_config, tool_path)
+            cmd = self._build_command(effective_config, tool_path, project_root)
             result = self._run_command(cmd, cwd=scan_root)
             try:
                 self._write_string_inventory(

--- a/slopmop/checks/quality/duplicate_strings.py
+++ b/slopmop/checks/quality/duplicate_strings.py
@@ -19,6 +19,8 @@ from slopmop.checks.base import (
     Flaw,
     GateCategory,
     GateLevel,
+    Requirement,
+    Requirements,
     ScopeInfo,
     ToolContext,
     count_source_scope,
@@ -182,6 +184,27 @@ class StringDuplicationCheck(BaseCheck):
             ["."],
             {".py"},
             self._get_effective_config(),
+        )
+
+    def requirements(self) -> Requirements:
+        """The Node runtime that runs the find-duplicate-strings tool.
+
+        Optional: when Node (or a global ``find-duplicate-strings`` binary) is
+        absent the gate degrades to a WARNED result rather than failing. The
+        tool script itself ships vendored with slop-mop; ``node`` is the only
+        external dependency, and declaring it lets doctor/the Action ensure it
+        is present instead of the gate discovering it missing at runtime.
+        """
+        return Requirements(
+            items=(
+                Requirement(
+                    kind="system",
+                    name="node",
+                    optional=True,
+                    alternatives=("find-duplicate-strings",),
+                    reason="runtime for the find-duplicate-strings duplication scanner",
+                ),
+            )
         )
 
     def is_applicable(self, project_root: str) -> bool:

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -641,7 +641,10 @@ class SecurityCheck(SecurityLocalCheck):
                 Requirement(
                     kind="python",
                     name="pip-audit",
-                    probe="binary",
+                    # Invoked as ``python -m pip_audit``, so detection must probe
+                    # the module, not a ``pip-audit`` script that may not exist.
+                    probe="import",
+                    import_name="pip_audit",
                     optional=True,
                     reason="audits installed dependencies for known CVEs (OSV database)",
                 ),

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -634,10 +634,16 @@ class SecurityCheck(SecurityLocalCheck):
 
         pip-audit is pip-installed but invoked as a binary (probe="binary").
         """
-        base = super().requirements()
+        # Unlike security:local, the full audit's run() executes a FIXED scanner
+        # set regardless of the `scanners` config, so declare exactly that set —
+        # otherwise doctor/the Action could install fewer tools than run() uses.
         return Requirements(
-            items=base.items
-            + (
+            items=(
+                self._SCANNER_REQUIREMENTS["bandit"],
+                self._SCANNER_REQUIREMENTS["semgrep"],
+                self._SCANNER_REQUIREMENTS[
+                    "detect-secrets"
+                ],  # pragma: allowlist secret
                 Requirement(
                     kind="python",
                     name="pip-audit",

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -527,7 +527,17 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
 
     def _run_semgrep(self, project_root: str) -> SecuritySubResult:
         """Run semgrep static analysis."""
-        cmd = ["semgrep", "scan", "--config=auto", "--json", "--quiet"]
+        # Invoke the same executable the availability probe resolved. Detection
+        # is venv-aware (find_tool), so a venv-only semgrep must be run by its
+        # resolved path, not a bare name PATH can't see — otherwise broadening
+        # detection would turn a former skip into a failure.
+        semgrep = (
+            self.resolve_requirement_path(
+                self._SCANNER_REQUIREMENTS["semgrep"], project_root
+            )
+            or "semgrep"
+        )
+        cmd = [semgrep, "scan", "--config=auto", "--json", "--quiet"]
         for d in self._get_exclude_dirs():
             cmd.extend(["--exclude", d])
 

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -13,13 +13,12 @@ with code files, not just Python projects.
 
 import json
 import os
-import shutil
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, ClassVar, Dict, List, Optional, cast
 
 from slopmop.checks.base import (
     BaseCheck,
@@ -28,6 +27,8 @@ from slopmop.checks.base import (
     Flaw,
     GateCategory,
     GateLevel,
+    Requirement,
+    Requirements,
     ToolContext,
 )
 from slopmop.checks.mixins import PythonCheckMixin
@@ -283,44 +284,74 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
         """Return reason for skipping - no source files to scan."""
         return "No Python, JavaScript, or TypeScript files found to scan for security issues"
 
-    @staticmethod
-    def _is_scanner_available(name: str, importable: dict[str, str]) -> bool:
-        """Check if a scanner tool is available on this system.
+    # External-dependency contract: the tool each scanner needs, declared once
+    # and consumed by both requirements() (what doctor/the Action installs) and
+    # _is_scanner_available (what the gate runs) — so they can't drift. All are
+    # optional: a missing scanner degrades gracefully, it doesn't fail the gate.
+    # detect-secrets installs under that name but imports as ``detect_secrets``;
+    # semgrep is pip-installed yet invoked as a binary (probe="binary").
+    _SCANNER_REQUIREMENTS: ClassVar[Dict[str, Requirement]] = {
+        "bandit": Requirement(
+            kind="python",
+            name="bandit",
+            optional=True,
+            reason="static security analysis of Python code",
+        ),
+        "semgrep": Requirement(
+            kind="python",
+            name="semgrep",
+            probe="binary",
+            optional=True,
+            reason="pattern-based security scanning (pip-installed, run as a binary)",
+        ),
+        "detect-secrets": Requirement(  # pragma: allowlist secret
+            kind="python",
+            name="detect-secrets",  # pragma: allowlist secret
+            import_name="detect_secrets",  # pragma: allowlist secret
+            optional=True,
+            reason="scans for secrets committed to the repo",
+        ),
+    }
 
-        For Python-based scanners (bandit, detect-secrets), checks
-        importability via ``find_spec`` (not ``import_module``).
-        ``import_module("bandit")`` pulls in stevedore, which enumerates
-        every entry-point plugin and logs WARNING for each failed load —
-        "Could not load 'sarif'" on every run.  ``find_spec`` probes the
-        import machinery without executing the target package.
+    def requirements(self) -> Requirements:
+        """The configured scanners' tools, for doctor/the Action to install.
+
+        Config-dependent: only the scanners this repo enables are declared.
         """
-        if name in importable:
-            try:
-                import importlib.util
+        configured = self.config.get("scanners", list(self._SCANNER_REQUIREMENTS))
+        return Requirements(
+            items=tuple(
+                self._SCANNER_REQUIREMENTS[name]
+                for name in configured
+                if name in self._SCANNER_REQUIREMENTS
+            )
+        )
 
-                return importlib.util.find_spec(importable[name]) is not None
-            except (ImportError, ModuleNotFoundError, ValueError):
-                return False
-        # External binary (semgrep, etc.)
-        return shutil.which(name) is not None
+    def _is_scanner_available(self, name: str, project_root: str) -> bool:
+        """Whether scanner *name* can run, via the shared requirement probe.
+
+        Python scanners (bandit, detect-secrets) are probed by importability;
+        semgrep by binary presence — the same checks ``requirements()`` /
+        ``missing_requirements`` use, so availability and declaration agree.
+        """
+        req = self._SCANNER_REQUIREMENTS.get(name)
+        if req is None:
+            return False
+        return self.is_requirement_satisfied(req, project_root)
 
     def _resolve_configured_scanners(
         self,
         scanner_map: dict[str, Callable[[str], SecuritySubResult]],
+        project_root: str = "",
     ) -> tuple[List[Callable[[str], SecuritySubResult]], List[str]]:
-        """Identify which scanners are configured and available to run."""
+        """Identify which configured scanners are available to run."""
         configured = self.config.get("scanners", list(scanner_map.keys()))
         sub_checks: List[Callable[[str], SecuritySubResult]] = []
         skipped: List[str] = []
-        _importable = {
-            "bandit": "bandit",
-            "detect-secrets": "detect_secrets",  # pragma: allowlist secret
-        }
         for name in configured:
             if name not in scanner_map:
                 continue
-            available = self._is_scanner_available(name, _importable)
-            if available:
+            if self._is_scanner_available(name, project_root):
                 sub_checks.append(scanner_map[name])
             else:
                 skipped.append(_SCANNER_NOT_INSTALLED.format(name=name))
@@ -342,7 +373,9 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             "detect-secrets": self._run_detect_secrets,
         }
 
-        sub_checks, skipped = self._resolve_configured_scanners(scanner_map)
+        sub_checks, skipped = self._resolve_configured_scanners(
+            scanner_map, project_root
+        )
 
         if not sub_checks:
             duration = time.time() - start_time
@@ -585,6 +618,25 @@ class SecurityCheck(SecurityLocalCheck):
     def superseded_by(self) -> Optional[str]:
         """Full security audit is the superseding gate, not the superseded one."""
         return None
+
+    def requirements(self) -> Requirements:
+        """The configured code scanners plus pip-audit for dependency auditing.
+
+        pip-audit is pip-installed but invoked as a binary (probe="binary").
+        """
+        base = super().requirements()
+        return Requirements(
+            items=base.items
+            + (
+                Requirement(
+                    kind="python",
+                    name="pip-audit",
+                    probe="binary",
+                    optional=True,
+                    reason="audits installed dependencies for known CVEs (OSV database)",
+                ),
+            )
+        )
 
     def run(self, project_root: str) -> CheckResult:
         """Run all security checks including dependency scanning."""

--- a/tests/unit/test_duplicate_strings_check.py
+++ b/tests/unit/test_duplicate_strings_check.py
@@ -100,6 +100,21 @@ class TestStringDuplicationCheck:
         assert "--json" in cmd
         assert "2" in cmd  # default threshold
 
+    def test_node_resolved_through_find_tool(self, check, monkeypatch, tmp_path):
+        """node is resolved via find_tool (the same primitive the requirements
+        contract probes), not invoked bare — so "declared present" and "the gate
+        runs it" can't drift."""
+        monkeypatch.setattr(
+            "slopmop.checks.quality.duplicate_strings.find_tool",
+            lambda name, root: "/opt/node/bin/node" if name == "node" else None,
+        )
+        js_tool = tmp_path / "index.js"
+        js_tool.write_text("// tool")
+        cmd = check._build_command(
+            check._get_effective_config(), js_tool, str(tmp_path)
+        )
+        assert cmd[0] == "/opt/node/bin/node"  # resolved, not bare "node"
+
     def test_build_command_with_ignore(self, check):
         """Test command includes ignore patterns."""
         config = check._get_effective_config()

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -311,6 +311,25 @@ class TestProbeKinds:
         monkeypatch.setenv("SM_TEST_TOKEN", "x")
         assert gate.missing_requirements(str(tmp_path)) == []
 
+    def test_env_probe_honours_alternatives(self, monkeypatch, tmp_path):
+        # GH_TOKEN with a GITHUB_TOKEN alternative — either set satisfies it.
+        class _EnvAlt(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(
+                        Requirement(
+                            kind="env",
+                            name="SM_PRIMARY_TOKEN",
+                            alternatives=("SM_ALT_TOKEN",),
+                        ),
+                    )
+                )
+
+        gate = _EnvAlt({})
+        monkeypatch.delenv("SM_PRIMARY_TOKEN", raising=False)
+        monkeypatch.setenv("SM_ALT_TOKEN", "x")
+        assert gate.missing_requirements(str(tmp_path)) == []
+
 
 class TestHardGateRequirements:
     """The two API-stressing gates declare their real deps."""
@@ -324,13 +343,23 @@ class TestHardGateRequirements:
         assert by_name["semgrep"].probe == "binary"  # pip install, binary probe
         assert all(r.optional for r in reqs.items)  # graceful degradation
 
-    def test_security_full_adds_pip_audit(self):
+    def test_security_full_declares_fixed_set_regardless_of_config(self):
         from slopmop.checks.security import SecurityCheck
 
-        by_name = {r.name: r for r in SecurityCheck({}).requirements().items}
-        assert "pip-audit" in by_name
-        # pip-audit runs as `python -m pip_audit`, so it's import-probed, not a
-        # binary on PATH — detection must match invocation (#306 review).
+        # run() executes a fixed scanner set ignoring `scanners`, so
+        # requirements() must declare that whole set even when config trims it,
+        # or doctor/the Action would under-install (#306 review).
+        by_name = {
+            r.name: r
+            for r in SecurityCheck({"scanners": ["bandit"]}).requirements().items
+        }
+        assert set(by_name) == {
+            "bandit",
+            "semgrep",
+            "detect-secrets",  # pragma: allowlist secret
+            "pip-audit",
+        }
+        # pip-audit runs as `python -m pip_audit`, so it's import-probed.
         assert by_name["pip-audit"].probe == "import"
         assert by_name["pip-audit"].import_name == "pip_audit"
 

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -327,8 +327,12 @@ class TestHardGateRequirements:
     def test_security_full_adds_pip_audit(self):
         from slopmop.checks.security import SecurityCheck
 
-        names = {r.name for r in SecurityCheck({}).requirements().items}
-        assert "pip-audit" in names
+        by_name = {r.name: r for r in SecurityCheck({}).requirements().items}
+        assert "pip-audit" in by_name
+        # pip-audit runs as `python -m pip_audit`, so it's import-probed, not a
+        # binary on PATH — detection must match invocation (#306 review).
+        assert by_name["pip-audit"].probe == "import"
+        assert by_name["pip-audit"].import_name == "pip_audit"
 
     def test_detect_secrets_import_name_declared(self):
         from slopmop.checks.security import SecurityLocalCheck

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from slopmop.checks.base import (
     REQUIREMENTS_MANIFEST_SCHEMA_VERSION,
     BaseCheck,
@@ -219,3 +221,128 @@ class TestManifestDeterminism:
         # Pinned version round-trips for the consumer to install exactly.
         bandit = next(r for r in doc["requirements"] if r["name"] == "bandit")
         assert bandit["version"] == "1.7.5"
+        # probe + import_name are part of the serialized contract.
+        assert "probe" in bandit and "import_name" in bandit
+
+
+class TestProbeKinds:
+    """Detection probes the way kind/probe dictates (driven by the hard gates)."""
+
+    def test_python_kind_probes_importability(self, monkeypatch, tmp_path):
+        seen = {}
+
+        def fake_module(name: str) -> bool:
+            seen["name"] = name
+            return True
+
+        monkeypatch.setattr("slopmop.checks.base._module_available", fake_module)
+
+        class _PyGate(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(items=(Requirement(kind="python", name="bandit"),))
+
+        gate = _PyGate({})
+        assert gate.is_requirement_satisfied(
+            gate.requirements().items[0], str(tmp_path)
+        )
+        # Binary lookup is NOT used for a python/import requirement.
+        assert seen["name"] == "bandit"
+        # A python requirement has no resolvable path.
+        assert (
+            gate.resolve_requirement_path(gate.requirements().items[0], str(tmp_path))
+            is None
+        )
+
+    def test_import_name_differs_from_install_name(self, monkeypatch, tmp_path):
+        # detect-secrets installs under that name but imports as detect_secrets.
+        importable = {"detect_secrets"}
+        monkeypatch.setattr(
+            "slopmop.checks.base._module_available", lambda n: n in importable
+        )
+
+        class _DS(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(
+                        Requirement(
+                            kind="python",
+                            name="detect-secrets",
+                            import_name="detect_secrets",
+                        ),
+                    )
+                )
+
+        gate = _DS({})
+        assert gate.missing_requirements(str(tmp_path)) == []
+
+    def test_semgrep_is_python_install_but_binary_probe(self, monkeypatch, tmp_path):
+        # Probed as a binary even though kind=python (pip-installed CLI).
+        monkeypatch.setattr(
+            "slopmop.checks.base.find_tool",
+            lambda name, root: "/usr/bin/semgrep" if name == "semgrep" else None,
+        )
+        # _module_available must NOT be consulted for a binary-probed req.
+        monkeypatch.setattr(
+            "slopmop.checks.base._module_available",
+            lambda n: pytest.fail("import probe used for binary requirement"),
+        )
+
+        class _SG(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(Requirement(kind="python", name="semgrep", probe="binary"),)
+                )
+
+        gate = _SG({})
+        assert gate.missing_requirements(str(tmp_path)) == []
+
+    def test_env_kind_probes_environment(self, monkeypatch, tmp_path):
+        class _EnvGate(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(Requirement(kind="env", name="SM_TEST_TOKEN"),)
+                )
+
+        gate = _EnvGate({})
+        monkeypatch.delenv("SM_TEST_TOKEN", raising=False)
+        assert [r.name for r in gate.missing_requirements(str(tmp_path))] == [
+            "SM_TEST_TOKEN"
+        ]
+        monkeypatch.setenv("SM_TEST_TOKEN", "x")
+        assert gate.missing_requirements(str(tmp_path)) == []
+
+
+class TestHardGateRequirements:
+    """The two API-stressing gates declare their real deps."""
+
+    def test_security_declares_configured_scanners(self):
+        from slopmop.checks.security import SecurityLocalCheck
+
+        reqs = SecurityLocalCheck({"scanners": ["bandit", "semgrep"]}).requirements()
+        by_name = {r.name: r for r in reqs.items}
+        assert set(by_name) == {"bandit", "semgrep"}
+        assert by_name["semgrep"].probe == "binary"  # pip install, binary probe
+        assert all(r.optional for r in reqs.items)  # graceful degradation
+
+    def test_security_full_adds_pip_audit(self):
+        from slopmop.checks.security import SecurityCheck
+
+        names = {r.name for r in SecurityCheck({}).requirements().items}
+        assert "pip-audit" in names
+
+    def test_detect_secrets_import_name_declared(self):
+        from slopmop.checks.security import SecurityLocalCheck
+
+        reqs = SecurityLocalCheck(
+            {"scanners": ["detect-secrets"]}  # pragma: allowlist secret
+        ).requirements()
+        (ds,) = reqs.items
+        assert ds.import_name == "detect_secrets"  # pragma: allowlist secret
+
+    def test_duplicate_strings_declares_node(self):
+        from slopmop.checks.quality.duplicate_strings import StringDuplicationCheck
+
+        (req,) = StringDuplicationCheck({}).requirements().items
+        assert req.name == "node"
+        assert req.optional is True
+        assert "find-duplicate-strings" in req.alternatives

--- a/tests/unit/test_security_checks.py
+++ b/tests/unit/test_security_checks.py
@@ -34,6 +34,25 @@ class TestSecuritySubResult:
 class TestSecurityLocalCheck:
     """Tests for SecurityLocalCheck."""
 
+    def test_semgrep_invoked_via_resolved_path(self, monkeypatch):
+        """semgrep is run by the path find_tool resolved (venv-aware), not a
+        bare name — so broadening detection to the venv can't turn a former
+        skip into a failure (#306 review)."""
+        check = SecurityLocalCheck({})
+        monkeypatch.setattr(
+            "slopmop.checks.base.find_tool",
+            lambda name, root: "/proj/venv/bin/semgrep" if name == "semgrep" else None,
+        )
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMock(success=True, output="", returncode=0)
+
+        monkeypatch.setattr(check, "_run_command", fake_run)
+        check._run_semgrep("/proj")
+        assert captured["cmd"][0] == "/proj/venv/bin/semgrep"
+
     def test_name(self):
         """Test check name."""
         check = SecurityLocalCheck({})


### PR DESCRIPTION
**Stacked on #305** (base = `feat/gate-requirements-contract`). Converts the two gates we flagged as the API-stressing cases — if the contract shape handles these, the remaining ~38 are mechanical.

## What they stressed (that actionlint didn't)

- **install channel ≠ detection method.** `semgrep` is pip-installed but invoked as a binary. Added `probe` (binary | import | env | none), orthogonal to `kind`. semgrep = `kind=python, probe=binary`.
- **install name ≠ import name.** `detect-secrets` imports as `detect_secrets`. Added `import_name`.
- **python-package probing.** `BaseCheck.is_requirement_satisfied()` + `_module_available()` (via `find_spec`, dodging stevedore's plugin-enumeration warnings — the same reason the security gate already used `find_spec`). `missing_requirements` now probes every kind correctly, not just system binaries.

Both new fields serialize into the manifest. Still **schema v1** — it's unreleased with no consumers, so evolving it pre-consumer is legitimate; the version exists to protect consumers, of which there are none until the doctor emitter lands.

## The conversions

- **`security:local`** declares its configured scanners (bandit/semgrep/detect-secrets) as optional requirements and replaces `_is_scanner_available`'s scattered `find_spec`/`shutil.which` with the shared probe — one source of truth for "what the gate runs" and "what doctor installs". **`security` (full)** adds `pip-audit`.
- **`duplicate-strings`** declares the `node` runtime (optional; global `find-duplicate-strings` binary as an `alternative`) — the real external dep it previously only discovered at subprocess time.

All optional (both gates degrade gracefully today), so **behavior-preserving**. Full suite green (3330); new tests cover the probe kinds, name/import-name split, the pip-installed-binary case, env probing, and each gate's declarations.

## Next
Remaining gates by category; wire `requirement_block_result` into required-tool gates' `run()`; registry enforcement test (lands last); then `sm doctor --required-deps` + the v2 Action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Implements a requirements contract for external tool “presence” by extending `Requirement` with `probe` (binary|import|env|none) and `import_name`, and adding `BaseCheck._module_available()` plus `BaseCheck.is_requirement_satisfied()`/probe-aware `missing_requirements()`. This replaces scattered PATH/import/spec checks with a single, consistent probing model and ensures requirements are serialized into the manifest with the new fields.

Updates the `security` and `duplicate-strings` gates to declare dependencies as optional requirements and to resolve/invoke the same executables/modules they probe: `semgrep` and `node` are run via venv-aware `find_tool()`/resolved paths, `detect-secrets` uses the correct `import_name` (`detect_secrets`), and `pip-audit` is probed as an import (`pip_audit`) since it runs as `python -m pip_audit`. Also fixes probe behavior drift (notably `semgrep` and `node` invocation) and aligns env probing to honor `alternatives`.

Adds unit tests covering probe kinds, `import_name` handling, and the specific “resolved path is what gets invoked” cases; test suite passes (3330 tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->