### PR TITLE
refactor(doctor): unify on requirements() — retire required_tools + REQUIRED_TOOLS

### DIFF
--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -624,13 +624,15 @@ class Requirement:
         }
 
     def resolved_install_hint(self) -> str:
-        """The install command to show a user, with a kind-based fallback."""
+        """The remediation to show a user, with a kind-based fallback."""
         if self.install_hint:
             return self.install_hint
         if self.kind == "python":
             return f"pip install {self.name}"
         if self.kind == "npm":
             return f"npm install -g {self.name}"
+        if self.kind == "env":
+            return f"Set the {self.name} environment variable"
         return f"Install {self.name}"
 
 

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -602,6 +602,12 @@ class Requirement:
     alternatives: tuple[str, ...] = ()
     probe: str = ""  # "" = default by kind; "binary" | "import" | "env" | "none"
     import_name: str = ""  # for probe="import" when it differs from name
+    # User-facing install command for slop-mop's OWN env-doctor remediation —
+    # e.g. "pipx install slopmop[security]" or "Install Flutter SDK: …". Distinct
+    # from how the downstream Action installs (name + version + kind): this tells
+    # a slop-mop *user* how to fix their environment. Empty ⇒ doctor falls back
+    # to a kind-based default ("pip install <name>").
+    install_hint: str = ""
 
     def to_manifest(self) -> Dict[str, Any]:
         """Serialize to the deterministic manifest shape doctor/the Action read."""
@@ -613,8 +619,19 @@ class Requirement:
             "alternatives": sorted(self.alternatives),
             "probe": self.probe,
             "import_name": self.import_name,
+            "install_hint": self.install_hint,
             "reason": self.reason,
         }
+
+    def resolved_install_hint(self) -> str:
+        """The install command to show a user, with a kind-based fallback."""
+        if self.install_hint:
+            return self.install_hint
+        if self.kind == "python":
+            return f"pip install {self.name}"
+        if self.kind == "npm":
+            return f"npm install -g {self.name}"
+        return f"Install {self.name}"
 
 
 @dataclass(frozen=True)
@@ -642,7 +659,12 @@ def build_requirements_document(requirements: "Requirements") -> Dict[str, Any]:
 
 
 def pip_cli_requirement(
-    name: str, version: Optional[str], reason: str, *, optional: bool = False
+    name: str,
+    version: Optional[str],
+    reason: str,
+    *,
+    optional: bool = False,
+    extra: Optional[str] = None,
 ) -> Requirement:
     """A pip-installed tool invoked as a CLI binary — the common gate case.
 
@@ -650,6 +672,10 @@ def pip_cli_requirement(
     run as a command, so they install via pip (``kind="python"``) yet are
     detected on PATH (``probe="binary"``). ``version`` is an EXACT pin; keep it
     in sync with pyproject's declared floor (a drift test guards this).
+
+    ``extra`` names the slop-mop extras group that bundles this tool (``lint``,
+    ``typing``, ``analysis``, ``security``) so the env-doctor can tell a slop-mop
+    user to ``pipx install slopmop[<extra>]`` — one command for the whole group.
     """
     return Requirement(
         kind="python",
@@ -658,6 +684,7 @@ def pip_cli_requirement(
         probe="binary",
         reason=reason,
         optional=optional,
+        install_hint=f"pipx install slopmop[{extra}]" if extra else "",
     )
 
 

--- a/slopmop/checks/base.py
+++ b/slopmop/checks/base.py
@@ -756,26 +756,10 @@ class BaseCheck(ABC):
     # rather than relying on gate-name string matching.
     is_formatting_gate: ClassVar[bool] = False
 
-    # Tools this gate needs at runtime.  Doctor uses this to verify
-    # tool availability *before* the gate runs.  Opt-in: gates that
-    # don't declare this are still diagnosed by tool_context heuristics
-    # (e.g. NODE gates check for node_modules, PROJECT gates check for
-    # venv), but SM_TOOL gates should list specific executables.
-    required_tools: ClassVar[List[str]] = []
-
-    # Minimum version constraints for tools declared in ``required_tools``.
-    # Maps tool name → PEP 440 version specifier string (e.g. ``">=24.0"``).
-    # Doctor uses this to call ``<tool> --version`` and warn when the
-    # installed version does not satisfy the constraint.  Opt-in: most
-    # gates leave this empty.
-    required_tool_versions: ClassVar[Dict[str, str]] = {}
-
-    # How to install missing tools.  Doctor reads this to generate
-    # actionable remediation hints.  Use "pip" for Python-ecosystem
-    # tools, or a freeform string like "Install {tool} from https://..."
-    # for tools that aren't pip-installable.  Default "pip" covers most
-    # SM_TOOL gates.  Override in subclasses for non-pip tools.
-    install_hint: ClassVar[str] = "pip"
+    # External tools a gate needs are declared via requirements() (the
+    # Requirement contract — name, exact pin, kind/probe, install_hint). The
+    # former required_tools / required_tool_versions / install_hint class
+    # attributes have been retired in favour of that single source.
 
     def __init__(
         self, config: Dict[str, Any], runner: Optional[SubprocessRunner] = None

--- a/slopmop/checks/dart/analyze.py
+++ b/slopmop/checks/dart/analyze.py
@@ -23,6 +23,7 @@ from slopmop.checks.dart.common import (
     FLUTTER_NOT_AVAILABLE,
     find_pubspec_dirs,
     format_package_label,
+    FLUTTER_INSTALL_HINT,
 )
 from slopmop.core.result import (
     CheckResult,
@@ -47,7 +48,7 @@ class FlutterAnalyzeCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
-                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
+                    install_hint=FLUTTER_INSTALL_HINT,
                     optional=True,
                     reason="static analysis of Flutter/Dart code",
                 ),

--- a/slopmop/checks/dart/analyze.py
+++ b/slopmop/checks/dart/analyze.py
@@ -48,6 +48,7 @@ class FlutterAnalyzeCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
+                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
                     optional=True,
                     reason="static analysis of Flutter/Dart code",
                 ),

--- a/slopmop/checks/dart/analyze.py
+++ b/slopmop/checks/dart/analyze.py
@@ -37,7 +37,6 @@ class FlutterAnalyzeCheck(BaseCheck):
     """Run flutter analyze across all discovered pubspec packages."""
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["flutter"]
 
     def requirements(self) -> Requirements:
         # Optional: a missing flutter WARNs (degrades), it does not fail
@@ -55,7 +54,6 @@ class FlutterAnalyzeCheck(BaseCheck):
             )
         )
 
-    install_hint = "path"
     role = CheckRole.FOUNDATION
 
     @property

--- a/slopmop/checks/dart/analyze.py
+++ b/slopmop/checks/dart/analyze.py
@@ -20,10 +20,10 @@ from slopmop.checks.dart.common import (
     FLUTTER_CACHE_NOT_WRITABLE,
     FLUTTER_CACHE_PERMISSION_ERROR,
     FLUTTER_INSTALL_FIX_SUGGESTION,
+    FLUTTER_INSTALL_HINT,
     FLUTTER_NOT_AVAILABLE,
     find_pubspec_dirs,
     format_package_label,
-    FLUTTER_INSTALL_HINT,
 )
 from slopmop.core.result import (
     CheckResult,

--- a/slopmop/checks/dart/common.py
+++ b/slopmop/checks/dart/common.py
@@ -6,6 +6,11 @@ from typing import Iterable, List
 FLUTTER_CACHE_PERMISSION_ERROR = "engine.stamp: Operation not permitted"
 FLUTTER_NOT_AVAILABLE = "flutter not available"
 FLUTTER_INSTALL_FIX_SUGGESTION = "Install Flutter SDK and ensure `flutter` is on PATH"
+# Install-hint commands carried on the requirement contract (env-doctor fix).
+FLUTTER_INSTALL_HINT = (
+    "Install Flutter SDK: https://docs.flutter.dev/get-started/install"
+)
+DART_INSTALL_HINT = "Install Dart SDK: https://dart.dev/get-dart"
 FLUTTER_CACHE_NOT_WRITABLE = (
     "Flutter SDK cache path is not writable in this environment"
 )

--- a/slopmop/checks/dart/coverage.py
+++ b/slopmop/checks/dart/coverage.py
@@ -29,6 +29,7 @@ from slopmop.checks.dart.common import (
     FLUTTER_NOT_AVAILABLE,
     NO_FLUTTER_TEST_DIRECTORIES_FOUND,
     find_pubspec_dirs,
+    FLUTTER_INSTALL_HINT,
 )
 from slopmop.constants import COVERAGE_BELOW_THRESHOLD
 from slopmop.core.result import (
@@ -69,7 +70,7 @@ class DartCoverageCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
-                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
+                    install_hint=FLUTTER_INSTALL_HINT,
                     optional=True,
                     reason="measures Flutter/Dart test coverage",
                 ),

--- a/slopmop/checks/dart/coverage.py
+++ b/slopmop/checks/dart/coverage.py
@@ -59,7 +59,6 @@ class DartCoverageCheck(BaseCheck):
     """Flutter test coverage gate (parses coverage/lcov.info)."""
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["flutter"]
 
     def requirements(self) -> Requirements:
         # Optional: a missing flutter WARNs (degrades), it does not fail
@@ -77,7 +76,6 @@ class DartCoverageCheck(BaseCheck):
             )
         )
 
