### PR TITLE
fix: tech-debt phase 2 — unpinned-ref check, venv unification, registry smoke, drain-test root cause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,3 +186,9 @@ pip_audit_ignore_vulns = [
 pip_audit_ignore_vulns = [
     "GHSA-5239-wwwm-4pmq",  # pygments ReDoS (CVE-2026-4539), low severity, no fix available
 ]
+
+[tool.slopmop.myopia.gates."github-actions-hygiene"]
+# The dogfood deliberately tracks the moving @v2 major tag — that tag is the
+# delivery channel for action fixes and validating what consumers resolve is
+# the dogfood's whole point. Everything else must be SHA-pinned.
+allow_unpinned = ["scienceisneato/slop-mop-action"]

--- a/slopmop/checks/mixins.py
+++ b/slopmop/checks/mixins.py
@@ -73,6 +73,14 @@ PYTHON_SOURCE_PATH = "system_path"
 PYTHON_SOURCE_NOT_FOUND = "not_found"
 
 
+# Recognized project-venv directory names, in priority order. The single
+# source of truth for every consumer that resolves a project environment —
+# detect_venv_path (pyright config), has_project_venv, and the mixin's
+# python resolution must agree on this, or gates silently analyze
+# different environments.
+VENV_DIR_NAMES = ("venv", ".venv")
+
+
 def _find_python_in_venv(venv_path: Path) -> Optional[str]:
     """Return the ``python`` inside *venv_path* or None if none exists."""
     for subpath in ["bin/python", "Scripts/python.exe"]:
@@ -85,12 +93,33 @@ def _find_python_in_venv(venv_path: Path) -> Optional[str]:
 def has_project_venv(project_root: str | Path) -> bool:
     """True when *project_root* contains a ``venv/`` or ``.venv/``."""
     root = Path(project_root)
-    for venv_dir in ("venv", ".venv"):
+    for venv_dir in VENV_DIR_NAMES:
         if (root / venv_dir / "bin" / "python").exists():
             return True
         if (root / venv_dir / "Scripts" / "python.exe").exists():
             return True
     return False
+
+
+def detect_venv_path(project_root: str) -> tuple[Optional[str], Optional[str]]:
+    """Detect the project venv as a ``(parent_dir, venv_name)`` pair.
+
+    The shape pyright's ``venvPath``/``venv`` config wants, hosted here so
+    every consumer resolves the same environment (this used to live in
+    type_checking.py as a private duplicate that could drift from
+    ``has_project_venv``). Priority: project-local venvs in
+    ``VENV_DIR_NAMES`` order, then ``$VIRTUAL_ENV``. Returns
+    ``(None, None)`` when nothing is found.
+    """
+    for venv_name in VENV_DIR_NAMES:
+        if (Path(project_root) / venv_name).exists():
+            return project_root, venv_name
+
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if virtual_env and Path(virtual_env).exists():
+        return str(Path(virtual_env).parent), Path(virtual_env).name
+
+    return None, None
 
 
 def _git_tracked_python_files_exist(project_root: Path) -> bool | None:

--- a/slopmop/checks/python/type_checking.py
+++ b/slopmop/checks/python/type_checking.py
@@ -28,7 +28,7 @@ import shutil
 import time
 from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, cast
 
 from slopmop.checks.base import (
     BaseCheck,
@@ -40,7 +40,7 @@ from slopmop.checks.base import (
     ToolContext,
     pip_cli_requirement,
 )
-from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.mixins import PythonCheckMixin, detect_venv_path
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 from slopmop.utils.jsonc import loads_jsonc
 
@@ -154,28 +154,6 @@ def _detect_python_version(project_root: str) -> str:
             # if anything goes wrong, we fall back to the default version below.
             pass
     return "3.11"
-
-
-def _detect_venv_path(project_root: str) -> Tuple[Optional[str], Optional[str]]:
-    """Detect venv path and name for pyright config.
-
-    Returns (venvPath, venv) tuple for pyrightconfig.json.
-    Priority: project-local venvs first, then VIRTUAL_ENV.
-    """
-    # Check project-local venvs first (highest priority)
-    for venv_name in ["venv", ".venv"]:
-        venv_path = Path(project_root) / venv_name
-        if venv_path.exists():
-            return project_root, venv_name
-
-    # Fall back to VIRTUAL_ENV if no project venv exists
-    virtual_env = os.environ.get("VIRTUAL_ENV")
-    if virtual_env and Path(virtual_env).exists():
-        venv_parent = str(Path(virtual_env).parent)
-        venv_name = Path(virtual_env).name
-        return venv_parent, venv_name
-
-    return None, None
 
 
 def _detect_source_dirs(project_root: str) -> List[str]:
@@ -375,7 +353,7 @@ class PythonTypeCheckingCheck(BaseCheck, PythonCheckMixin):
         """Build pyrightconfig.json content for this run."""
         source_dirs = _detect_source_dirs(project_root)
         python_version = _detect_python_version(project_root)
-        venv_path, venv_name = _detect_venv_path(project_root)
+        venv_path, venv_name = detect_venv_path(project_root)
         base_config_file = self.config.get("pyright_config_file")
         explicitly_configured = bool(base_config_file)
         # Fall back to a project-owned pyrightconfig.json so its rule overrides

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -27,6 +27,10 @@ _PYTHON_HEREDOC_RE = re.compile(
     r"\b(?:python|python3(?:\.\d+)?)\b.*<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?"
 )
 _ACTIONLINT_RE = re.compile(r"^(.*?):(\d+):(\d+):\s*(.*?)(?:\s+\[(.+)\])?$")
+# An immutable pin is a FULL 40-hex commit SHA — abbreviated SHAs are
+# forgeable (an attacker can mine a colliding short prefix) and tags/branches
+# are mutable, so neither counts as pinned.
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 _DEPRECATED_ACTION_MIN_MAJOR = {
     "actions/checkout": (5, "actions/checkout@v5"),
     "actions/setup-python": (6, "actions/setup-python@v6"),
@@ -263,6 +267,15 @@ class GitHubActionsHygieneCheck(BaseCheck):
                 default=True,
                 description="Run actionlint when the executable is available on PATH",
             ),
+            ConfigField(
+                name="allow_unpinned",
+                field_type="string[]",
+                default=[],
+                description=(
+                    "owner/repo action prefixes exempt from the unpinned-ref "
+                    "check (deliberate moving tags, e.g. a first-party action)"
+                ),
+            ),
         ]
 
     def requirements(self) -> Requirements:
@@ -375,6 +388,9 @@ class GitHubActionsHygieneCheck(BaseCheck):
                     findings.extend(
                         self._deprecated_action_findings(uses, rel_path, lines)
                     )
+                    findings.extend(
+                        self._unpinned_action_findings(uses, rel_path, lines)
+                    )
                 if _uses_checkout(step):
                     findings.extend(
                         self._checkout_permission_findings(
@@ -410,6 +426,53 @@ class GitHubActionsHygieneCheck(BaseCheck):
                 line=_line_for_uses(lines, uses_value),
                 rule_id="deprecated-action-version",
                 fix_strategy=f"Upgrade to {replacement} or a newer supported major.",
+            )
+        ]
+
+    def _unpinned_action_findings(
+        self,
+        uses_value: str,
+        rel_path: str,
+        lines: list[str],
+    ) -> list[Finding]:
+        """Flag third-party actions referenced by mutable tag/branch refs.
+
+        A tag like ``@v5`` can be repointed by whoever controls the action
+        repo, silently changing the code CI executes — the supply-chain gap
+        is closed by pinning to an immutable full commit SHA. Deliberate
+        moving tags (e.g. a first-party action whose major tag is the
+        delivery channel) can be exempted via the ``allow_unpinned`` config
+        list, which matches the ``owner/repo`` prefix case-insensitively.
+        """
+        # Local composite actions and docker images aren't owner/repo@ref
+        # marketplace actions — the pinning model doesn't apply.
+        if uses_value.startswith("./") or uses_value.startswith("docker://"):
+            return []
+        action, ref = _action_ref(uses_value)
+        if not ref:
+            return []
+        if _FULL_SHA_RE.fullmatch(ref):
+            return []
+        from slopmop.utils import as_str_list
+
+        allow = [a.lower() for a in as_str_list(self.config.get("allow_unpinned"))]
+        if any(action == a or action.startswith(a + "/") for a in allow):
+            return []
+        return [
+            Finding(
+                message=(
+                    f"Unpinned GitHub Action ref: {uses_value} — a mutable "
+                    "tag/branch can be repointed to different code"
+                ),
+                level=FindingLevel.ERROR,
+                file=rel_path,
+                line=_line_for_uses(lines, uses_value),
+                rule_id="unpinned-action-ref",
+                fix_strategy=(
+                    "Pin to the full commit SHA (uses: owner/repo@<40-hex-sha> "
+                    "# vX.Y.Z), or add the action to this gate's "
+                    "allow_unpinned config if the moving tag is deliberate."
+                ),
             )
         ]
 

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -29,8 +29,9 @@ _PYTHON_HEREDOC_RE = re.compile(
 _ACTIONLINT_RE = re.compile(r"^(.*?):(\d+):(\d+):\s*(.*?)(?:\s+\[(.+)\])?$")
 # An immutable pin is a FULL 40-hex commit SHA — abbreviated SHAs are
 # forgeable (an attacker can mine a colliding short prefix) and tags/branches
-# are mutable, so neither counts as pinned.
-_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+# are mutable, so neither counts as pinned. Case-insensitive: git SHAs are
+# hex and GitHub accepts either case in ``uses:`` refs.
+_FULL_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 _DEPRECATED_ACTION_MIN_MAJOR = {
     "actions/checkout": (5, "actions/checkout@v5"),
     "actions/setup-python": (6, "actions/setup-python@v6"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures for slopmop tests."""
 
+import os
 from pathlib import Path
 from typing import Generator
 from unittest.mock import MagicMock, Mock
@@ -141,3 +142,23 @@ def make_mock_status_registry(all_gates=None, swab_gates=None, scour_gates=None)
     mock_check.skip_reason.return_value = ""
     mock_reg.get_check.return_value = mock_check
     return mock_reg
+
+
+@pytest.fixture
+def isolated_git_env(monkeypatch, tmp_path_factory):
+    """Shield real-git tests from the developer's machine git config.
+
+    Functional tests that create real repos and commit in them inherit the
+    developer's global/system git config through the environment — most
+    destructively a machine-wide ``core.hooksPath`` (e.g. slop-mop's own gang
+    hooks), whose hooks then intercept the test repos' commits and change
+    observable behavior (tests pass on bare CI runners, fail on hook-managed
+    workstations). Point git at an empty global config and a null system
+    config so tests see the same bare environment CI does. Env vars propagate
+    to every subprocess the code under test spawns.
+    """
+    fake_global = tmp_path_factory.mktemp("gitcfg") / "gitconfig"
+    fake_global.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(fake_global))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    return fake_global

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from slopmop.checks import ensure_checks_registered
 from slopmop.checks.workflow import GitHubActionsHygieneCheck
 from slopmop.checks.workflow.github_actions import (
     _action_ref,
@@ -30,6 +31,9 @@ def _check() -> GitHubActionsHygieneCheck:
 
 class TestGitHubActionsHygieneCheck:
     def test_name_and_registration(self):
+        # Registry is a process-global other test files usually populate first;
+        # register explicitly so this test passes in isolation too.
+        ensure_checks_registered()
         check = _check()
 
         assert check.full_name == "myopia:github-actions-hygiene"
@@ -50,8 +54,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       - run: python --version
 """,
         )
@@ -104,7 +108,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 """,
         )
 
@@ -123,7 +127,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 """,
         )
 
@@ -143,7 +147,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 """,
         )
 
@@ -171,6 +175,11 @@ jobs:
         assert result.status == CheckStatus.FAILED
         assert result.findings[0].rule_id == "deprecated-action-version"
         assert "actions/checkout@v5" in result.findings[0].fix_strategy
+        # A deprecated tag ref is also an unpinned ref — both findings fire.
+        assert {f.rule_id for f in result.findings} == {
+            "deprecated-action-version",
+            "unpinned-action-ref",
+        }
 
     def test_empty_and_non_mapping_workflows_are_safe_noops(self, tmp_path):
         _write_workflow(tmp_path, "", "empty.yml")
@@ -214,7 +223,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 """,
             )
 
@@ -235,7 +244,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 """,
         )
 
@@ -255,7 +264,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7178a7dbf82e28a83dcf4e123a4c26e0d4f9d # v5
         with:
           use_oidc: true
   npm:
@@ -286,7 +295,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 """,
         )
 
