### PR TITLE
fix: tech-debt phase 1 — config divergence, dogfood floor, API promotion, sed guard

### DIFF
--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -9,10 +9,15 @@
 # (`sm doctor --required-deps`) and fails if that manifest has drifted, so
 # this job also exercises the deterministic-install + drift-guard path.
 #
-# Advisory by design. The repo's own gates (slopmop-sarif.yml) own
-# enforcement; this job only fails if the action itself breaks, not on
-# scour findings (fail-on-failure: false). SARIF upload is left to the
-# primary gate to avoid duplicate Code Scanning alerts.
+# Mostly advisory — but with a floor. The repo's own gates
+# (slopmop-sarif.yml) own finding-level enforcement, so raw scour exit
+# codes don't fail this job (fail-on-failure: false) and warnings stay
+# advisory. However, a FAILING gate under the action when the primary gate
+# is green means the action's environment broke something — exactly what
+# dogfooding exists to catch — so minimum-grade "A" fails the job on any
+# failing gate rather than smiling green over a failed verdict (which
+# masked a real type-blindness regression once). SARIF upload is left to
+# the primary gate to avoid duplicate Code Scanning alerts.
 name: Action Dogfood
 
 on:
@@ -81,6 +86,10 @@ jobs:
         with:
           command: scour
           fail-on-failure: "false"
+          # Grade floor: any FAILING gate (grade < A) fails this job — a
+          # divergence from the green primary gate is an action-env bug.
+          # Warnings (still grade A) remain advisory.
+          minimum-grade: "A"
           upload-sarif: "false"
 
       - name: Report hull grade

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,6 +513,16 @@ jobs:
             "/^[[:space:]]*slopmop-version:/,/default:/ s|^([[:space:]]*)default:.*|\\1default: \"==${VERSION}\"|" \
             action.yml
 
+          # Postcondition: the pin must now be present. A structural change in
+          # action.yml can make the sed match NOTHING — which previously fell
+          # through to the "already pinned" branch below and reported a false
+          # success. Fail loudly instead (continue-on-error on this step keeps
+          # the release itself shipping).
+          if ! grep -qE "^[[:space:]]*default:[[:space:]]*\"==${VERSION}\"" action.yml; then
+            echo "::error::sed did not produce a slopmop-version pin of ==${VERSION} in ${ACTION_REPO}/action.yml — its structure may have changed. Bump the pin manually."
+            exit 1
+          fi
+
           if git diff --quiet; then
             echo "${ACTION_REPO} already pinned to ==${VERSION}; nothing to do."
             exit 0

--- a/slopmop/cli/buff.py
+++ b/slopmop/cli/buff.py
@@ -184,7 +184,7 @@ def _normalize_buff_args(args: argparse.Namespace) -> argparse.Namespace:
     )
 
 
-def _load_json_file(path: Path) -> dict[str, Any]:
+def load_json_file(path: Path) -> dict[str, Any]:
     """Load a JSON file and enforce object shape."""
 
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -220,7 +220,7 @@ def _load_latest_protocol(project_root: str, pr_number: int) -> dict[str, Any] |
     protocol_path = loop_dir / "protocol.json"
     if not protocol_path.exists():
         return None