-    install_hint = "path"
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_UNLIKELY
 

--- a/slopmop/checks/dart/coverage.py
+++ b/slopmop/checks/dart/coverage.py
@@ -26,10 +26,10 @@ from slopmop.checks.dart.common import (
     FLUTTER_CACHE_NOT_WRITABLE,
     FLUTTER_CACHE_PERMISSION_ERROR,
     FLUTTER_INSTALL_FIX_SUGGESTION,
+    FLUTTER_INSTALL_HINT,
     FLUTTER_NOT_AVAILABLE,
     NO_FLUTTER_TEST_DIRECTORIES_FOUND,
     find_pubspec_dirs,
-    FLUTTER_INSTALL_HINT,
 )
 from slopmop.constants import COVERAGE_BELOW_THRESHOLD
 from slopmop.core.result import (

--- a/slopmop/checks/dart/coverage.py
+++ b/slopmop/checks/dart/coverage.py
@@ -70,6 +70,7 @@ class DartCoverageCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
+                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
                     optional=True,
                     reason="measures Flutter/Dart test coverage",
                 ),

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -16,7 +16,11 @@ from slopmop.checks.base import (
     find_tool,
 )
 from slopmop.checks.constants import NO_PUBSPEC_YAML_FOUND
-from slopmop.checks.dart.common import find_pubspec_dirs, format_package_label
+from slopmop.checks.dart.common import (
+    find_pubspec_dirs,
+    format_package_label,
+    DART_INSTALL_HINT,
+)
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -40,7 +44,7 @@ class DartFormatCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="dart",
-                    install_hint="Install Dart SDK: https://dart.dev/get-dart",
+                    install_hint=DART_INSTALL_HINT,
                     optional=True,
                     reason="formats Dart code",
                 ),

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -30,7 +30,6 @@ class DartFormatCheck(BaseCheck):
     """Check canonical Dart formatting across the repo."""
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["dart"]
 
     def requirements(self) -> Requirements:
         # Optional: a missing dart WARNs (degrades), it does not fail
@@ -48,7 +47,6 @@ class DartFormatCheck(BaseCheck):
             )
         )
 
-    install_hint = "path"
     role = CheckRole.FOUNDATION
 
     @property

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -17,9 +17,9 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.constants import NO_PUBSPEC_YAML_FOUND
 from slopmop.checks.dart.common import (
+    DART_INSTALL_HINT,
     find_pubspec_dirs,
     format_package_label,
-    DART_INSTALL_HINT,
 )
 from slopmop.core.result import (
     CheckResult,

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -41,6 +41,7 @@ class DartFormatCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="dart",
+                    install_hint="Install Dart SDK: https://dart.dev/get-dart",
                     optional=True,
                     reason="formats Dart code",
                 ),

--- a/slopmop/checks/dart/generated_artifacts.py
+++ b/slopmop/checks/dart/generated_artifacts.py
@@ -37,6 +37,7 @@ class DartGeneratedArtifactsCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
+                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
                     optional=True,
                     reason="checks generated Dart artifacts are current",
                 ),

--- a/slopmop/checks/dart/generated_artifacts.py
+++ b/slopmop/checks/dart/generated_artifacts.py
@@ -16,7 +16,11 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.constants import NO_PUBSPEC_YAML_FOUND
-from slopmop.checks.dart.common import find_pubspec_dirs, unique_strings
+from slopmop.checks.dart.common import (
+    find_pubspec_dirs,
+    unique_strings,
+    FLUTTER_INSTALL_HINT,
+)
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 MAX_SHOWN = 20
@@ -36,7 +40,7 @@ class DartGeneratedArtifactsCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
-                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
+                    install_hint=FLUTTER_INSTALL_HINT,
                     optional=True,
                     reason="checks generated Dart artifacts are current",
                 ),

--- a/slopmop/checks/dart/generated_artifacts.py
+++ b/slopmop/checks/dart/generated_artifacts.py
@@ -26,7 +26,6 @@ class DartGeneratedArtifactsCheck(BaseCheck):
     """Fail when Flutter build/tool artifacts are committed."""
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["flutter"]
 
     def requirements(self) -> Requirements:
         # Optional: a missing flutter WARNs (degrades), it does not fail
@@ -44,7 +43,6 @@ class DartGeneratedArtifactsCheck(BaseCheck):
             )
         )
 
-    install_hint = "path"
     role = CheckRole.DIAGNOSTIC
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_UNLIKELY
 

--- a/slopmop/checks/dart/generated_artifacts.py
+++ b/slopmop/checks/dart/generated_artifacts.py
@@ -17,9 +17,9 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.constants import NO_PUBSPEC_YAML_FOUND
 from slopmop.checks.dart.common import (
+    FLUTTER_INSTALL_HINT,
     find_pubspec_dirs,
     unique_strings,
-    FLUTTER_INSTALL_HINT,
 )
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -39,7 +39,6 @@ class FlutterTestsCheck(BaseCheck):
     """Run flutter test across all discovered test packages."""
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["flutter"]
 
     def requirements(self) -> Requirements:
         # Optional: a missing flutter WARNs (degrades), it does not fail
@@ -57,7 +56,6 @@ class FlutterTestsCheck(BaseCheck):
             )
         )
 
