### PR TITLE
fix(gates): find-duplicate-strings as npm dep + .slopmop gitignore robustness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,11 @@
 #       Workflow:   release.yml
 #       Environment: pypi
 #   - Add a RELEASE_PR_TOKEN secret from a fine-grained PAT or GitHub App token
-#     that can create PRs, read checks, merge PRs, and trigger follow-up workflows
+#     that can create PRs, read checks, merge PRs, and trigger follow-up workflows.
+#     IMPORTANT: it must also have **write (contents + pull-requests) access to
+#     ScienceIsNeato/slop-mop-action** — the "Bump slop-mop-action pin" job clones
+#     and opens a PR there. Without that scope that job 403s (best-effort, so the
+#     release still ships) and the action's slopmop-version must be bumped by hand.
 #   - (Optional) Do the same on https://test.pypi.org for staging
 
 name: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ body, so **a release cannot be published without a matching section here.**
 
 Format: one `## X.Y.Z` section per release, newest first.
 
+## 2.11.0
+
+### Gate dependencies
+
+- **The string-duplication scanner is a declared npm dependency** (#316) — the
+  `myopia:string-duplication` gate now declares `find-duplicate-strings` (npm,
+  pinned) in its `requirements()`, so it appears in `sm doctor --required-deps`
+  and the v2 GitHub Action installs it. The vendored copy under `tools/` is a
+  development convenience whose built output is gitignored, so it isn't present
+  in a fresh clone or a pip/pipx-installed slop-mop — without this the gate
+  warned-and-skipped in CI.
+
+### Fixes
+
+- **`.slopmop/` gitignore management recognizes the contents form** (#316) —
+  `ensure_slopmop_gitignored` now treats `.slopmop/*` (used by repos that commit
+  a file under `.slopmop/`, e.g. `required-deps.json` for the v2 Action) as
+  already-ignored, instead of appending a duplicate `.slopmop/` rule each run.
+
 ## 2.10.0
 
 ### Gate dependencies

--- a/slopmop/checks/quality/duplicate_strings.py
+++ b/slopmop/checks/quality/duplicate_strings.py
@@ -188,21 +188,29 @@ class StringDuplicationCheck(BaseCheck):
         )
 
     def requirements(self) -> Requirements:
-        """The Node runtime that runs the find-duplicate-strings tool.
+        """The find-duplicate-strings scanner and the Node runtime it needs.
 
-        Optional: when Node (or a global ``find-duplicate-strings`` binary) is
-        absent the gate degrades to a WARNED result rather than failing. The
-        tool script itself ships vendored with slop-mop; ``node`` is the only
-        external dependency, and declaring it lets doctor/the Action ensure it
-        is present instead of the gate discovering it missing at runtime.
+        Both optional: when absent the gate degrades to a WARNED result rather
+        than failing. The vendored copy under ``tools/`` is a *development*
+        convenience — its built ``lib/`` and ``node_modules/`` are gitignored, so
+        it isn't present in a fresh clone or a pip/pipx-installed slop-mop. A
+        deployed slop-mop (e.g. the GitHub Action) therefore needs the scanner
+        from npm; declaring it here puts it in the dependency manifest so the
+        Action installs it instead of the gate discovering it missing at runtime.
         """
         return Requirements(
             items=(
                 Requirement(
+                    kind="npm",
+                    name="find-duplicate-strings",
+                    version="3.1.1",
+                    optional=True,
+                    reason="the string-duplication scanner CLI",
+                ),
+                Requirement(
                     kind="system",
                     name="node",
                     optional=True,
-                    alternatives=("find-duplicate-strings",),
                     reason="runtime for the find-duplicate-strings duplication scanner",
                 ),
             )

--- a/slopmop/utils/__init__.py
+++ b/slopmop/utils/__init__.py
@@ -143,7 +143,12 @@ def ensure_slopmop_gitignored(project_root: Path) -> bool:
         content = gitignore.read_text(encoding="utf-8")
         for line in content.splitlines():
             stripped = line.strip()
-            if stripped == _SLOPMOP_GITIGNORE_ENTRY:
+            # Treat both the directory form (``.slopmop/``) and the contents
+            # form (``.slopmop/*``) as "already ignored". The contents form is
+            # what repos use to keep a committed file under .slopmop/ (e.g.
+            # ``required-deps.json`` for the v2 Action) re-includable; without
+            # recognizing it we'd append a duplicate ``.slopmop/`` on every run.
+            if stripped in (_SLOPMOP_GITIGNORE_ENTRY, _SLOPMOP_GITIGNORE_ENTRY + "*"):
                 return False
         # Ensure we start on a new line
         if content and not content.endswith("\n"):

--- a/tests/unit/test_ensure_gitignore.py
+++ b/tests/unit/test_ensure_gitignore.py
@@ -58,3 +58,15 @@ def test_includes_comment_in_new_gitignore(tmp_path: Path) -> None:
     ensure_slopmop_gitignored(tmp_path)
     content = (tmp_path / ".gitignore").read_text(encoding="utf-8")
     assert "# slop-mop working directory" in content
+
+
+def test_recognizes_contents_form_glob(tmp_path: Path) -> None:
+    # Repos that commit a file under .slopmop/ (e.g. required-deps.json for the
+    # v2 Action) use the `.slopmop/*` contents form so the file stays
+    # re-includable. The function must treat that as already-ignored and NOT
+    # append a duplicate `.slopmop/` directory rule.
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(".slopmop/*\n!.slopmop/required-deps.json\n", encoding="utf-8")
+    assert ensure_slopmop_gitignored(tmp_path) is False
+    content = gitignore.read_text(encoding="utf-8")
+    assert content.count(".slopmop/") == 2  # the glob + the negation, nothing new

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -372,13 +372,20 @@ class TestHardGateRequirements:
         (ds,) = reqs.items
         assert ds.import_name == "detect_secrets"  # pragma: allowlist secret
 
-    def test_duplicate_strings_declares_node(self):
+    def test_duplicate_strings_declares_scanner_and_node(self):
         from slopmop.checks.quality.duplicate_strings import StringDuplicationCheck
 
-        (req,) = StringDuplicationCheck({}).requirements().items
-        assert req.name == "node"
-        assert req.optional is True
-        assert "find-duplicate-strings" in req.alternatives
+        reqs = StringDuplicationCheck({}).requirements().items
+        by_name = {r.name: r for r in reqs}
+        # The scanner is an npm tool (the vendored copy is dev-only, gitignored),
+        # so a deployed slop-mop installs it from npm — pinned, optional.
+        scanner = by_name["find-duplicate-strings"]
+        assert scanner.kind == "npm"
+        assert scanner.version == "3.1.1"
+        assert scanner.optional is True
+        # node is the runtime, also optional (gate WARNs if absent).
+        assert by_name["node"].kind == "system"
+        assert by_name["node"].optional is True
 
 
 class TestPythonToolGates:


### PR DESCRIPTION
The two follow-ups + the "hidden missing dep" the v2 dogfood surfaced.

## 1. The hidden missing dep (string-duplication warned in CI)
`myopia:string-duplication` runs `find-duplicate-strings`. The vendored copy under `tools/` looked self-sufficient, but its built `lib/cli/index.js` and `node_modules/` are **gitignored** — so a fresh clone or a pip/pipx-installed slop-mop (the v2 Action) doesn't have a runnable tool, and the gate warned-and-skipped. v1 papered over this with a hardcoded `npm install -g find-duplicate-strings@3.1.1`; I dropped that in v2 on the wrong assumption it was vendored.

**Fix:** the gate declares `find-duplicate-strings` (npm, `3.1.1`, optional) in `requirements()`, so it lands in `sm doctor --required-deps` and the Action installs it via its npm path. `node` stays as the optional runtime. Contract-based, not hardcoded.

## 2. Follow-up: `.slopmop/` gitignore robustness
`ensure_slopmop_gitignored` only recognized the exact `.slopmop/` line, so when a repo uses the `.slopmop/*` contents form (to keep a committed `required-deps.json` re-includable) it appended a duplicate `.slopmop/` rule every run. Now it recognizes both forms.

Tests updated/added for both; full suite green (3358).

## Next (after this releases as 2.11.0)
Action bumps to 2.11.0; slop-mop regenerates its manifest (now includes `find-duplicate-strings`) → the dogfood's string-duplication gate runs fully → genuinely zero-warning run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes two issues discovered during v2 dogfooding:

**1. Missing npm dependency for string-duplication gate**
- Updated `StringDuplicationCheck.requirements()` to declare `find-duplicate-strings` as an optional npm dependency (v3.1.1) so it’s installed by the v2 GitHub Action
- Strengthened `tests/unit/test_gate_requirements.py` to assert both the optional npm scanner requirement and the optional `node` system requirement are declared

**2. Robust `.slopmop/` gitignore handling**
- Updated `ensure_slopmop_gitignored()` to treat both `.slopmop/` and `.slopmop/*` gitignore forms as already covered, preventing duplicate `.slopmop/` rules on repeated runs
- Added `test_recognizes_contents_form_glob` in `tests/unit/test_ensure_gitignore.py`

**Changelog:** Added v2.11.0 release notes documenting both changes.

All 3358 tests passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->