@@ -438,3 +447,117 @@ jobs:
         files = _workflow_files(tmp_path, [".github/workflows", "missing"])
 
         assert [path.name for path in files] == ["ci.yaml", "ci.yml"]
+
+
+class TestUnpinnedActionRefs:
+    """The unpinned-action-ref check: mutable tags/branches vs SHA pins."""
+
+    def _run(self, tmp_path, body, config=None):
+        _write_workflow(tmp_path, body)
+        cfg = {"run_actionlint": False}
+        cfg.update(config or {})
+        return GitHubActionsHygieneCheck(cfg).run(str(tmp_path))
+
+    def test_tag_ref_is_flagged(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v6
+""",
+        )
+        assert result.status == CheckStatus.FAILED
+        (finding,) = result.findings
+        assert finding.rule_id == "unpinned-action-ref"
+        assert "actions/setup-node@v6" in finding.message
+
+    def test_branch_ref_is_flagged(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: someorg/some-action@main
+""",
+        )
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "unpinned-action-ref"
+
+    def test_full_sha_pin_is_clean(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+""",
+        )
+        assert result.status == CheckStatus.PASSED
+
+    def test_short_sha_is_not_a_pin(self, tmp_path):
+        # Abbreviated SHAs are forgeable — only the full 40-hex counts.
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@48b55a0
+""",
+        )
+        assert result.status == CheckStatus.FAILED
+        assert result.findings[0].rule_id == "unpinned-action-ref"
+
+    def test_allowlist_exempts_exact_and_subpath(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ScienceIsNeato/slop-mop-action@v2
+      - uses: github/codeql-action/upload-sarif@v4
+""",
+            config={
+                "allow_unpinned": [
+                    "scienceisneato/slop-mop-action",
+                    "github/codeql-action",
+                ]
+            },
+        )
+        assert result.status == CheckStatus.PASSED
+
+    def test_local_and_docker_refs_are_exempt(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/local-thing
+      - uses: docker://alpine:latest
+""",
+        )
+        assert result.status == CheckStatus.PASSED