-    install_hint = "path"
     role = CheckRole.FOUNDATION
 
     @property

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -20,12 +20,12 @@ from slopmop.checks.dart.common import (
     FLUTTER_CACHE_NOT_WRITABLE,
     FLUTTER_CACHE_PERMISSION_ERROR,
     FLUTTER_INSTALL_FIX_SUGGESTION,
+    FLUTTER_INSTALL_HINT,
     FLUTTER_NOT_AVAILABLE,
     NO_FLUTTER_TEST_DIRECTORIES_FOUND,
     find_flutter_test_package_dirs,
     find_pubspec_dirs,
     format_package_label,
-    FLUTTER_INSTALL_HINT,
 )
 from slopmop.core.result import (
     CheckResult,

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -50,6 +50,7 @@ class FlutterTestsCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
+                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
                     optional=True,
                     reason="runs the Flutter/Dart test suite",
                 ),

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -25,6 +25,7 @@ from slopmop.checks.dart.common import (
     find_flutter_test_package_dirs,
     find_pubspec_dirs,
     format_package_label,
+    FLUTTER_INSTALL_HINT,
 )
 from slopmop.core.result import (
     CheckResult,
@@ -49,7 +50,7 @@ class FlutterTestsCheck(BaseCheck):
                 Requirement(
                     kind="system",
                     name="flutter",
-                    install_hint="Install Flutter SDK: https://docs.flutter.dev/get-started/install",
+                    install_hint=FLUTTER_INSTALL_HINT,
                     optional=True,
                     reason="runs the Flutter/Dart test suite",
                 ),

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -110,7 +110,6 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["black", "isort", "autoflake", "flake8", "ruff"]
     role = CheckRole.FOUNDATION
 
     def requirements(self) -> Requirements:

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -119,18 +119,27 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         return Requirements(
             items=(
                 pip_cli_requirement(
-                    "black", "26.5.1", "code formatting", optional=True
+                    "black", "26.5.1", "code formatting", optional=True, extra="lint"
                 ),
-                pip_cli_requirement("isort", "8.0.1", "import sorting", optional=True),
+                pip_cli_requirement(
+                    "isort", "8.0.1", "import sorting", optional=True, extra="lint"
+                ),
                 pip_cli_requirement(
                     "autoflake",
                     "2.3.3",
                     "removes unused imports/variables",
                     optional=True,
+                    extra="lint",
                 ),
-                pip_cli_requirement("flake8", "7.3.0", "style linting", optional=True),
                 pip_cli_requirement(
-                    "ruff", "0.15.0", "fast linting + formatting", optional=True
+                    "flake8", "7.3.0", "style linting", optional=True, extra="lint"
+                ),
+                pip_cli_requirement(
+                    "ruff",
+                    "0.15.0",
+                    "fast linting + formatting",
+                    optional=True,
+                    extra="lint",
                 ),
             )
         )

--- a/slopmop/checks/python/static_analysis.py
+++ b/slopmop/checks/python/static_analysis.py
@@ -100,7 +100,11 @@ class PythonStaticAnalysisCheck(BaseCheck, PythonCheckMixin):
         return Requirements(
             items=(
                 pip_cli_requirement(
-                    "mypy", "1.19.1", "static type analysis", optional=True
+                    "mypy",
+                    "1.19.1",
+                    "static type analysis",
+                    optional=True,
+                    extra="typing",
                 ),
             )
         )

--- a/slopmop/checks/python/static_analysis.py
+++ b/slopmop/checks/python/static_analysis.py
@@ -92,7 +92,6 @@ class PythonStaticAnalysisCheck(BaseCheck, PythonCheckMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["mypy"]
     role = CheckRole.FOUNDATION
 
     def requirements(self) -> Requirements:

--- a/slopmop/checks/python/type_checking.py
+++ b/slopmop/checks/python/type_checking.py
@@ -240,7 +240,6 @@ class PythonTypeCheckingCheck(BaseCheck, PythonCheckMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["pyright"]
     role = CheckRole.FOUNDATION
 
     def requirements(self) -> Requirements:

--- a/slopmop/checks/python/type_checking.py
+++ b/slopmop/checks/python/type_checking.py
@@ -250,7 +250,10 @@ class PythonTypeCheckingCheck(BaseCheck, PythonCheckMixin):
         return Requirements(
             items=(
                 pip_cli_requirement(
-                    "pyright", "1.1.408", "static type checking of Python code"
+                    "pyright",
+                    "1.1.408",
+                    "static type checking of Python code",
+                    extra="typing",
                 ),
             )
         )

--- a/slopmop/checks/quality/complexity.py
+++ b/slopmop/checks/quality/complexity.py
@@ -77,6 +77,7 @@ class ComplexityCheck(BaseCheck, PythonCheckMixin):
                     "6.0.1",
                     "measures cyclomatic complexity",
                     optional=True,
+                    extra="analysis",
                 ),
             )
         )

--- a/slopmop/checks/quality/complexity.py
+++ b/slopmop/checks/quality/complexity.py
@@ -64,7 +64,6 @@ class ComplexityCheck(BaseCheck, PythonCheckMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["radon"]
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_LIKELY
 

--- a/slopmop/checks/quality/dead_code.py
+++ b/slopmop/checks/quality/dead_code.py
@@ -100,6 +100,7 @@ class DeadCodeCheck(BaseCheck):
                     "2.14",
                     "detects unused (dead) Python code",
                     optional=True,
+                    extra="analysis",
                 ),
             )
         )

--- a/slopmop/checks/quality/dead_code.py
+++ b/slopmop/checks/quality/dead_code.py
@@ -87,7 +87,6 @@ class DeadCodeCheck(BaseCheck):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["vulture"]
     role = CheckRole.FOUNDATION
     remediation_churn = RemediationChurn.DOWNSTREAM_CHANGES_VERY_LIKELY
 

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -37,6 +37,7 @@ from slopmop.constants import NO_ISSUES_FOUND
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 _SCANNER_NOT_INSTALLED = "{name} (not installed)"
+_SECURITY_INSTALL_HINT = "pipx install slopmop[security]"
 
 # A scanner that fails to even start (its Python module isn't importable in the
 # interpreter we shell out to) is a tooling/environment problem, NOT a security
@@ -295,7 +296,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             name="bandit",
             optional=True,
             reason="static security analysis of Python code",
-            install_hint="pipx install slopmop[security]",
+            install_hint=_SECURITY_INSTALL_HINT,
         ),
         "semgrep": Requirement(
             kind="python",
@@ -303,7 +304,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             probe="binary",
             optional=True,
             reason="pattern-based security scanning (pip-installed, run as a binary)",
-            install_hint="pipx install slopmop[security]",
+            install_hint=_SECURITY_INSTALL_HINT,
         ),
         "detect-secrets": Requirement(  # pragma: allowlist secret
             kind="python",
@@ -311,7 +312,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             import_name="detect_secrets",  # pragma: allowlist secret
             optional=True,
             reason="scans for secrets committed to the repo",
-            install_hint="pipx install slopmop[security]",
+            install_hint=_SECURITY_INSTALL_HINT,
         ),
     }
 
@@ -655,7 +656,7 @@ class SecurityCheck(SecurityLocalCheck):
                     import_name="pip_audit",
                     optional=True,
                     reason="audits installed dependencies for known CVEs (OSV database)",
-                    install_hint="pipx install slopmop[security]",
+                    install_hint=_SECURITY_INSTALL_HINT,
                 ),
             )
         )

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -149,7 +149,6 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
     """
 
     tool_context = ToolContext.SM_TOOL
-    required_tools = ["bandit", "detect-secrets"]
     role = CheckRole.FOUNDATION
     level = GateLevel.SCOUR
 

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -296,6 +296,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             name="bandit",
             optional=True,
             reason="static security analysis of Python code",
+            install_hint="pipx install slopmop[security]",
         ),
         "semgrep": Requirement(
             kind="python",
@@ -303,6 +304,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             probe="binary",
             optional=True,
             reason="pattern-based security scanning (pip-installed, run as a binary)",
+            install_hint="pipx install slopmop[security]",
         ),
         "detect-secrets": Requirement(  # pragma: allowlist secret
             kind="python",
@@ -310,6 +312,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             import_name="detect_secrets",  # pragma: allowlist secret
             optional=True,
             reason="scans for secrets committed to the repo",
+            install_hint="pipx install slopmop[security]",
         ),
     }
 
@@ -653,6 +656,7 @@ class SecurityCheck(SecurityLocalCheck):
                     import_name="pip_audit",
                     optional=True,
                     reason="audits installed dependencies for known CVEs (OSV database)",
+                    install_hint="pipx install slopmop[security]",
                 ),
             )
         )

--- a/slopmop/checks/tool_inventory.py
+++ b/slopmop/checks/tool_inventory.py
@@ -8,22 +8,28 @@ instead of a hand-maintained list. Replaces the former hardcoded
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
-def gate_tool_inventory() -> List[Tuple[str, str, str]]:
+def gate_tool_inventory(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[Tuple[str, str, str]]:
     """Return ``(tool_name, gate_name, install_hint)`` for every declared tool.
 
-    Walks every registered gate's ``requirements()`` (instantiated with empty
-    config, so the full default tool set is reported) and emits one row per
+    Walks every registered gate's ``requirements()`` and emits one row per
     ``(tool, gate)``. ``install_hint`` is the user-facing remediation command
     (``pipx install slopmop[security]``, an SDK URL, …). Sorted for stable
     output. Only ``system``/``python``/``npm`` tools are listed — ``env``
     requirements aren't "installable tools".