-    return _load_json_file(protocol_path)
+    return load_json_file(protocol_path)
 
 
 def _select_iteration_batch(

--- a/slopmop/cli/detection.py
+++ b/slopmop/cli/detection.py
@@ -157,13 +157,13 @@ def _detect_tools(project_root: Path) -> Dict[str, Any]:
         - missing_tools: list of (tool_name, check_name, install_command) for missing tools
     """
     from slopmop.checks.tool_inventory import gate_tool_inventory
-    from slopmop.doctor.sm_env import _load_repo_config
+    from slopmop.doctor.sm_env import load_repo_config
 
     available: List[str] = []
     missing: List[Tuple[str, str, str]] = []
     seen_available: Set[str] = set()
 
-    config = _load_repo_config(project_root)
+    config = load_repo_config(project_root)
     for tool_name, check_name, install_cmd in gate_tool_inventory(config):
         found = find_tool(tool_name, str(project_root))
         if found:

--- a/slopmop/cli/doctor.py
+++ b/slopmop/cli/doctor.py
@@ -189,9 +189,9 @@ def _print_gates_tree(project_root: Path, json_mode: bool = False) -> int:
     registry = get_registry()
     root = str(project_root)
     # requirements() is config-dependent, so render with THIS repo's config.
-    from slopmop.doctor.sm_env import _load_repo_config
+    from slopmop.doctor.sm_env import load_repo_config
 
-    config = _load_repo_config(project_root)
+    config = load_repo_config(project_root)
 
     swab_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
     scour_gates: List[Tuple[str, str, List[Tuple[str, bool]]]] = []
@@ -271,9 +271,9 @@ def _print_required_deps(project_root: Path) -> int:
     """
     from slopmop.checks.base import build_requirements_document
     from slopmop.checks.tool_inventory import aggregate_requirements
-    from slopmop.doctor.sm_env import _load_repo_config
+    from slopmop.doctor.sm_env import load_repo_config
 
-    config = _load_repo_config(project_root)
+    config = load_repo_config(project_root)
     document = build_requirements_document(
         aggregate_requirements(config, project_root=str(project_root))
     )

--- a/slopmop/cli/hooks.py
+++ b/slopmop/cli/hooks.py
@@ -97,7 +97,7 @@ fi
 """
 
 
-def _get_git_hooks_dir(project_root: Path) -> Optional[Path]:
+def get_git_hooks_dir(project_root: Path) -> Optional[Path]:
     """Find the .git/hooks directory for a project."""
     git_dir = project_root / ".git"
     if not git_dir.is_dir():
@@ -693,7 +693,7 @@ def cmd_commit_hooks(args: argparse.Namespace) -> int:
     if not args.hooks_action:
         args.hooks_action = "status"
 
-    hooks_dir = _get_git_hooks_dir(project_root)
+    hooks_dir = get_git_hooks_dir(project_root)
 
     # Global install/uninstall targets ~/.slopmop/git-hooks via core.hooksPath,
     # so it doesn't need to run inside a git repo. Per-repo actions do.
@@ -729,7 +729,7 @@ HOOK_PARK_SUFFIX = ".refit-parked"
 
 def _pre_commit_hook_path(project_root: Path) -> Optional[Path]:
     """Return the canonical pre-commit hook path for *project_root*."""
-    hooks_dir = _get_git_hooks_dir(project_root)
+    hooks_dir = get_git_hooks_dir(project_root)
     if hooks_dir is None:
         return None
     return hooks_dir / "pre-commit"

--- a/slopmop/cli/refit.py
+++ b/slopmop/cli/refit.py
@@ -35,7 +35,7 @@ from slopmop.cli._refit_precheck import (
     precheck_path,
     save_precheck,
 )
-from slopmop.cli.buff import _load_json_file
+from slopmop.cli.buff import load_json_file
 from slopmop.cli.scan_triage import write_json_out
 from slopmop.core.registry import get_registry
 from slopmop.reporting.envelope import Status, build_envelope
@@ -303,7 +303,7 @@ def _load_plan(project_root: Path) -> Dict[str, Any]:
     path = _plan_path(project_root)
     if not path.exists():
         raise FileNotFoundError("No refit plan found. Run `sm refit --start`.")
-    return _load_json_file(path)
+    return load_json_file(path)
 
 
 def _save_protocol(project_root: Path, protocol: Dict[str, Any]) -> None:
@@ -528,7 +528,7 @@ def _build_plan(project_root: Path, scour_artifact_path: Path) -> Dict[str, Any]
     register_custom_gates(config)
     registry = get_registry()
 
-    artifact = _load_json_file(scour_artifact_path)
+    artifact = load_json_file(scour_artifact_path)
     failing_results = _failed_results_from_scour_artifact(artifact)
 
     checks: List[BaseCheck] = []

--- a/slopmop/cli/upgrade.py
+++ b/slopmop/cli/upgrade.py
@@ -72,7 +72,7 @@ def _module_root() -> Path:
     return Path(slopmop.__file__).resolve().parent.parent
 
 
-def _running_from_source_checkout() -> bool:
+def running_from_source_checkout() -> bool:
     root = _module_root()
     return (root / "pyproject.toml").exists() and (root / ".git").exists()
 
@@ -395,7 +395,7 @@ def cmd_upgrade(args: argparse.Namespace) -> int:
     _require_packaging()
     version_class = _packaging_version_class()
     project_root = Path(getattr(args, "project_root", ".")).resolve()
-    if _running_from_source_checkout():
+    if running_from_source_checkout():
         print(f"❌ {SOURCE_CHECKOUT_UPGRADE_ERROR}", file=sys.stderr)
         return 1
     try:

--- a/slopmop/doctor/gate_preflight.py
+++ b/slopmop/doctor/gate_preflight.py
@@ -47,14 +47,19 @@ class GatePreflightRecord:
 
 
 def _load_gate_preflight_config(project_root: Path) -> Dict[str, Any]:
-    path = project_root / ".sb_config.json"
-    if not path.exists():
-        return {}
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
-    return cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
+    """Load the repo's RESOLVED config via the canonical loader.
+
+    Delegates to ``load_repo_config`` (``.sb_config.json`` merged with
+    ``[tool.slopmop]`` from pyproject.toml) so preflight sees exactly the
+    config that ``sm swab``/``sm scour`` run with. A previous version read
+    only ``.sb_config.json``, which silently ignored pyproject-configured
+    repos — refit/doctor readiness then disagreed with the actual gate run.
+    """
+    # Function-local import: sm_env pulls helpers from this module, so a
+    # module-level import here would be circular (house style for doctor).
+    from slopmop.doctor.sm_env import load_repo_config
+
+    return load_repo_config(project_root)
 
 
 def _as_dict_or_empty(value: Any) -> Dict[str, Any]:

--- a/slopmop/doctor/runtime.py
+++ b/slopmop/doctor/runtime.py
@@ -154,9 +154,9 @@ class SmResolutionCheck(DoctorCheck):
         }
 
         if not first:
-            from slopmop.cli.upgrade import _running_from_source_checkout
+            from slopmop.cli.upgrade import running_from_source_checkout
 
-            if _running_from_source_checkout():
+            if running_from_source_checkout():
                 return self._warn(
                     "sm not on PATH (source checkout)",
                     detail=(

--- a/slopmop/doctor/sm_env.py
+++ b/slopmop/doctor/sm_env.py
@@ -114,7 +114,7 @@ class SmPipCheck(DoctorCheck):
         )
 
 
-def _load_repo_config(project_root: object) -> Dict[str, Any]:
+def load_repo_config(project_root: object) -> Dict[str, Any]:
     """Load this repo's RESOLVED config (``.sb_config.json`` merged with
     ``[tool.slopmop]`` from pyproject.toml) so config-dependent requirements()
     match exactly what ``sm swab``/``sm scour`` run with.