--- a/tests/unit/test_github_actions_hygiene.py
+++ b/tests/unit/test_github_actions_hygiene.py
@@ -507,6 +507,22 @@ jobs:
         )
         assert result.status == CheckStatus.PASSED
 
+    def test_uppercase_full_sha_pin_is_clean(self, tmp_path):
+        # Git SHAs are hex and GitHub accepts either case in uses: refs.
+        result = self._run(
+            tmp_path,
+            """
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@48B55A011BDA9F5D6AEB4C2D9C7362E8DAE4041E # v6.4.0
+""",
+        )
+        assert result.status == CheckStatus.PASSED
+
     def test_short_sha_is_not_a_pin(self, tmp_path):
         # Abbreviated SHAs are forgeable — only the full 40-hex counts.
         result = self._run(

--- a/tests/unit/test_refit_drain_functional.py
+++ b/tests/unit/test_refit_drain_functional.py
@@ -19,6 +19,26 @@ import pytest
 
 from slopmop.cli._refit_formatting import drain_formatting_before_commit
 
+
+@pytest.fixture(autouse=True)
+def _functional_environment(isolated_git_env):
+    """Make these functional tests self-sufficient and machine-independent.
+
+    Two ingredients, found the hard way:
+    - ``ensure_checks_registered()``: drain resolves formatters through the
+      process-global registry. In a full suite run some earlier test file
+      populates it; run this file in isolation and the registry is empty, so
+      drain silently no-ops — no formatting, no style commit. That was the
+      real cause of "fails locally, passes CI".
+    - ``isolated_git_env``: real commits must not inherit the developer's
+      machine git config (global core.hooksPath etc.) — defense-in-depth so
+      the tests see the same bare git environment CI does.
+    """
+    from slopmop.checks import ensure_checks_registered
+
+    ensure_checks_registered()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_registry_smoke.py
+++ b/tests/unit/test_registry_smoke.py
@@ -1,0 +1,72 @@
+"""Real-registry smoke tests — no mocks, the actual registration path.
+
+The refit/executor unit suites exercise their logic against ``_FakeRegistry``
+stand-ins, which means a regression in real gate registration, instantiation,
+or remediation-priority resolution would sail through them. These tests run
+the genuine ``ensure_checks_registered`` + ``CheckRegistry`` end to end so
+that class of break is caught in the unit tier (tech-debt audit finding #9).
+"""
+
+from __future__ import annotations
+
+from slopmop.checks import ensure_checks_registered
+from slopmop.checks.base import BaseCheck
+from slopmop.core.registry import curated_remediation_order_names, get_registry
+
+
+def _registry():
+    ensure_checks_registered()
+    return get_registry()
+
+
+class TestRealRegistrySmoke:
+    def test_all_gates_register_and_instantiate(self):
+        registry = _registry()
+        names = registry.list_checks()
+        # A registration regression usually shows up as a silently shorter
+        # list, not an exception — anchor a floor well below the real count
+        # (38 at time of writing) but far above any partial-import failure.
+        assert len(names) >= 30
+
+        for name in names:
+            check = registry.get_check(name, {})
+            assert isinstance(check, BaseCheck), f"{name} failed to instantiate"
+            assert check.full_name == name
+            # The stringly-typed contract every consumer split()s on.
+            category, _, gate = name.partition(":")
+            assert category and gate, f"malformed gate name: {name!r}"
+
+    def test_remediation_priorities_resolve_for_every_gate(self):
+        registry = _registry()
+        checks = [registry.get_check(name, {}) for name in registry.list_checks()]
+        instantiated = [c for c in checks if c is not None]
+        assert instantiated
+
+        for check in instantiated:
+            priority = registry.remediation_priority_for_check(check)
+            assert isinstance(priority, int)
+            source = registry.remediation_priority_source_for_check(check)
+            assert isinstance(source, str) and source
+
+    def test_remediation_sort_is_total_and_stable(self):
+        registry = _registry()
+        checks = [registry.get_check(name, {}) for name in registry.list_checks()]
+        instantiated = [c for c in checks if c is not None]
+
+        ordered = registry.sort_checks_for_remediation(instantiated)
+        # Total: nothing dropped or duplicated by sorting.
+        assert sorted(c.full_name for c in ordered) == sorted(
+            c.full_name for c in instantiated
+        )
+        # Stable/deterministic: sorting twice yields the same order.
+        again = registry.sort_checks_for_remediation(instantiated)
+        assert [c.full_name for c in ordered] == [c.full_name for c in again]
+
+    def test_curated_remediation_order_names_are_real_gates(self):
+        # The curated ordering is maintained by hand — every entry must still
+        # correspond to a registered gate, or the priority table silently
+        # stops applying to the gate it meant to rank.
+        registry = _registry()
+        registered = set(registry.list_checks())
+        for name in curated_remediation_order_names():
+            assert name in registered, f"curated order references unknown gate {name!r}"


### PR DESCRIPTION
Phase 2 of the tech-debt audit — the slop-mop-side items (the action-repo `project-install` input ships separately).

## 1. `github-actions-hygiene` now catches unpinned action refs (audit #5)
New `unpinned-action-ref` check: any `owner/repo@ref` that isn't a **full 40-hex commit SHA** is a finding — mutable tags/branches can be repointed to different code, and short SHAs are forgeable. `./local` and `docker://` refs exempt. Deliberate moving tags opt out via the new `allow_unpinned` config (prefix-matched); slop-mop allowlists its own `slop-mop-action@v2` dogfood ref in pyproject. Closes the gap where CodeRabbit caught unpinned actions our own gate missed. 6 new tests; existing fixtures SHA-pinned; the deprecated-major test now asserts both findings coexist on a deprecated tag.

**Consumer note:** repos with tag-pinned actions will see new findings on upgrade — that's the check working; remediation is pin-or-allowlist.

## 2. Venv detection unified (audit #7)
`type_checking._detect_venv_path` (private duplicate) → `mixins.detect_venv_path`, sharing the new `VENV_DIR_NAMES` constant with `has_project_venv`. One source of truth for "which dirs count as the project venv, in what order" — the exact divergence class behind this week's environment bugs. No behavior change.

## 3. Real-registry smoke tests (audit #9)
`test_registry_smoke.py` exercises genuine registration end-to-end: every gate registers + instantiates with `full_name == registered name`, remediation priorities resolve, the remediation sort is total/stable, and the hand-curated order references only real gates. The refit suite's `_FakeRegistry` can no longer hide a real registration regression.

## 4. Drain functional tests: root cause found ≠ the theory (audit #11)
The two `test_refit_drain_functional` tests that failed locally all week were *not* victims of machine git hooks (first theory, instrumented and falsified): **drain resolves formatters via the process-global registry, which is empty when the file runs in isolation** — drain silently no-ops, so no style commit. They passed in CI only because earlier test files happened to register gates. The autouse fixture now registers checks and *also* isolates git config (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` → CI-faithful bare environment, defense-in-depth). Same order-dependence fixed in `test_name_and_registration`.

## Proof
**3,372 passed with zero deselects** — first fully-clean local run of the suite including the two previously-quarantined tests. Hygiene gate passes on slop-mop's own workflows (allowlist verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)