+
+    ``requirements()`` is config-dependent (configured scanners, run_actionlint
+    …), so pass the repo's resolved config to report exactly what THIS repo's
+    gates need; the default (``{}``) reports the full default tool set.
     """
     from slopmop.checks import ensure_checks_registered
     from slopmop.core.registry import get_registry
 
+    config = config or {}
     ensure_checks_registered()
     registry = get_registry()
 
@@ -32,7 +38,7 @@ def gate_tool_inventory() -> List[Tuple[str, str, str]]:
     for gate_name in registry.list_checks():
         if not isinstance(gate_name, str):
             continue
-        check = registry.get_check(gate_name, {})
+        check = registry.get_check(gate_name, config)
         if check is None:
             continue
         for req in check.requirements().items:

--- a/slopmop/checks/tool_inventory.py
+++ b/slopmop/checks/tool_inventory.py
@@ -1,0 +1,46 @@
+"""Registry-derived external-tool inventory.
+
+Single source of truth for "what external tools do slop-mop's gates need, and
+how does a user install them" — derived from each gate's ``requirements()``
+instead of a hand-maintained list. Replaces the former hardcoded
+``REQUIRED_TOOLS`` in ``slopmop.cli.detection``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+
+def gate_tool_inventory() -> List[Tuple[str, str, str]]:
+    """Return ``(tool_name, gate_name, install_hint)`` for every declared tool.
+
+    Walks every registered gate's ``requirements()`` (instantiated with empty
+    config, so the full default tool set is reported) and emits one row per
+    ``(tool, gate)``. ``install_hint`` is the user-facing remediation command
+    (``pipx install slopmop[security]``, an SDK URL, …). Sorted for stable
+    output. Only ``system``/``python``/``npm`` tools are listed — ``env``
+    requirements aren't "installable tools".
+    """
+    from slopmop.checks import ensure_checks_registered
+    from slopmop.core.registry import get_registry
+
+    ensure_checks_registered()
+    registry = get_registry()
+
+    rows: List[Tuple[str, str, str]] = []
+    seen: set[Tuple[str, str]] = set()
+    for gate_name in registry.list_checks():
+        if not isinstance(gate_name, str):
+            continue
+        check = registry.get_check(gate_name, {})
+        if check is None:
+            continue
+        for req in check.requirements().items:
+            if req.kind == "env":
+                continue
+            key = (req.name, gate_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append((req.name, gate_name, req.resolved_install_hint()))
+    return sorted(rows)

--- a/slopmop/cli/config.py
+++ b/slopmop/cli/config.py
@@ -397,25 +397,22 @@ def _enable_gate(
     # missing before their first run.  Informational only — never
     # blocks enable, and a bug in doctor must not break config.
     try:
-        from slopmop.checks.base import find_tool
-
         ensure_checks_registered()
         registry = get_registry()
         check = registry.get_check(gate_name, config)
         if check is not None:
-            missing = [
-                t
-                for t in check.required_tools
-                if find_tool(t, str(project_root)) is None
-            ]
+            missing = check.missing_requirements(str(project_root))
             if missing:
-                hint = check.install_hint
-                print(f"\n  ⚠️  Missing tools: {', '.join(missing)}")
-                if hint == "pip":
-                    print(f"     → pip install {' '.join(missing)}")
-                else:
-                    for t in missing:
-                        print(f"     → Install {t} and ensure it is on PATH")
+                names = [r.name for r in missing]
+                print(f"\n  ⚠️  Missing tools: {', '.join(names)}")
+                # Each requirement carries its own install command (slop-mop
+                # extras group, SDK URL, …); dedup identical ones.
+                seen: set[str] = set()
+                for req in missing:
+                    hint = req.resolved_install_hint()
+                    if hint not in seen:
+                        seen.add(hint)
+                        print(f"     → {hint}")
     except (ImportError, KeyError, ValueError, OSError) as exc:
         import logging
 

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -157,12 +157,14 @@ def _detect_tools(project_root: Path) -> Dict[str, Any]:
         - missing_tools: list of (tool_name, check_name, install_command) for missing tools
     """
     from slopmop.checks.tool_inventory import gate_tool_inventory
+    from slopmop.doctor.sm_env import _load_repo_config
 
     available: List[str] = []
     missing: List[Tuple[str, str, str]] = []
     seen_available: Set[str] = set()
 
-    for tool_name, check_name, install_cmd in gate_tool_inventory():
+    config = _load_repo_config(project_root)
+    for tool_name, check_name, install_cmd in gate_tool_inventory(config):
         found = find_tool(tool_name, str(project_root))
         if found:
             if tool_name not in seen_available:

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -24,39 +24,9 @@ from slopmop.checks.mixins import (
 #   testing   — pytest, pytest-cov, diff-cover
 #   all       — everything above
 
-# Install-command constants (one source of truth for each extra group)
-_INSTALL_LINT = "pipx install slopmop[lint]"
-_INSTALL_TYPING = "pipx install slopmop[typing]"
-_INSTALL_ANALYSIS = "pipx install slopmop[analysis]"
-_INSTALL_SECURITY = "pipx install slopmop[security]"
-_INSTALL_DART = "Install Dart SDK: https://dart.dev/get-dart"
-_INSTALL_FLUTTER = "Install Flutter SDK: https://docs.flutter.dev/get-started/install"
-
-REQUIRED_TOOLS: List[Tuple[str, str, str]] = [
-    # Lint & format (sloppy-formatting.py gate) → [lint] extra
-    ("black", "laziness:sloppy-formatting.py", _INSTALL_LINT),
-    ("isort", "laziness:sloppy-formatting.py", _INSTALL_LINT),
-    ("autoflake", "laziness:sloppy-formatting.py", _INSTALL_LINT),
-    ("flake8", "laziness:sloppy-formatting.py", _INSTALL_LINT),
-    # Static analysis → [analysis] extra
-    ("vulture", "laziness:dead-code.py", _INSTALL_ANALYSIS),
-    # Type checking → [typing] extra
-    ("mypy", "overconfidence:missing-annotations.py", _INSTALL_TYPING),
-    ("pyright", "overconfidence:type-blindness.py", _INSTALL_TYPING),
-    # Security scanning → [security] extra
-    ("bandit", "myopia:vulnerability-blindness.py", _INSTALL_SECURITY),
-    ("semgrep", "myopia:vulnerability-blindness.py", _INSTALL_SECURITY),
-    ("detect-secrets", "myopia:vulnerability-blindness.py", _INSTALL_SECURITY),
-    ("pip-audit", "myopia:dependency-risk.py", _INSTALL_SECURITY),
-    # Complexity scanning → [analysis] extra
-    ("radon", "laziness:complexity-creep.py", _INSTALL_ANALYSIS),
-    # Dart/Flutter maintenance gates
-    ("flutter", "overconfidence:missing-annotations.dart", _INSTALL_FLUTTER),
-    ("flutter", "overconfidence:untested-code.dart", _INSTALL_FLUTTER),
-    ("dart", "laziness:sloppy-formatting.dart", _INSTALL_DART),
-    # Dart/Flutter coverage gate
-    ("flutter", "overconfidence:coverage-gaps.dart", _INSTALL_FLUTTER),
-]
+# The tool inventory (which tool, which gate, how to install it) is no longer
+# hand-maintained here — it is derived from each gate's requirements() via
+# slopmop.checks.tool_inventory.gate_tool_inventory(). See _detect_tools().
 
 # Canonical language keys derived from scc --format json output.
 _PYTHON_LANGS = {"python"}
@@ -186,11 +156,13 @@ def _detect_tools(project_root: Path) -> Dict[str, Any]:
         - available_tools: list of tool names that are installed
         - missing_tools: list of (tool_name, check_name, install_command) for missing tools
     """
+    from slopmop.checks.tool_inventory import gate_tool_inventory
+
     available: List[str] = []
     missing: List[Tuple[str, str, str]] = []
     seen_available: Set[str] = set()
 
-    for tool_name, check_name, install_cmd in REQUIRED_TOOLS:
+    for tool_name, check_name, install_cmd in gate_tool_inventory():
         found = find_tool(tool_name, str(project_root))
         if found:
             if tool_name not in seen_available:

--- a/slopmop/cli/doctor.py
+++ b/slopmop/cli/doctor.py
@@ -182,7 +182,7 @@ def _print_list_checks() -> None:
 def _print_gates_tree(project_root: Path, json_mode: bool = False) -> int:
     """Show quality gates grouped by level with required tools and status."""
     from slopmop.checks import ensure_checks_registered
-    from slopmop.checks.base import GateLevel, find_tool
+    from slopmop.checks.base import GateLevel
     from slopmop.core.registry import get_registry
 
     ensure_checks_registered()
@@ -192,11 +192,15 @@ def _print_gates_tree(project_root: Path, json_mode: bool = False) -> int:
     swab_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
     scour_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
 
-    for name, cls in registry._check_classes.items():
-        tools_status: List[Tuple[str, bool]] = []
-        for tool in cls.required_tools:
-            path = find_tool(tool, root)
-            tools_status.append((tool, path is not None))
+    for name in registry.list_checks():
+        check = registry.get_check(name, {})
+        if check is None:
+            continue
+        cls = type(check)
+        tools_status: List[Tuple[str, bool]] = [
+            (req.name, check.is_requirement_satisfied(req, root))
+            for req in check.requirements().items
+        ]
 
         role_tag = cls.role.value if hasattr(cls, "role") else ""
         entry = (name, role_tag, tools_status)

--- a/slopmop/cli/doctor.py
+++ b/slopmop/cli/doctor.py
@@ -188,12 +188,16 @@ def _print_gates_tree(project_root: Path, json_mode: bool = False) -> int:
     ensure_checks_registered()
     registry = get_registry()
     root = str(project_root)
+    # requirements() is config-dependent, so render with THIS repo's config.
+    from slopmop.doctor.sm_env import _load_repo_config
+
+    config = _load_repo_config(project_root)
 
     swab_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
     scour_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
 
     for name in registry.list_checks():
-        check = registry.get_check(name, {})
+        check = registry.get_check(name, config)
         if check is None:
             continue
         cls = type(check)

--- a/slopmop/doctor/gate_preflight.py
+++ b/slopmop/doctor/gate_preflight.py
@@ -94,8 +94,14 @@ def _gate_config_fingerprint(config: Dict[str, Any], gate_name: str) -> str:
 
 
 def _missing_required_tools(check: BaseCheck, project_root: Path) -> Tuple[str, ...]:
+    # Only REQUIRED tools block a gate — an absent optional tool just degrades
+    # it (the gate WARNs and runs), so it must not count as "blocked".
     return tuple(
-        sorted(req.name for req in check.missing_requirements(str(project_root)))
+        sorted(
+            req.name
+            for req in check.missing_requirements(str(project_root))
+            if not req.optional
+        )
     )
 
 

--- a/slopmop/doctor/gate_preflight.py
+++ b/slopmop/doctor/gate_preflight.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple, cast
 
 from slopmop.checks import ensure_checks_registered
-from slopmop.checks.base import BaseCheck, find_tool
+from slopmop.checks.base import BaseCheck
 from slopmop.checks.custom import register_custom_gates
 from slopmop.core.registry import get_registry
 
@@ -94,12 +94,9 @@ def _gate_config_fingerprint(config: Dict[str, Any], gate_name: str) -> str:
 
 
 def _missing_required_tools(check: BaseCheck, project_root: Path) -> Tuple[str, ...]:
-    missing: List[str] = []
-    root = str(project_root)
-    for tool in check.required_tools:
-        if find_tool(tool, root) is None:
-            missing.append(tool)
-    return tuple(sorted(missing))
+    return tuple(
+        sorted(req.name for req in check.missing_requirements(str(project_root)))
+    )
 
 
 def gather_gate_preflight_records(

--- a/slopmop/doctor/sm_env.py
+++ b/slopmop/doctor/sm_env.py
@@ -219,14 +219,15 @@ class ToolInventoryCheck(DoctorCheck):
         List[Tuple[str, str, str]],
         List[Tuple[str, str]],
     ]:
-        """Iterate REQUIRED_TOOLS and classify as resolved/missing/rejected."""
+        """Classify the inventory's tools as resolved/missing/rejected."""
         validator = get_validator()
         resolved: Dict[str, str] = {}
         missing: List[Tuple[str, str, str]] = []
         validator_rejects: List[Tuple[str, str]] = []
         seen: set[str] = set()
 
-        for tool_name, check_name, install_cmd in gate_tool_inventory():
+        config = _load_repo_config(root)
+        for tool_name, check_name, install_cmd in gate_tool_inventory(config):
             if tool_name in seen:
                 continue
             seen.add(tool_name)
@@ -496,7 +497,7 @@ class GateReadinessCheck(DoctorCheck):
             + _group_install_hints(
                 [
                     (t, "", cmd)
-                    for t, _, cmd in gate_tool_inventory()
+                    for t, _, cmd in gate_tool_inventory(config)
                     if t in missing_tools
                 ]
             ),

--- a/slopmop/doctor/sm_env.py
+++ b/slopmop/doctor/sm_env.py
@@ -13,8 +13,9 @@ reinstalling inside a pipx-managed env via raw ``pip install`` is a
 footgun.  The hint points to the right reinstall command.
 
 ``sm_env.tool_inventory`` — the check that actually tells you why gates
-are skipping.  Reuses ``REQUIRED_TOOLS`` and ``find_tool()`` so it
-reports exactly what the gates will see.  Also sanity-tests each
+are skipping.  Derives its tool list from each gate's ``requirements()``
+(via ``gate_tool_inventory()``) and ``find_tool()`` so it reports exactly
+what the gates will see.  Also sanity-tests each
 resolved path against the subprocess validator so the very bug that
 prompted this feature (Windows ``.exe`` rejected by the allowlist)
 surfaces as a FAIL here rather than a silent gate skip.
@@ -25,7 +26,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from slopmop.checks.base import find_tool
 from slopmop.checks.tool_inventory import gate_tool_inventory
@@ -111,6 +112,24 @@ class SmPipCheck(DoctorCheck):
             fix_hint=_reinstall_hint(),
             data=data,
         )
+
+
+def _load_repo_config(project_root: object) -> Dict[str, Any]:
+    """Load this repo's .sb_config.json (or {}) so config-dependent
+    requirements() reflect the repo, not the defaults."""
+    import json
+    from pathlib import Path
+
+    path = Path(str(project_root)) / ".sb_config.json"
+    if not path.exists():
+        return {}
+    try:
+        data: object = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return cast(Dict[str, Any], data)
+        return {}
+    except (OSError, ValueError):
+        return {}
 
 
 def _reinstall_hint() -> str:
@@ -226,7 +245,12 @@ class ToolInventoryCheck(DoctorCheck):
     def _collect_version_violations(
         self, resolved: Dict[str, str], root: str
     ) -> List[Tuple[str, str, str]]:
-        """Check required_tool_versions constraints for all registered gates."""
+        """Warn when an installed tool is older than a gate's declared pin.
+
+        Reads each gate's requirements() (the pins replaced the retired
+        required_tool_versions map). The pin is treated as a FLOOR — a newer
+        installed version is fine, an older one is flagged.
+        """
         violations: List[Tuple[str, str, str]] = []
         try:
             from slopmop.checks import ensure_checks_registered  # noqa: PLC0415
@@ -236,22 +260,22 @@ class ToolInventoryCheck(DoctorCheck):
             registry = get_registry()
             seen: set[Tuple[str, str]] = set()
             for gate_name in registry.list_checks():
-                check_cls = registry._check_classes.get(gate_name)
-                if check_cls is None:
+                check = registry.get_check(gate_name, {})
+                if check is None:
                     continue
-                for tool, spec in getattr(
-                    check_cls, "required_tool_versions", {}
-                ).items():
-                    key = (tool, spec)
+                for req in check.requirements().items:
+                    if not req.version:
+                        continue
+                    key = (req.name, req.version)
                     if key in seen:
                         continue
                     seen.add(key)
-                    path = resolved.get(tool) or find_tool(tool, root)
+                    path = resolved.get(req.name) or find_tool(req.name, root)
                     if not path:
                         continue
-                    msg = _check_version_constraint(tool, path, spec)
+                    msg = _check_version_constraint(req.name, path, f">={req.version}")
                     if msg:
-                        violations.append((tool, gate_name, msg))
+                        violations.append((req.name, gate_name, msg))
         except Exception:  # noqa: BLE001 — advisory only
             pass
         return violations
@@ -417,6 +441,10 @@ class GateReadinessCheck(DoctorCheck):
         ensure_checks_registered()
         registry = get_registry()
         root = str(ctx.project_root)
+        # requirements() is config-dependent (configured scanners, run_actionlint
+        # …), so instantiate each gate with THIS repo's config for accurate
+        # readiness rather than the defaults.
+        config = _load_repo_config(ctx.project_root)
 
         total_gates = 0
         ready_gates = 0
@@ -424,11 +452,14 @@ class GateReadinessCheck(DoctorCheck):
         missing_tools: set[str] = set()
 
         for name in registry.list_checks():
-            check = registry.get_check(name, {})
+            check = registry.get_check(name, config)
             if check is None:
                 continue
             total_gates += 1
-            gate_missing = check.missing_requirements(root)
+            # Only REQUIRED missing tools block — optional tools just degrade.
+            gate_missing = [
+                r for r in check.missing_requirements(root) if not r.optional
+            ]
             if gate_missing:
                 blocked_gates.append(name)
                 missing_tools.update(r.name for r in gate_missing)

--- a/slopmop/doctor/sm_env.py
+++ b/slopmop/doctor/sm_env.py
@@ -28,7 +28,7 @@ import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 from slopmop.checks.base import find_tool
-from slopmop.cli.detection import REQUIRED_TOOLS
+from slopmop.checks.tool_inventory import gate_tool_inventory
 from slopmop.cli.upgrade import UpgradeError, classify_install
 from slopmop.doctor.base import DoctorCheck, DoctorContext, DoctorResult
 from slopmop.subprocess.validator import SecurityError, get_validator
@@ -207,7 +207,7 @@ class ToolInventoryCheck(DoctorCheck):
         validator_rejects: List[Tuple[str, str]] = []
         seen: set[str] = set()
 
-        for tool_name, check_name, install_cmd in REQUIRED_TOOLS:
+        for tool_name, check_name, install_cmd in gate_tool_inventory():
             if tool_name in seen:
                 continue
             seen.add(tool_name)
@@ -412,7 +412,6 @@ class GateReadinessCheck(DoctorCheck):
 
     def run(self, ctx: DoctorContext) -> DoctorResult:
         from slopmop.checks import ensure_checks_registered
-        from slopmop.checks.base import find_tool
         from slopmop.core.registry import get_registry
 
         ensure_checks_registered()
@@ -424,17 +423,17 @@ class GateReadinessCheck(DoctorCheck):
         blocked_gates: List[str] = []
         missing_tools: set[str] = set()
 
-        for name, cls in registry._check_classes.items():
+        for name in registry.list_checks():
+            check = registry.get_check(name, {})
+            if check is None:
+                continue
             total_gates += 1
-            gate_ok = True
-            for tool in cls.required_tools:
-                if not find_tool(tool, root):
-                    gate_ok = False
-                    missing_tools.add(tool)
-            if gate_ok:
-                ready_gates += 1
-            else:
+            gate_missing = check.missing_requirements(root)
+            if gate_missing:
                 blocked_gates.append(name)
+                missing_tools.update(r.name for r in gate_missing)
+            else:
+                ready_gates += 1
 
         data: dict[str, object] = {
             "total_gates": total_gates,
@@ -464,7 +463,11 @@ class GateReadinessCheck(DoctorCheck):
             ),
             fix_hint="sm doctor --gates   # full dependency tree\n"
             + _group_install_hints(
-                [(t, "", cmd) for t, _, cmd in REQUIRED_TOOLS if t in missing_tools]
+                [
+                    (t, "", cmd)
+                    for t, _, cmd in gate_tool_inventory()
+                    if t in missing_tools
+                ]
             ),
             data=data,
         )