@@ -235,7 +235,7 @@ class ToolInventoryCheck(DoctorCheck):
         validator_rejects: List[Tuple[str, str]] = []
         seen: set[str] = set()
 
-        config = _load_repo_config(root)
+        config = load_repo_config(root)
         for tool_name, check_name, install_cmd in gate_tool_inventory(config):
             if tool_name in seen:
                 continue
@@ -383,7 +383,7 @@ class PypiVersionCheck(DoctorCheck):
             _installed_version,
             _is_editable_install,
             _packaging_version_class,
-            _running_from_source_checkout,
+            running_from_source_checkout,
         )
 
         try:
@@ -412,7 +412,7 @@ class PypiVersionCheck(DoctorCheck):
 
         # Editable / source-checkout installs can't use ``sm upgrade``
         # — tell the developer the correct path instead.
-        is_dev = _running_from_source_checkout() or _is_editable_install()
+        is_dev = running_from_source_checkout() or _is_editable_install()
         if is_dev:
             return self._ok(
                 f"slopmop {current} (dev install; {latest} on PyPI)",
@@ -454,7 +454,7 @@ class GateReadinessCheck(DoctorCheck):
         # requirements() is config-dependent (configured scanners, run_actionlint
         # …), so instantiate each gate with THIS repo's config for accurate
         # readiness rather than the defaults.
-        config = _load_repo_config(ctx.project_root)
+        config = load_repo_config(ctx.project_root)
 
         total_gates = 0
         ready_gates = 0

--- a/slopmop/doctor/state.py
+++ b/slopmop/doctor/state.py
@@ -399,9 +399,9 @@ class StateCommitHookCheck(DoctorCheck):
     can_fix = True
 
     def _hook_path(self, ctx: DoctorContext) -> Optional[Path]:
-        from slopmop.cli.hooks import _get_git_hooks_dir
+        from slopmop.cli.hooks import get_git_hooks_dir
 
-        hooks_dir = _get_git_hooks_dir(ctx.project_root)
+        hooks_dir = get_git_hooks_dir(ctx.project_root)
         return (hooks_dir / "pre-commit") if hooks_dir else None
 
     def _hook_is_slopmop(self, hook_path: Path) -> bool:

--- a/tests/unit/test_doctor_checks.py
+++ b/tests/unit/test_doctor_checks.py
@@ -163,7 +163,7 @@ class TestSmResolutionCheck:
     def test_no_sm_on_path_source_checkout_warns(self, ctx, monkeypatch, tmp_path):
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
         with patch(
-            "slopmop.cli.upgrade._running_from_source_checkout",
+            "slopmop.cli.upgrade.running_from_source_checkout",
             return_value=True,
         ):
             r = SmResolutionCheck().run(ctx)
@@ -173,7 +173,7 @@ class TestSmResolutionCheck:
     def test_no_sm_on_path_installed_fails(self, ctx, monkeypatch, tmp_path):
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
         with patch(
-            "slopmop.cli.upgrade._running_from_source_checkout",
+            "slopmop.cli.upgrade.running_from_source_checkout",
             return_value=False,
         ):
             r = SmResolutionCheck().run(ctx)

--- a/tests/unit/test_gate_requirements.py
+++ b/tests/unit/test_gate_requirements.py
@@ -610,13 +610,13 @@ class TestDoctorMigrationFixes:
     def test_load_repo_config_reads_sb_config(self, tmp_path):
         import json
 
-        from slopmop.doctor.sm_env import _load_repo_config
+        from slopmop.doctor.sm_env import load_repo_config
 
-        assert _load_repo_config(tmp_path) == {}  # missing file → {}
+        assert load_repo_config(tmp_path) == {}  # missing file → {}
         (tmp_path / ".sb_config.json").write_text(json.dumps({"k": "v"}))
-        assert _load_repo_config(tmp_path) == {"k": "v"}
+        assert load_repo_config(tmp_path) == {"k": "v"}
         (tmp_path / ".sb_config.json").write_text("not json{")
-        assert _load_repo_config(tmp_path) == {}  # invalid → {}
+        assert load_repo_config(tmp_path) == {}  # invalid → {}
 
     def test_optional_missing_tool_does_not_block_preflight(
         self, monkeypatch, tmp_path

--- a/tests/unit/test_git_hooks.py
+++ b/tests/unit/test_git_hooks.py
@@ -14,10 +14,10 @@ from slopmop.cli.hooks import (
     _generate_merged_branch_guard,
     _generate_passthrough_hook,
     _generate_pre_push_hook_script,
-    _get_git_hooks_dir,
     _global_hooks_dir,
     _parse_hook_info,
     cmd_commit_hooks,
+    get_git_hooks_dir,
 )
 
 
@@ -44,12 +44,12 @@ class TestGitHooksFunctions:
     def test_get_git_hooks_dir(self, tmp_path):
         """Returns hooks dir for git repo."""
         (tmp_path / ".git").mkdir()
-        result = _get_git_hooks_dir(tmp_path)
+        result = get_git_hooks_dir(tmp_path)
         assert result == tmp_path / ".git" / "hooks"
 
     def test_get_git_hooks_dir_not_git(self, tmp_path):
         """Returns None for non-git directory."""
-        result = _get_git_hooks_dir(tmp_path)
+        result = get_git_hooks_dir(tmp_path)
         assert result is None
 
     def test_generate_hook_script(self):

--- a/tests/unit/test_refit_precheck.py
+++ b/tests/unit/test_refit_precheck.py
@@ -144,3 +144,36 @@ class TestApplyReviewActions:
 
         assert error is not None
         assert "Disable overconfidence:coverage-gaps.js" in error
+
+
+class TestPreflightConfigSources:
+    """Preflight must see the same RESOLVED config the gates run with.
+
+    Regression: the loader used to read only .sb_config.json, silently
+    ignoring [tool.slopmop] in pyproject.toml — so refit/doctor readiness
+    disagreed with the actual sm swab/scour behavior on pyproject-configured
+    repos (like slop-mop itself).
+    """
+
+    def test_pyproject_only_config_is_honored(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.slopmop]\ndisabled_gates = ["myopia:github-actions-hygiene"]\n'
+        )
+        from slopmop.doctor.gate_preflight import _load_gate_preflight_config
+
+        cfg = _load_gate_preflight_config(tmp_path)
+        assert cfg.get("disabled_gates") == ["myopia:github-actions-hygiene"]
+
+    def test_sb_config_layers_over_pyproject(self, tmp_path: Path) -> None:
+        # Same layering contract as sm swab/scour: pyproject is the base,
+        # .sb_config.json wins on conflicts.
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.slopmop]\ndisabled_gates = ["a:b"]\n'
+        )
+        (tmp_path / ".sb_config.json").write_text('{"disabled_gates": ["c:d"]}')
+        from slopmop.doctor.gate_preflight import _load_gate_preflight_config
+        from slopmop.sm import load_config
+
+        cfg = _load_gate_preflight_config(tmp_path)
+        assert cfg == load_config(tmp_path)  # byte-identical resolution
+        assert cfg.get("disabled_gates") == ["c:d"]

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -20,12 +20,12 @@ from slopmop.cli.upgrade import (
     _is_editable_install,
     _require_packaging,
     _run_upgrade_install,
-    _running_from_source_checkout,
     _upgrade_command,
     _validate_target_version,
     _validate_upgraded_install,
     _validated_pypi_url,
     cmd_upgrade,
+    running_from_source_checkout,
 )
 from tests.upgrade_scenario_helpers import materialize_upgrade_scenario
 
