### PR TITLE
chore(deps): regenerate manifest for 2.11.0 (find-duplicate-strings)

### DIFF
--- a/.slopmop/required-deps.json
+++ b/.slopmop/required-deps.json
@@ -3,6 +3,17 @@
     {
       "alternatives": [],
       "import_name": "",
+      "install_hint": "",
+      "kind": "npm",
+      "name": "find-duplicate-strings",
+      "optional": true,
+      "probe": "",
+      "reason": "the string-duplication scanner CLI",
+      "version": "3.1.1"
+    },
+    {
+      "alternatives": [],
+      "import_name": "",
       "install_hint": "pipx install slopmop[lint]",
       "kind": "python",
       "name": "autoflake",
@@ -155,9 +166,7 @@
       "version": null
     },
     {
-      "alternatives": [
-        "find-duplicate-strings"
-      ],
+      "alternatives": [],
       "import_name": "",
       "install_hint": "",
       "kind": "system",


### PR DESCRIPTION
The last lap of the v2 landing — regenerates slop-mop's committed dependency manifest against slopmop 2.11.0.

## What
`sm doctor --required-deps` now lists **find-duplicate-strings** (npm, 3.1.1), so the manifest goes 15 → 16 tools. `@v2` was re-tagged to the 2.11.0 action, so:
- **Drift check** matches (action emits 16 = committed 16)
- The action **npm-installs find-duplicate-strings** → `myopia:string-duplication` runs instead of warn-and-skip

## Expected result
The `slop-mop-action @v2` dogfood: grade A, **zero warnings** — the genuinely-clean landing. (This is the fresh PR that replaces the manifest-regen step #314 would have carried, since #314 merged early.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated `.slopmop/required-deps.json` to regenerate the dependency manifest against slopmop version 2.11.0. Added `find-duplicate-strings` (npm, version 3.1.1) as a required dependency for the string-duplication scanner, increasing the tool count from 15 to 16. Removed `find-duplicate-strings` from an existing requirement's alternatives list. The `@v2` tag now aligns with the 2.11.0 action, ensuring the drift check passes and the scanner is properly installed during the string-duplication scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->