--- a/tests/unit/test_doctor_checks.py
+++ b/tests/unit/test_doctor_checks.py
@@ -367,7 +367,10 @@ class TestToolInventoryCheck:
             ("black", "gate.complex", "install-cmd"),
         ]
         with (
-            patch("slopmop.doctor.sm_env.REQUIRED_TOOLS", fake_required),
+            patch(
+                "slopmop.doctor.sm_env.gate_tool_inventory",
+                return_value=fake_required,
+            ),
             patch("slopmop.doctor.sm_env.find_tool", return_value=None),
         ):
             r = ToolInventoryCheck().run(ctx)
@@ -399,7 +402,10 @@ class TestToolInventoryCheck:
             return "/bin/black" if name == "black" else None
 
         with (
-            patch("slopmop.doctor.sm_env.REQUIRED_TOOLS", fake_required),
+            patch(
+                "slopmop.doctor.sm_env.gate_tool_inventory",
+                return_value=fake_required,
+            ),
             patch("slopmop.doctor.sm_env.find_tool", side_effect=fake_find),
             patch(
                 "slopmop.subprocess.validator.CommandValidator.validate",

--- a/tests/unit/test_doctor_checks.py
+++ b/tests/unit/test_doctor_checks.py
@@ -994,18 +994,21 @@ class TestCheckVersionConstraint:
 class TestToolInventoryVersionViolations:
     """ToolInventoryCheck covers version-violation reporting paths."""
 
+    def _fake_gate(self, *reqs):
+        from slopmop.checks.base import Requirements
+
+        check = MagicMock()
+        check.requirements.return_value = Requirements(items=tuple(reqs))
+        check.missing_requirements.return_value = []
+        return check
+
     def test_version_violation_reported_as_fail(self, ctx):
-        """When tool is found but version constraint fails → FAIL."""
-        from slopmop.checks.base import BaseCheck
+        """Tool found but older than its declared pin → FAIL (pin is a floor)."""
+        from slopmop.checks.base import Requirement
 
-        class FakeGate(BaseCheck):
-            name = "test:fake-version-gate"
-            required_tools = ["black"]
-            required_tool_versions = {"black": ">=999.0"}
-
-            def run(self, project_root, config=None):  # type: ignore[override]
-                return self._pass()
-
+        check = self._fake_gate(
+            Requirement(kind="python", name="black", version="999.0")
+        )
         with (
             patch(
                 "slopmop.doctor.sm_env.find_tool",
@@ -1019,7 +1022,7 @@ class TestToolInventoryVersionViolations:
                 "slopmop.core.registry.get_registry",
                 return_value=MagicMock(
                     list_checks=lambda: ["test:fake-version-gate"],
-                    _check_classes={"test:fake-version-gate": FakeGate},
+                    get_check=lambda name, cfg: check,
                 ),
             ),
         ):
@@ -1027,30 +1030,13 @@ class TestToolInventoryVersionViolations:
         assert r.status is DoctorStatus.FAIL
         assert "version constraint" in r.summary
 
-    def test_later_stricter_version_constraint_is_not_deduped_away(self, ctx):
-        """Differing specs for the same tool must each be checked."""
-        from slopmop.checks.base import BaseCheck
+    def test_same_tool_pin_across_gates_is_reported_once(self, ctx):
+        """A tool pinned at the same version in two gates is deduped."""
+        from slopmop.checks.base import Requirement
 
-        class BroadGate(BaseCheck):
-            name = "test:broad-gate"
-            required_tools = ["black"]
-            required_tool_versions = {"black": ">=22.0"}
-
-            def run(self, project_root, config=None):  # type: ignore[override]
-                return self._pass()
-
-        class StrictGate(BaseCheck):
-            name = "test:strict-gate"
-            required_tools = ["black"]
-            required_tool_versions = {"black": ">=24.0"}
-
-            def run(self, project_root, config=None):  # type: ignore[override]
-                return self._pass()
-
-        def fake_check(_tool, _path, spec):
-            if spec == ">=24.0":
-                return "found 23.0.0, requires >=24.0"
-            return None
+        a = self._fake_gate(Requirement(kind="python", name="black", version="24.0"))
+        b = self._fake_gate(Requirement(kind="python", name="black", version="24.0"))
+        gates = {"test:gate-a": a, "test:gate-b": b}
 
         with (
             patch(
@@ -1059,29 +1045,21 @@ class TestToolInventoryVersionViolations:
             ),
             patch(
                 "slopmop.doctor.sm_env._check_version_constraint",
-                side_effect=fake_check,
+                return_value="found 23.0.0, requires >=24.0",
             ),
             patch(
                 "slopmop.core.registry.get_registry",
                 return_value=MagicMock(
-                    list_checks=lambda: ["test:broad-gate", "test:strict-gate"],
-                    _check_classes={
-                        "test:broad-gate": BroadGate,
-                        "test:strict-gate": StrictGate,
-                    },
+                    list_checks=lambda: list(gates),
+                    get_check=lambda name, cfg: gates[name],
                 ),
             ),
         ):
             r = ToolInventoryCheck().run(ctx)
 
         assert r.status is DoctorStatus.FAIL
-        assert r.data["version_violations"] == [
-            {
-                "tool": "black",
-                "gate": "test:strict-gate",
-                "message": "found 23.0.0, requires >=24.0",
-            }
-        ]
+        assert len(r.data["version_violations"]) == 1
+        assert r.data["version_violations"][0]["tool"] == "black"
 
 
 # ── sm_env.GateDiagnosticsCheck ──────────────────────────────────────────

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -627,8 +627,35 @@ class TestDoctorMigrationFixes:
                     )
                 )
 
