### PR TITLE
chore(ci): cap artifact retention

### DIFF
--- a/.github/workflows/slopmop-sarif.yml
+++ b/.github/workflows/slopmop-sarif.yml
@@ -190,6 +190,8 @@ jobs:
           name: slopmop-results
           path: slopmop-results.json
           if-no-files-found: warn
+          # buff downloads this shortly after the run; a week is a safe margin.
+          retention-days: 7
 
       - name: Publish SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2


### PR DESCRIPTION
## What
Cap GitHub Actions artifact retention and stop uploading htmlcov bloat.

## Why
Audit across all active repos found **every** artifact upload was using GitHub's default **90-day** retention, and coverage uploads shipped the full `htmlcov/` HTML site (~10MB/run). With CI churn this accrued storage/GB-hours against the 0.5GB free tier. (Concurrency-cancellation was already in place, so minutes were fine — retention was the gap.)

## Changes
- `slopmop-sarif.yml`: slopmop-results (buff-consumed) → 7d

## Risk
Low. Artifacts are regenerable CI output; `sm buff` regenerates its inputs by re-running. Coverage.xml (the machine-readable report) is retained; only the rarely-downloaded HTML tree is dropped.