### PR TITLE
feat(gates): declare requirements() for quality tool-gates (vulture, radon)

### DIFF
--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -641,6 +641,26 @@ def build_requirements_document(requirements: "Requirements") -> Dict[str, Any]:
     }
 
 
+def pip_cli_requirement(
+    name: str, version: Optional[str], reason: str, *, optional: bool = False
+) -> Requirement:
+    """A pip-installed tool invoked as a CLI binary — the common gate case.
+
+    Most Python quality tools (black, mypy, vulture, …) ship on PyPI but are
+    run as a command, so they install via pip (``kind="python"``) yet are
+    detected on PATH (``probe="binary"``). ``version`` is an EXACT pin; keep it
+    in sync with pyproject's declared floor (a drift test guards this).
+    """
+    return Requirement(
+        kind="python",
+        name=name,
+        version=version,
+        probe="binary",
+        reason=reason,
+        optional=optional,
+    )
+
+
 class BaseCheck(ABC):
     """Abstract base class for all quality gate checks.
 

--- a/slopmop/checks/quality/complexity.py
+++ b/slopmop/checks/quality/complexity.py
@@ -21,7 +21,9 @@ from slopmop.checks.base import (
     Flaw,
     GateCategory,
     RemediationChurn,
+    Requirements,
     ToolContext,
+    pip_cli_requirement,
     should_prune_dir,
 )
 from slopmop.checks.constants import COMMAND_NOT_FOUND
@@ -65,6 +67,19 @@ class ComplexityCheck(BaseCheck, PythonCheckMixin):
     required_tools = ["radon"]
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_LIKELY
+
+    def requirements(self) -> Requirements:
+        # Optional: a missing radon WARNs (degrades), it doesn't fail the gate.
+        return Requirements(
+            items=(
+                pip_cli_requirement(
+                    "radon",
+                    "6.0.1",
+                    "measures cyclomatic complexity",
+                    optional=True,
+                ),
+            )
+        )
 
     @property
     def name(self) -> str:
@@ -151,8 +166,12 @@ class ComplexityCheck(BaseCheck, PythonCheckMixin):
                 output="No src_dirs configured and no Python files found.",
             )
 
+        # Invoke the same radon the requirement resolves (venv-aware), not a
+        # bare name PATH may not see.
+        (radon_req,) = self.requirements().items
+        radon = self.resolve_requirement_path(radon_req, project_root) or "radon"
         cmd = [
-            "radon",
+            radon,
             "cc",
             "--min",
             "D",

--- a/slopmop/checks/quality/dead_code.py
+++ b/slopmop/checks/quality/dead_code.py
@@ -20,9 +20,11 @@ from slopmop.checks.base import (
     Flaw,
     GateCategory,
     RemediationChurn,
+    Requirements,
     ToolContext,
     count_source_scope,
     find_tool,
+    pip_cli_requirement,
 )
 from slopmop.checks.constants import COMMAND_NOT_FOUND
 from slopmop.core.result import (
@@ -88,6 +90,19 @@ class DeadCodeCheck(BaseCheck):
     required_tools = ["vulture"]
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_LIKELY
+
+    def requirements(self) -> Requirements:
+        # Optional: a missing vulture WARNs (degrades), it doesn't fail the gate.
+        return Requirements(
+            items=(
+                pip_cli_requirement(
+                    "vulture",
+                    "2.14",
+                    "detects unused (dead) Python code",
+                    optional=True,
+                ),
+            )
+        )
 
     @property
     def name(self) -> str:

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -379,3 +379,76 @@ class TestHardGateRequirements:
         assert req.name == "node"
         assert req.optional is True
         assert "find-duplicate-strings" in req.alternatives
+
+
+class TestPythonToolGates:
+    """Python tool-gates declare their pip-installed CLIs with exact pins."""
+
+    def test_dead_code_declares_vulture(self):
+        from slopmop.checks.quality.dead_code import DeadCodeCheck
+
+        (req,) = DeadCodeCheck({}).requirements().items
+        assert req.name == "vulture"
+        assert req.kind == "python" and req.probe == "binary"
+        assert req.version == "2.14"
+        assert req.optional is True  # missing vulture WARNs, doesn't block
+
+    def test_complexity_declares_radon(self):
+        from slopmop.checks.quality.complexity import ComplexityCheck
+
+        (req,) = ComplexityCheck({}).requirements().items
+        assert req.name == "radon"
+        assert req.version == "6.0.1"
+        assert req.optional is True  # missing radon WARNs, doesn't block
+
+    def test_complexity_invokes_radon_via_resolved_path(self, monkeypatch, tmp_path):
+        # radon is invoked by the path the requirement resolves (venv-aware),
+        # not a bare name — same drift fix as semgrep/node.
+        from slopmop.checks.quality.complexity import ComplexityCheck
+
+        (tmp_path / "m.py").write_text("def f():\n    return 1\n")
+        monkeypatch.setattr(
+            "slopmop.checks.base.find_tool",
+            lambda name, root: "/venv/bin/radon" if name == "radon" else None,
+        )
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            from unittest.mock import MagicMock
+
+            return MagicMock(returncode=0, output="", success=True)
+
+        check = ComplexityCheck({"src_dirs": [str(tmp_path)]})
+        monkeypatch.setattr(check, "_run_command", fake_run)
+        check.run(str(tmp_path))
+        assert captured["cmd"][0] == "/venv/bin/radon"
+
+
+class TestVersionPinsTrackPyproject:
+    """Exact pins must satisfy pyproject's declared floor (no drift below it)."""
+
+    def _pyproject_floor(self, tool: str) -> str:
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        text = (root / "pyproject.toml").read_text()
+        m = re.search(rf'"{re.escape(tool)}>=([0-9][^"]*)"', text)
+        assert m, f"{tool} not found with a floor in pyproject.toml"
+        return m.group(1)
+
+    def test_pins_satisfy_pyproject_floors(self):
+        from packaging.version import Version
+
+        from slopmop.checks.quality.complexity import ComplexityCheck
+        from slopmop.checks.quality.dead_code import DeadCodeCheck
+
+        for gate in (DeadCodeCheck({}), ComplexityCheck({})):
+            for req in gate.requirements().items:
+                if req.version is None:
+                    continue
+                floor = self._pyproject_floor(req.name)
+                assert Version(req.version) >= Version(
+                    floor
+                ), f"{req.name} pin {req.version} is below pyproject floor {floor}"