-        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda n, r: None)
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda *_a: None)
         # Only the required tool counts toward "blocked".
         assert _missing_required_tools(_OptionalToolGate({}), Path(tmp_path)) == (
             "req",
         )
+
+    def test_inventory_forwards_config_to_get_check(self, monkeypatch):
+        # Config-awareness: the repo config reaches get_check so config-gated
+        # requirements reflect the repo (#310 review).
+        from unittest.mock import MagicMock
+
+        from slopmop.checks import tool_inventory
+
+        captured = {}
+
+        class _Reg:
+            def list_checks(self):
+                return ["g"]
+
+            def get_check(self, name, cfg):
+                captured["cfg"] = cfg
+                m = MagicMock()
+                m.requirements.return_value = Requirements()
+                return m
+
+        import slopmop.checks as checks_mod
+        import slopmop.core.registry as reg_mod
+
+        monkeypatch.setattr(reg_mod, "get_registry", lambda: _Reg())
+        monkeypatch.setattr(checks_mod, "ensure_checks_registered", lambda: None)
+        tool_inventory.gate_tool_inventory({"x": 1})
+        assert captured["cfg"] == {"x": 1}

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -523,3 +523,69 @@ class TestAllToolGatesDeclareRequirements:
                     assert not any(
                         c in req.version for c in "<>=~ "
                     ), f"{name}: {req.name} version {req.version!r} looks like a range"
