### PR TITLE
feat(doctor): manifest excludes not-applicable gates' tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ body, so **a release cannot be published without a matching section here.**
 
 Format: one `## X.Y.Z` section per release, newest first.
 
+## 2.10.0
+
+### Gate dependencies
+
+- **`sm doctor --required-deps` is applicability-aware** (#315) — the dependency
+  manifest now excludes tools belonging to gates that don't apply to the repo
+  (e.g. the Dart/Flutter gates when there's no `pubspec.yaml`). A gate that
+  won't run doesn't make its tools "required", so the manifest — and the v2
+  GitHub Action that installs from it — reflects exactly what the repo actually
+  needs, instead of warning about system tools for gates that never execute.
+
 ## 2.9.0
 
 ### Gate dependencies

--- a/slopmop/checks/tool_inventory.py
+++ b/slopmop/checks/tool_inventory.py
@@ -55,7 +55,22 @@ def gate_tool_inventory(
     return sorted(rows)
 
 
-def aggregate_requirements(config: Optional[Dict[str, Any]] = None) -> "Requirements":
+def _gate_applies(check: Any, project_root: str) -> bool:
+    """Whether a gate applies to this repo, defaulting to True on error.
+
+    Conservative: if ``is_applicable`` raises, we keep the gate's tools rather
+    than risk dropping a genuinely-needed dependency from the manifest.
+    """
+    try:
+        return bool(check.is_applicable(project_root))
+    except Exception:  # noqa: BLE001 — better to over-include than miss a tool
+        return True
+
+
+def aggregate_requirements(
+    config: Optional[Dict[str, Any]] = None,
+    project_root: Optional[str] = None,
+) -> "Requirements":
     """Union of every gate's requirements(), deduped by tool name.
 
     This is what ``sm doctor --required-deps`` serializes into the manifest the
@@ -63,6 +78,12 @@ def aggregate_requirements(config: Optional[Dict[str, Any]] = None) -> "Requirem
     (install channel), exact pin, and probe. Config-dependent like the
     inventory — pass the repo config to reflect only the tools THIS repo's gates
     need. Deterministic: the Requirements manifest sorts by (kind, name).
+
+    When ``project_root`` is given, gates that are *not applicable* to that repo
+    (e.g. the Dart gates in a project with no ``pubspec.yaml``) are skipped —
+    a gate that won't run doesn't make its tools "required", so the manifest
+    reflects exactly what THIS repo actually needs. Omit it (the default) to get
+    the full config-enabled tool set regardless of applicability.
     """
     from slopmop.checks import ensure_checks_registered
     from slopmop.checks.base import Requirements
@@ -78,6 +99,8 @@ def aggregate_requirements(config: Optional[Dict[str, Any]] = None) -> "Requirem
             continue
         check = registry.get_check(gate_name, config)
         if check is None:
+            continue
+        if project_root is not None and not _gate_applies(check, project_root):
             continue
         for req in check.requirements().items:
             # Dedup by tool name — a tool has one pin/kind regardless of how

--- a/slopmop/cli/doctor.py
+++ b/slopmop/cli/doctor.py
@@ -263,16 +263,20 @@ def _print_gates_tree(project_root: Path, json_mode: bool = False) -> int:
 def _print_required_deps(project_root: Path) -> int:
     """Emit the external-dependency manifest the GitHub Action installs from.
 
-    A schema-versioned JSON document — the union of every gate's requirements()
-    for THIS repo's config — so the Action can install each tool by its exact
-    pin and install channel deterministically.
+    A schema-versioned JSON document — the union of every *applicable* gate's
+    requirements() for THIS repo's config — so the Action can install each tool
+    by its exact pin and install channel deterministically. Gates that don't
+    apply to the repo (e.g. Dart gates with no pubspec) are excluded: their
+    tools aren't needed because the gate won't run.
     """
     from slopmop.checks.base import build_requirements_document
     from slopmop.checks.tool_inventory import aggregate_requirements
     from slopmop.doctor.sm_env import _load_repo_config
 
     config = _load_repo_config(project_root)
-    document = build_requirements_document(aggregate_requirements(config))
+    document = build_requirements_document(
+        aggregate_requirements(config, project_root=str(project_root))
+    )
     print(json.dumps(document, indent=2, sort_keys=True))
     return 0
 

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -718,6 +718,11 @@ class TestRequiredDepsManifest:
     def test_emitter_outputs_schema_versioned_manifest(self, capsys, tmp_path):
         from slopmop.cli.doctor import _print_required_deps
 
+        # The emitter filters by applicability, so the repo needs Python content
+        # for the Python tool-gates (black/mypy/pyright/bandit) to apply.
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "__init__.py").write_text("x = 1\n")
+
         assert _print_required_deps(tmp_path) == 0
         doc = json.loads(capsys.readouterr().out)
         assert doc["schema_version"] == REQUIREMENTS_MANIFEST_SCHEMA_VERSION
@@ -790,3 +795,63 @@ class TestRequiredDepsManifest:
             ValueError, match="Conflicting requirements for tool 'black'"
         ):
             tool_inventory.aggregate_requirements()
+
+    def test_aggregate_filters_not_applicable_gates(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from slopmop.checks import tool_inventory
+
+        def gate(applicable, *reqs):
+            m = MagicMock()
+            m.requirements.return_value = Requirements(items=tuple(reqs))
+            m.is_applicable.return_value = applicable
+            return m
+
+        gates = {
+            "applies": gate(True, Requirement(kind="system", name="actionlint")),
+            "nope": gate(False, Requirement(kind="system", name="dart")),
+        }
+        import slopmop.checks as checks_mod
+        import slopmop.core.registry as reg_mod
+
+        monkeypatch.setattr(
+            reg_mod,
+            "get_registry",
+            lambda: MagicMock(
+                list_checks=lambda: list(gates), get_check=lambda n, c: gates[n]
+            ),
+        )
+        monkeypatch.setattr(checks_mod, "ensure_checks_registered", lambda: None)
+
+        # With a project_root, the not-applicable gate's tool is excluded.
+        filtered = tool_inventory.aggregate_requirements({}, project_root="/repo")
+        assert sorted(r.name for r in filtered.items) == ["actionlint"]
+        # Without a project_root, the full set is returned (back-compat).
+        full = tool_inventory.aggregate_requirements({})
+        assert sorted(r.name for r in full.items) == ["actionlint", "dart"]
+
+    def test_aggregate_includes_gate_when_is_applicable_raises(self, monkeypatch):
+        # Conservative: an is_applicable that blows up must not silently drop a
+        # potentially-needed tool.
+        from unittest.mock import MagicMock
+
+        from slopmop.checks import tool_inventory
+
+        boom = MagicMock()
+        boom.requirements.return_value = Requirements(
+            items=(Requirement(kind="system", name="actionlint"),)
+        )
+        boom.is_applicable.side_effect = RuntimeError("cannot tell")
+
+        import slopmop.checks as checks_mod
+        import slopmop.core.registry as reg_mod
+
+        monkeypatch.setattr(
+            reg_mod,
+            "get_registry",
+            lambda: MagicMock(list_checks=lambda: ["g"], get_check=lambda n, c: boom),
+        )
+        monkeypatch.setattr(checks_mod, "ensure_checks_registered", lambda: None)
+
+        out = tool_inventory.aggregate_requirements({}, project_root="/repo")
+        assert [r.name for r in out.items] == ["actionlint"]


### PR DESCRIPTION
Step 1 of finishing the v2 Action landing: make `sm doctor --required-deps` reflect what a repo **actually needs**, not every config-enabled gate's tools.

## Why
The v2 action's dogfood warned `System tools not on PATH: actionlint dart flutter`. For slop-mop, `dart`/`flutter` gates are **not applicable** (no `pubspec.yaml`) — they never run — so listing their tools as "required" is misleading noise. The manifest should be "what this repo needs."

## What
`aggregate_requirements(config, project_root=None)` gains an optional `project_root`; when given, it skips gates whose `is_applicable(project_root)` is False. `_print_required_deps` passes it. Result on slop-mop: system tools drop from `[actionlint, dart, flutter, node]` → `[actionlint, node]` (17 → 15 tools).

- Conservative: an `is_applicable()` that raises **keeps** the tool (never silently drop a needed dep).
- Omitting `project_root` preserves the full config-enabled set — back-compat for the doctor inventory and other callers.

Tests: not-applicable gate excluded; raising `is_applicable` still included; the emitter test now seeds Python content so the Python tool-gates apply. Full suite green (3357), swab clean.

## Next (after this releases as 2.10.0)
The action bumps to 2.10.0 + fixes the Node 20 cache deprecation; slop-mop regenerates its committed manifest (drops dart/flutter) and installs actionlint in the dogfood → fully clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Modified the `sm doctor --required-deps` command to exclude tools from gates that don't apply to the current repository by adding an optional `project_root` parameter to `aggregate_requirements()`. When provided, gates whose `is_applicable(project_root)` returns `False` are filtered out from the dependency manifest.

## Key updates

- `aggregate_requirements()` now accepts optional `project_root` parameter and skips non-applicable gates
- `_print_required_deps()` passes `project_root` to reflect actual repository dependencies
- Conservative error handling: if `is_applicable()` raises an exception, the gate's tools are retained
- Updated tests to verify filtering behavior and exception handling

## Impact

In slop-mop, reduces reported required tools from 4 to 2 (removes dart/flutter since no `pubspec.yaml` exists). Maintains backward compatibility—when `project_root` is omitted, full set of config-enabled tools is returned.

## Testing

3,357 tests pass; new tests added for applicability filtering and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->