### PR DESCRIPTION
Continues the per-gate `requirements()` conversion (your call: per-gate explicit, exact pins). First batch of the Python tool-gates — the two single-tool quality gates.

## What's here

- **`pip_cli_requirement(name, version, reason, optional=)`** helper in base for the common case: a pip-installed tool invoked as a CLI (`kind="python"`, `probe="binary"`). Keeps each gate's `requirements()` a one-liner while staying per-gate explicit.
- **dead-code → vulture**, **complexity → radon**, both with **exact pins** (2.14, 6.0.1).
- Both declared **`optional=True`** — and that's a real finding: each gate **WARNs** (degrades) rather than fails when its tool is missing. So `required_tools` was a *misnomer* here; the `optional` flag carries degradation info the legacy list couldn't. (Relevant to the upcoming doctor migration.)
- **complexity now invokes radon via the resolved path** (`resolve_requirement_path` → `find_tool`) instead of a bare name — matching the detection probe, the same drift fix the hard cases forced.

## Version pins
The pins are the **tested-against** versions, not the pyproject floors — `ruff>=0.1.0` etc. are floors that would *downgrade* if pinned literally. A new **drift-guard test** asserts each pin satisfies pyproject's declared floor, so a pin can't slip below the supported minimum. Pins bump deliberately (dependabot-style), matching the no-auto-update decision.

## Scope
Quality gates only this round. Next: `static_analysis` (mypy), `lint_format` (black/isort/ruff/…), `type_checking` (pyright — the first genuinely *required* tool, which raises the could-not-run/ERROR-vs-warn policy question), then the dart gates, then migrating doctor's four `required_tools` consumers onto `requirements()` and removing the legacy attrs.

Full suite green (3337).

🤖 Generated with [Claude Code](https://claude.com/claude-code)