+
+
+class TestMigrationCoverage:
+    """Exercise the consumer-migration code paths."""
+
+    def test_resolved_install_hint_fallbacks(self):
+        assert (
+            Requirement(
+                kind="python", name="x", install_hint="custom hint"
+            ).resolved_install_hint()
+            == "custom hint"
+        )
+        assert (
+            Requirement(kind="python", name="bandit").resolved_install_hint()
+            == "pip install bandit"
+        )
+        assert (
+            Requirement(kind="npm", name="jscpd").resolved_install_hint()
+            == "npm install -g jscpd"
+        )
+        assert (
+            Requirement(kind="system", name="flutter").resolved_install_hint()
+            == "Install flutter"
+        )
+
+    def test_inventory_skips_env_requirements(self, monkeypatch):
+        # env-kind requirements are not installable tools — excluded.
+        from slopmop.checks import tool_inventory
+
+        class _FakeReg:
+            def list_checks(self):
+                return ["fake:gate"]
+
+            def get_check(self, name, cfg):
+                return _EnvAndToolGate({})
+
+        class _EnvAndToolGate(_ToollessGate):
+            def requirements(self):
+                return Requirements(
+                    items=(
+                        Requirement(kind="env", name="GH_TOKEN"),
+                        Requirement(kind="system", name="sometool"),
+                    )
+                )
+
+        # tool_inventory lazily imports these — patch them at their source.
+        import slopmop.checks as checks_mod
+        import slopmop.core.registry as reg_mod
+
+        monkeypatch.setattr(reg_mod, "get_registry", lambda: _FakeReg())
+        monkeypatch.setattr(checks_mod, "ensure_checks_registered", lambda: None)
+        rows = tool_inventory.gate_tool_inventory()
+        names = {t for t, _g, _h in rows}
+        assert "sometool" in names
+        assert "GH_TOKEN" not in names
+
+    def test_gate_preflight_missing_tools_uses_requirements(
+        self, monkeypatch, tmp_path
+    ):
+        from pathlib import Path
+
+        from slopmop.doctor.gate_preflight import _missing_required_tools
+
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda name, root: None)
+        gate = _RequiredToolGate({})
+        assert _missing_required_tools(gate, Path(tmp_path)) == ("frobnicate",)

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -589,3 +589,46 @@ class TestMigrationCoverage:
         monkeypatch.setattr("slopmop.checks.base.find_tool", lambda name, root: None)
         gate = _RequiredToolGate({})
         assert _missing_required_tools(gate, Path(tmp_path)) == ("frobnicate",)
+
+
+class TestDoctorMigrationFixes:
+    """Cover the #310 review-fix paths."""
+
+    def test_resolved_install_hint_env_fallback(self):
+        assert (
+            Requirement(kind="env", name="GH_TOKEN").resolved_install_hint()
+            == "Set the GH_TOKEN environment variable"
+        )
+
+    def test_load_repo_config_reads_sb_config(self, tmp_path):
+        import json
+
+        from slopmop.doctor.sm_env import _load_repo_config
+
+        assert _load_repo_config(tmp_path) == {}  # missing file → {}
+        (tmp_path / ".sb_config.json").write_text(json.dumps({"k": "v"}))
+        assert _load_repo_config(tmp_path) == {"k": "v"}
+        (tmp_path / ".sb_config.json").write_text("not json{")
+        assert _load_repo_config(tmp_path) == {}  # invalid → {}
+
+    def test_optional_missing_tool_does_not_block_preflight(
+        self, monkeypatch, tmp_path
+    ):
+        from pathlib import Path
+
+        from slopmop.doctor.gate_preflight import _missing_required_tools
+
+        class _OptionalToolGate(_ToollessGate):
+            def requirements(self) -> Requirements:
+                return Requirements(
+                    items=(
+                        Requirement(kind="system", name="opt", optional=True),
+                        Requirement(kind="system", name="req", optional=False),
+                    )
+                )
+
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda n, r: None)
+        # Only the required tool counts toward "blocked".
+        assert _missing_required_tools(_OptionalToolGate({}), Path(tmp_path)) == (
+            "req",
+        )

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -455,10 +455,10 @@ class TestVersionPinsTrackPyproject:
 
 
 class TestAllToolGatesDeclareRequirements:
-    """Registry-wide invariant: every gate that needs external tools declares
-    them via requirements(). Guards against a new gate re-introducing the
-    scattered-detection problem, and keeps the legacy required_tools list in
-    sync with the contract until the doctor migration retires it."""
+    """Registry-wide invariant: the requirements() contract is now the single
+    source of "what external tools do gates need". These guard that the derived
+    inventory stays complete and well-formed (the legacy required_tools /
+    REQUIRED_TOOLS sources have been retired)."""
 
     def _registry(self):
         from slopmop.checks import ensure_checks_registered