@@ -124,13 +124,13 @@ class TestMetadataHelpers:
         (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
         (tmp_path / ".git").write_text("gitdir: .git/modules/x\n")
         with patch("slopmop.cli.upgrade._module_root", return_value=tmp_path):
-            assert _running_from_source_checkout() is True
+            assert running_from_source_checkout() is True
 
     def test_running_from_source_checkout_false_for_installed_package(
         self, tmp_path: Path
     ):
         with patch("slopmop.cli.upgrade._module_root", return_value=tmp_path):
-            assert _running_from_source_checkout() is False
+            assert running_from_source_checkout() is False
 
 
 class TestPypiVersionHelpers:
@@ -267,7 +267,7 @@ class TestInstallCommandHelpers:
 
 
 class TestUpgradeCommand:
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=True)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=True)
     def test_upgrade_rejects_source_checkout(self, _mock_checkout, tmp_path, capsys):
         args = argparse.Namespace(
             project_root=str(tmp_path),
@@ -285,7 +285,7 @@ class TestUpgradeCommand:
     @patch("slopmop.cli.upgrade._resolve_target_version", return_value="0.9.1")
     @patch("slopmop.cli.upgrade._detect_install_type", return_value="venv")
     @patch("slopmop.cli.upgrade._installed_version", return_value="0.9.0")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_check_mode_does_not_mutate(
         self,
         _mock_checkout,
@@ -314,7 +314,7 @@ class TestUpgradeCommand:
     @patch("slopmop.cli.upgrade._detect_install_type", return_value="venv")
     @patch("slopmop.cli.upgrade._installed_version_fresh", return_value="0.9.1")
     @patch("slopmop.cli.upgrade._installed_version", return_value="0.9.0")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_upgrade_runs_backup_install_migrations_and_validation(
         self,
         _mock_checkout,
@@ -356,7 +356,7 @@ class TestUpgradeCommand:
     @patch("slopmop.cli.upgrade._resolve_target_version", return_value="0.9.0")
     @patch("slopmop.cli.upgrade._detect_install_type", return_value="venv")
     @patch("slopmop.cli.upgrade._installed_version", return_value="0.9.0")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_upgrade_noops_when_already_current(
         self,
         _mock_checkout,
@@ -385,7 +385,7 @@ class TestUpgradeCommand:
     @patch("slopmop.cli.upgrade._detect_install_type", return_value="venv")
     @patch("slopmop.cli.upgrade._installed_version_fresh", return_value="0.9.1")
     @patch("slopmop.cli.upgrade._installed_version", return_value="0.9.0")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_upgrade_reports_validation_failure(
         self,
         _mock_checkout,
@@ -426,7 +426,7 @@ class TestUpgradeCommand:
         side_effect=UpgradeError("bad install"),
     )
     @patch("slopmop.cli.upgrade._installed_version", return_value="0.9.0")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_upgrade_fails_for_unsupported_install(
         self,
         _mock_checkout,
@@ -462,7 +462,7 @@ class TestUpgradeCommand:
     @patch("slopmop.cli.upgrade._installed_version_fresh")
     @patch("slopmop.cli.upgrade._detect_install_type", return_value="venv")
     @patch("slopmop.cli.upgrade._installed_version")
-    @patch("slopmop.cli.upgrade._running_from_source_checkout", return_value=False)
+    @patch("slopmop.cli.upgrade.running_from_source_checkout", return_value=False)
     def test_upgrade_runs_real_migrations_for_fixture_scenarios(
         self,
         _mock_checkout,
@@ -586,7 +586,7 @@ class TestMissingDependencyGuard:
         with (
             patch("builtins.__import__", side_effect=_fake_import),
             patch(
-                "slopmop.cli.upgrade._running_from_source_checkout", return_value=False
+                "slopmop.cli.upgrade.running_from_source_checkout", return_value=False
             ),
         ):
             with pytest.raises(MissingDependencyError):


### PR DESCRIPTION
Phase 1 of the tech-debt audit — the four quick-win findings, one branch.

## 1. gate_preflight config divergence (verified live bug)
`_load_gate_preflight_config` read only `.sb_config.json`, silently ignoring `[tool.slopmop]` in pyproject.toml — so `sm refit --start` and doctor readiness saw **different config than what `sm swab`/`sm scour` actually run with** on pyproject-configured repos (including this one). Verified empirically before the fix: the preflight loader returned `{}` where the canonical loader returned the pyproject config. Now delegates to the canonical loader; regression tests cover pyproject-only and layered (.sb_config.json-over-pyproject) configs. Same bug class as the one fixed in #310 — recurrence is why config-source unification is Phase 3 of the audit.

## 2. Dogfood grade floor
`action-dogfood.yml` was fully advisory (`fail-on-failure: "false"`) — a green badge over a failed scour verdict, which masked a real type-blindness regression once. It keeps findings-level enforcement with the primary gate (raw exit codes still don't fail it, warnings stay advisory) but adds **`minimum-grade: "A"`**: a failing gate under the action while the primary gate is green is an action-environment bug — exactly what dogfooding exists to catch — and now fails the job.

## 3. Promote 4 cross-module private helpers to public API
Five modules imported another package's underscore-privates: `load_repo_config` (was `doctor.sm_env._load_repo_config`, used by `cli/detection` + `cli/doctor`), `load_json_file` (`cli.buff`, used by `cli/refit`), `running_from_source_checkout` (`cli.upgrade`, used by `doctor/runtime` + `doctor/sm_env`), `get_git_hooks_dir` (`cli.hooks`, used by `doctor/state`). Mechanical rename, all call sites + test patch-strings updated.

## 4. Release bump-job postcondition
The action-pin bump edits `action.yml` via a bounded sed; if the file's structure ever shifts, the sed matches nothing and the job fell through to the "already pinned" branch — reporting a **false success**. Now a grep postcondition verifies the pin actually landed and errors loudly otherwise (`continue-on-error` keeps the release itself shipping).

Full suite green (3,360 — includes 2 new regression tests). Swab clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Aligned preflight gate config loading with the canonical repo config resolver, so it now honors both `.sb_config.json` and `[tool.slopmop]` from `pyproject.toml`; added regression coverage for pyproject-only and layered configs.
- Raised the action dogfood gate floor to `minimum-grade: "A"` so failing gates now fail the job instead of being reported as successful.
- Promoted shared helpers to public API: `load_repo_config`, `load_json_file`, `running_from_source_checkout`, and `get_git_hooks_dir`, with call sites and tests updated.
- Hardened the release pin bump step to verify the `sed` edit actually updated `action.yml`, failing if the expected pin is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->