@@ -467,27 +467,44 @@ class TestAllToolGatesDeclareRequirements:
         ensure_checks_registered()
         return get_registry()
 
-    def test_required_tools_gates_declare_matching_requirements(self):
-        registry = self._registry()
-        offenders = []
-        for name in registry.list_checks():
-            check = registry.get_check(name, {})
-            if check is None:
-                continue
-            legacy = list(getattr(check, "required_tools", []) or [])
-            if not legacy:
-                continue
-            covered = set()
-            for req in check.requirements().items:
-                covered.add(req.name)
-                covered.update(req.alternatives)
-            missing = [t for t in legacy if t not in covered]
-            if missing:
-                offenders.append((name, missing))
-        assert not offenders, (
-            "gates list required_tools without a matching requirements() "
-            f"declaration: {offenders}"
-        )
+    def test_inventory_covers_the_core_first_party_tools(self):
+        # The derived inventory must keep covering the tools the gates run — a
+        # snapshot so a future gate that drops a requirement is caught.
+        from slopmop.checks.tool_inventory import gate_tool_inventory
+
+        tools = {t for t, _gate, _hint in gate_tool_inventory()}
+        expected = {
+            "black",
+            "isort",
+            "autoflake",
+            "flake8",
+            "ruff",
+            "mypy",
+            "pyright",
+            "vulture",
+            "radon",
+            "bandit",
+            "semgrep",
+            "detect-secrets",  # pragma: allowlist secret
+            "pip-audit",
+            "flutter",
+            "dart",
+        }
+        assert expected <= tools, f"inventory missing: {expected - tools}"
+
+    def test_inventory_rows_carry_a_nonempty_install_hint(self):
+        from slopmop.checks.tool_inventory import gate_tool_inventory
+
+        for tool, gate, hint in gate_tool_inventory():
+            assert hint, f"{tool} (in {gate}) has no install hint"
+
+    def test_security_tools_share_the_extras_install_hint(self):
+        # The extras-group remediation that REQUIRED_TOOLS used to hardcode is
+        # now derived from requirements().
+        from slopmop.checks.security import SecurityCheck
+
+        for req in SecurityCheck({}).requirements().items:
+            assert req.resolved_install_hint() == "pipx install slopmop[security]"
 
     def test_every_declared_requirement_is_well_formed(self):
         registry = self._registry()

--- a/tests/unit/test_sm_cli_config.py
+++ b/tests/unit/test_sm_cli_config.py
@@ -187,6 +187,38 @@ class TestCmdConfig:
             "disabled_gates", []
         )
 
+    def test_enable_gate_shows_missing_tool_install_hint(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Enabling a gate whose tools are missing surfaces each requirement's
+        own install hint (derived from requirements(), not a class attr)."""
+        (tmp_path / "main.py").write_text("print('x')\n")
+        (tmp_path / ".sb_config.json").write_text(
+            json.dumps({"disabled_gates": ["myopia:vulnerability-blindness.py"]})
+        )
+        # Make every tool look absent so the readiness block fires.
+        monkeypatch.setattr("slopmop.checks.base.find_tool", lambda n, r: None)
+        monkeypatch.setattr("slopmop.checks.base._module_available", lambda n: False)
+
+        args = argparse.Namespace(
+            project_root=str(tmp_path),
+            show=False,
+            enable="myopia:vulnerability-blindness.py",
+            disable=None,
+            current_pr_number=None,
+            clear_current_pr=False,
+            include_dir=None,
+            exclude_dir=None,
+            json=None,
+            swabbing_timeout=None,
+        )
+
+        cmd_config(args)
+
+        out = capsys.readouterr().out
+        assert "Missing tools" in out
+        assert "pipx install slopmop[security]" in out
+
     def test_enable_gate_not_applicable(self, tmp_path, capsys):
         """--enable refuses gates that cannot apply to this repo."""
         (tmp_path / ".sb_config.json").write_text(

--- a/tests/unit/test_sm_cli_config.py
+++ b/tests/unit/test_sm_cli_config.py
@@ -213,7 +213,7 @@ class TestCmdConfig:
             swabbing_timeout=None,
         )
 
-        cmd_config(args)
+        assert cmd_config(args) == 0
 
         out = capsys.readouterr().out
         assert "Missing tools" in out


### PR DESCRIPTION
The full unification (your call): `requirements()` becomes the **single source** of "what external tools do gates need, and how does a user install them." Both legacy sources and the three legacy class attrs are retired.

## The reconciliation
The blocker was that two sources served different audiences:
- `requirements()` → downstream **Action** (install `bandit==1.7.5`).
- `REQUIRED_TOOLS` (`detection.py`) → slop-mop's **own env-doctor** (`pipx install slopmop[security]`).

Resolved by giving `Requirement` an **`install_hint`** — the user-facing remediation command — set via `pip_cli_requirement(..., extra="security")` (→ `pipx install slopmop[security]`) or an explicit SDK URL. One Requirement now carries both the per-tool pin (for the Action) and the extras-group hint (for the env-doctor).

## Consumers migrated
- **`detection.py`**: the hardcoded `REQUIRED_TOOLS` list is gone; `_detect_tools()` derives `(tool, gate, install_hint)` from the new `tool_inventory.gate_tool_inventory()`.
- **`sm_env.py`** (both loops + install-hint grouping), **`gate_preflight.py`**, **`config.py`**, **`doctor.py`** → all read `requirements()` / `missing_requirements()` / `is_requirement_satisfied()`.

## Retired
`BaseCheck.required_tools` / `required_tool_versions` / `install_hint` class attrs, and `required_tools=[...]` / `install_hint="path"` on all ~11 gates.

## Why this is strictly better
The derived inventory now covers **ruff, node, actionlint** too — tools the hand-maintained `REQUIRED_TOOLS` had silently missed. Enforcement tests assert the inventory stays complete and every row carries an install hint.

Full suite green (3339; the 2 `test_refit_drain_functional` failures are pre-existing — fail on clean main, formatter-version flakiness).

## Next (the original goal this unlocks)
`sm doctor --required-deps` manifest emitter (additive, now trivial — one source) → the **v2 Action** consumer + the org-wide manual-scour audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes `requirements()` the single source of truth for both gate external-tool needs and the user install/remediation commands, removing the prior split between per-tool pins, legacy per-gate class attributes, and a hardcoded `REQUIRED_TOOLS` list.

**Core changes**
- Added `Requirement.install_hint` plus `Requirement.resolved_install_hint()` to produce environment-doctor install guidance (uses `install_hint` when provided; otherwise falls back by requirement kind).
- Extended `pip_cli_requirement(..., extra=...)` to auto-generate install hints for extras groups (e.g., `pipx install slopmop[security]`).
- Added `checks/tool_inventory.py: gate_tool_inventory()` to derive a deduped `(tool, gate, install_hint)` registry from all gates’ `requirements()` (skips `env`-kind requirements), replacing the hardcoded tool inventory.
- Updated gates to declare dependencies via `requirements()` only (retired legacy `required_tools`, `required_tool_versions`, and gate-level `install_hint`).

**Behavioral fixes / migrations**
- Doctor readiness + preflight now treat missing **optional** tools as WARN (only non-optional missing tools block).
- Gate checks now instantiate using each repo’s `.sb_config.json`, so `requirements()` reflects repo configuration.
- Version checks now interpret pinned requirements as **minimum floors** (warn when installed versions are older, rather than enforcing exact pins).
- Missing-tool remediation messages are sourced from the unified inventory/`resolved_install_hint()`, including env-kind-specific variable hints.

**Consumer updates**
- `cli/detection.py`, `doctor/sm_env.py`, `doctor/gate_preflight.py`, `cli/config.py`, and `cli/doctor.py` migrated to the unified requirements/tool-inventory flow.

**Testing**
- Updated and extended unit tests to mock `gate_tool_inventory()`, validate deduping/version reporting, and cover `resolved_install_hint()` + env skipping + migration behavior.
- Test suite passes (3339 passing tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->