### PR TITLE
refactor: tech-debt phase 3 — one gate-name parser, one enablement truth, named timeouts

### DIFF
--- a/.github/workflows/action-dogfood.yml
+++ b/.github/workflows/action-dogfood.yml
@@ -47,23 +47,6 @@ jobs:
           # from the real gate and inflates "provisional".
           fetch-depth: 0
 
-      # Type-aware gates (pyright/mypy) resolve imports against a detected venv
-      # (./venv, ./.venv, or $VIRTUAL_ENV). The v2 action installs slop-mop and
-      # the gate tools, but NOT this project's own dependencies — so without a
-      # project venv, pyright can't resolve our imports (e.g. the tomli fallback,
-      # which ships transitively via semgrep) and type-blindness fails on
-      # phantom "unknown type" findings. A real consumer installs their deps
-      # before this step; we mirror that here.
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install project deps into ./venv (for type-aware gate resolution)
-        run: |
-          python -m venv venv
-          ./venv/bin/pip install --upgrade pip
-          ./venv/bin/pip install -e ".[all]"
-
       # actionlint is a system tool the manifest can't install (Go binary). It's
       # applicable here (we have workflows), so provide it on PATH — otherwise
       # myopia:github-actions-hygiene warns-and-skips its actionlint pass. A real
@@ -91,6 +74,15 @@ jobs:
           # Warnings (still grade A) remain advisory.
           minimum-grade: "A"
           upload-sarif: "false"
+          # Type-aware gates (pyright/mypy) resolve imports against a detected
+          # venv (./venv, ./.venv, or $VIRTUAL_ENV); the action installs
+          # slop-mop + gate tools, not this project's deps. Provision them via
+          # the action's own input so the dogfood exercises project-install on
+          # every PR — the same drop-in path consumers use.
+          project-install: |
+            python -m venv venv
+            ./venv/bin/pip install --upgrade pip
+            ./venv/bin/pip install -e ".[all]"
 
       - name: Report hull grade
         env:

--- a/slopmop/checks/dart/analyze.py
+++ b/slopmop/checks/dart/analyze.py
@@ -25,6 +25,7 @@ from slopmop.checks.dart.common import (
     find_pubspec_dirs,
     format_package_label,
 )
+from slopmop.checks.timeouts import HEAVY_TASK_TIMEOUT
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -115,7 +116,7 @@ class FlutterAnalyzeCheck(BaseCheck):
             result = self._run_command(
                 [flutter_path, "analyze"],
                 cwd=str(package_dir),
-                timeout=300,
+                timeout=HEAVY_TASK_TIMEOUT,
             )
             if result.timed_out:
                 return self._create_result(

--- a/slopmop/checks/dart/coverage.py
+++ b/slopmop/checks/dart/coverage.py
@@ -31,6 +31,7 @@ from slopmop.checks.dart.common import (
     NO_FLUTTER_TEST_DIRECTORIES_FOUND,
     find_pubspec_dirs,
 )
+from slopmop.checks.timeouts import EXHAUSTIVE_TASK_TIMEOUT
 from slopmop.constants import COVERAGE_BELOW_THRESHOLD
 from slopmop.core.result import (
     CheckResult,
@@ -166,7 +167,7 @@ class DartCoverageCheck(BaseCheck):
         result = self._run_command(
             [flutter_path, "test", "--coverage"],
             cwd=str(package_dir),
-            timeout=900,
+            timeout=EXHAUSTIVE_TASK_TIMEOUT,
         )
         if not result.success or result.timed_out:
             if FLUTTER_CACHE_PERMISSION_ERROR in (result.output or ""):

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -119,7 +119,7 @@ class DartFormatCheck(BaseCheck):
                     status=CheckStatus.FAILED,
                     duration=time.time() - start_time,
                     output=result.output,
-                    error=f"{label}: dart format timed out after 2 minutes",
+                    error=f"{label}: dart format timed out after {SLOW_TOOL_TIMEOUT}s",
                     findings=[
                         Finding(
                             message=f"{label}: dart format timed out",

--- a/slopmop/checks/dart/format.py
+++ b/slopmop/checks/dart/format.py
@@ -21,6 +21,7 @@ from slopmop.checks.dart.common import (
     find_pubspec_dirs,
     format_package_label,
 )
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -111,7 +112,7 @@ class DartFormatCheck(BaseCheck):
             result = self._run_command(
                 [dart_path, "format", "--output=none", "--set-exit-if-changed", "."],
                 cwd=str(package_dir),
-                timeout=120,
+                timeout=SLOW_TOOL_TIMEOUT,
             )
             if result.timed_out:
                 return self._create_result(

--- a/slopmop/checks/dart/generated_artifacts.py
+++ b/slopmop/checks/dart/generated_artifacts.py
@@ -21,6 +21,7 @@ from slopmop.checks.dart.common import (
     find_pubspec_dirs,
     unique_strings,
 )
+from slopmop.checks.timeouts import QUICK_COMMAND_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 MAX_SHOWN = 20
@@ -97,7 +98,7 @@ class DartGeneratedArtifactsCheck(BaseCheck):
         ]
 
         git_result = self._run_command(
-            ["git", "ls-files"], cwd=project_root, timeout=30
+            ["git", "ls-files"], cwd=project_root, timeout=QUICK_COMMAND_TIMEOUT
         )
         duration = time.time() - start_time
         if not git_result.success:

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -127,7 +127,7 @@ class FlutterTestsCheck(BaseCheck):
                     status=CheckStatus.FAILED,
                     duration=time.time() - start_time,
                     output=result.output,
-                    error=f"Flutter tests timed out after 15 minutes ({label})",
+                    error=f"Flutter tests timed out after {EXHAUSTIVE_TASK_TIMEOUT}s ({label})",
                     findings=[
                         Finding(
                             message=f"Flutter tests timed out in {label}",

--- a/slopmop/checks/dart/tests.py
+++ b/slopmop/checks/dart/tests.py
@@ -27,6 +27,7 @@ from slopmop.checks.dart.common import (
     find_pubspec_dirs,
     format_package_label,
 )
+from slopmop.checks.timeouts import EXHAUSTIVE_TASK_TIMEOUT
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -119,7 +120,7 @@ class FlutterTestsCheck(BaseCheck):
             result = self._run_command(
                 [flutter_path, "test"],
                 cwd=str(package_dir),
-                timeout=900,
+                timeout=EXHAUSTIVE_TASK_TIMEOUT,
             )
             if result.timed_out:
                 return self._create_result(

--- a/slopmop/checks/general/jinja2_templates.py
+++ b/slopmop/checks/general/jinja2_templates.py
@@ -18,6 +18,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.timeouts import DEFAULT_TOOL_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 
@@ -180,7 +181,7 @@ class TemplateValidationCheck(BaseCheck, PythonCheckMixin):
             "--tb=short",
             "-x",
         ]
-        result = self._run_command(cmd, cwd=project_root, timeout=60)
+        result = self._run_command(cmd, cwd=project_root, timeout=DEFAULT_TOOL_TIMEOUT)
         duration = time.time() - start_time
 
         if result.success:

--- a/slopmop/checks/javascript/coverage.py
+++ b/slopmop/checks/javascript/coverage.py
@@ -28,6 +28,7 @@ from slopmop.checks.constants import (
     js_no_tests_fix_suggestion,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import HEAVY_TASK_TIMEOUT, SLOW_TOOL_TIMEOUT
 from slopmop.constants import (
     COVERAGE_BELOW_THRESHOLD,
     COVERAGE_GUIDANCE_FOOTER,
@@ -192,7 +193,7 @@ class JavaScriptCoverageCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             self._get_coverage_command(),
             cwd=project_root,
-            timeout=300,
+            timeout=HEAVY_TASK_TIMEOUT,
         )
         duration = time.time() - start_time
 
@@ -270,7 +271,9 @@ class JavaScriptCoverageCheck(BaseCheck, JavaScriptCheckMixin):
         if self.has_node_modules(project_root):
             return None
         npm_cmd = self._get_npm_install_command(project_root)
-        npm_result = self._run_command(npm_cmd, cwd=project_root, timeout=120)
+        npm_result = self._run_command(
+            npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT
+        )
         if npm_result.success:
             return None
         return self._create_result(
@@ -348,7 +351,7 @@ class JavaScriptCoverageCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             ["deno", "coverage", "--lcov", str(report_path)],
             cwd=project_root,
-            timeout=300,
+            timeout=HEAVY_TASK_TIMEOUT,
         )
         if not result.success:
             return None

--- a/slopmop/checks/javascript/dead_code.py
+++ b/slopmop/checks/javascript/dead_code.py
@@ -14,6 +14,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.constants import NPM_INSTALL_FAILED
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 from slopmop.utils.jsonc import loads_jsonc
@@ -117,7 +118,9 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
 
         if not self.has_node_modules(project_root):
             npm_cmd = self._get_npm_install_command(project_root)
-            npm_result = self._run_command(npm_cmd, cwd=project_root, timeout=120)
+            npm_result = self._run_command(
+                npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT
+            )
             if not npm_result.success:
                 return self._create_result(
                     status=CheckStatus.ERROR,
@@ -155,7 +158,7 @@ class JavaScriptDeadCodeCheck(BaseCheck, JavaScriptCheckMixin):
                         break
 
         try:
-            result = self._run_command(cmd, cwd=project_root, timeout=120)
+            result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
         finally:
             if tmp_config_path and os.path.exists(tmp_config_path):
                 os.unlink(tmp_config_path)

--- a/slopmop/checks/javascript/eslint_expect.py
+++ b/slopmop/checks/javascript/eslint_expect.py
@@ -30,6 +30,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import DEFAULT_TOOL_TIMEOUT, SLOW_TOOL_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 # Shared constants for test file discovery — single source of truth so
@@ -223,7 +224,9 @@ class JavaScriptExpectCheck(BaseCheck, JavaScriptCheckMixin):
             )
 
             env = {**os.environ, "ESLINT_USE_FLAT_CONFIG": "false"}
-            result = self._run_command(cmd, cwd=project_root, timeout=120, env=env)
+            result = self._run_command(
+                cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT, env=env
+            )
             duration = time.time() - start_time
 
             # Parse ESLint JSON output
@@ -298,7 +301,9 @@ class JavaScriptExpectCheck(BaseCheck, JavaScriptCheckMixin):
             "--no-fund",
             "--loglevel=error",
         ]
-        result = self._run_command(install_cmd, cwd=project_root, timeout=60)
+        result = self._run_command(
+            install_cmd, cwd=project_root, timeout=DEFAULT_TOOL_TIMEOUT
+        )
         if result.returncode != 0:
             return self._create_result(
                 status=CheckStatus.ERROR,

--- a/slopmop/checks/javascript/eslint_quick.py
+++ b/slopmop/checks/javascript/eslint_quick.py
@@ -18,6 +18,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import QUICK_COMMAND_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 # ESLint stylish format detail line:  line:col  error|warning  message  rule-id
@@ -131,7 +132,7 @@ class FrontendCheck(BaseCheck, JavaScriptCheckMixin):
             "--quiet",  # errors only
         ] + js_dirs
 
-        result = self._run_command(cmd, cwd=project_root, timeout=30)
+        result = self._run_command(cmd, cwd=project_root, timeout=QUICK_COMMAND_TIMEOUT)
         duration = time.time() - start_time
 
         if result.success:

--- a/slopmop/checks/javascript/lint_format.py
+++ b/slopmop/checks/javascript/lint_format.py
@@ -17,6 +17,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import DEFAULT_TOOL_TIMEOUT, SLOW_TOOL_TIMEOUT
 from slopmop.constants import ISSUES_FOUND_TEMPLATE, NPM_INSTALL_FAILED
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -415,14 +416,14 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             ["deno", "lint", "--fix"] + targets,
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
         result = self._run_command(
             ["deno", "fmt"] + targets,
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
@@ -439,7 +440,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         # Install deps if needed
         if not self.has_node_modules(project_root):
             npm_cmd = self._get_npm_install_command(project_root)
-            self._run_command(npm_cmd, cwd=project_root, timeout=120)
+            self._run_command(npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
 
         # Keep implicit Node auto-fix formatter-only. Type-aware ESLint --fix
         # can be arbitrarily expensive in hook/agent contexts and is better
@@ -447,7 +448,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             ["npx", "--yes", "prettier", *prettier_args],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
@@ -568,7 +569,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             ["deno", "lint", "--json"] + targets,
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if not result.success:
             findings: List[Finding] = []
@@ -626,7 +627,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         result = self._run_command(
             ["deno", "fmt", "--check"] + targets,
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if not result.success:
             msg = "Formatting issues found"
@@ -658,7 +659,9 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
         # Install deps if needed
         if not self.has_node_modules(project_root):
             npm_cmd = self._get_npm_install_command(project_root)
-            npm_result = self._run_command(npm_cmd, cwd=project_root, timeout=120)
+            npm_result = self._run_command(
+                npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT
+            )
             if not npm_result.success:
                 return self._create_result(
                     status=CheckStatus.ERROR,
@@ -719,7 +722,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
                 "--quiet",
             ],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
 
         if not result.success and result.output.strip():
@@ -797,7 +800,7 @@ class JavaScriptLintFormatCheck(BaseCheck, JavaScriptCheckMixin):
                 *self._get_node_prettier_args(project_root, for_write=False),
             ],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
 
         if not result.success:

--- a/slopmop/checks/javascript/tests.py
+++ b/slopmop/checks/javascript/tests.py
@@ -19,6 +19,7 @@ from slopmop.checks.constants import (
     js_no_tests_fix_suggestion,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import HEAVY_TASK_TIMEOUT, SLOW_TOOL_TIMEOUT
 from slopmop.constants import NPM_INSTALL_FAILED
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -173,7 +174,9 @@ class JavaScriptTestsCheck(BaseCheck, JavaScriptCheckMixin):
             project_root
         ):
             npm_cmd = self._get_npm_install_command(project_root)
-            npm_result = self._run_command(npm_cmd, cwd=project_root, timeout=120)
+            npm_result = self._run_command(
+                npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT
+            )
             if not npm_result.success:
                 return self._create_result(
                     status=CheckStatus.ERROR,
@@ -183,7 +186,9 @@ class JavaScriptTestsCheck(BaseCheck, JavaScriptCheckMixin):
                 )
 
         test_cmd = self._get_test_command()
-        result = self._run_command(test_cmd, cwd=project_root, timeout=300)
+        result = self._run_command(
+            test_cmd, cwd=project_root, timeout=HEAVY_TASK_TIMEOUT
+        )
 
         duration = time.time() - start_time
 

--- a/slopmop/checks/javascript/types.py
+++ b/slopmop/checks/javascript/types.py
@@ -37,6 +37,7 @@ from slopmop.checks.base import (
     ToolContext,
 )
 from slopmop.checks.mixins import JavaScriptCheckMixin
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.constants import NPM_INSTALL_FAILED
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -151,7 +152,9 @@ class JavaScriptTypesCheck(BaseCheck, JavaScriptCheckMixin):
         # Install deps if needed
         if not self.has_node_modules(project_root):
             npm_cmd = self._get_npm_install_command(project_root)
-            npm_result = self._run_command(npm_cmd, cwd=project_root, timeout=120)
+            npm_result = self._run_command(
+                npm_cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT
+            )
             if not npm_result.success:
                 return self._create_result(
                     status=CheckStatus.ERROR,

--- a/slopmop/checks/mixins.py
+++ b/slopmop/checks/mixins.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import List, Optional, cast
 
 from slopmop.checks.base import count_source_scope
+from slopmop.checks.timeouts import PROBE_TIMEOUT
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -130,7 +131,7 @@ def _git_tracked_python_files_exist(project_root: Path) -> bool | None:
             cwd=project_root,
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=PROBE_TIMEOUT,
             check=False,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
@@ -346,7 +347,7 @@ class PythonCheckMixin:
                 [python_path, "--version"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=PROBE_TIMEOUT,
             )
             return result.stdout.strip()
         except Exception:

--- a/slopmop/checks/pr/comments.py
+++ b/slopmop/checks/pr/comments.py
@@ -22,6 +22,7 @@ from slopmop.checks.base import (
     GateCategory,
     GateLevel,
 )
+from slopmop.checks.timeouts import PROBE_TIMEOUT, QUICK_COMMAND_TIMEOUT
 from slopmop.constants import NOT_A_GIT_REPO, action_buff_inspect_pr
 from slopmop.core.result import CheckResult, CheckStatus, Finding
 
@@ -124,7 +125,7 @@ class PRCommentsCheck(BaseCheck):
                 ["gh", "--version"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=PROBE_TIMEOUT,
                 cwd=project_root,
             )
             if result.returncode != 0:
@@ -147,7 +148,7 @@ class PRCommentsCheck(BaseCheck):
                 ["gh", "--version"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=PROBE_TIMEOUT,
                 cwd=project_root,
             )
             if result.returncode != 0:
@@ -220,7 +221,7 @@ class PRCommentsCheck(BaseCheck):
                 ["git", "branch", "--show-current"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=PROBE_TIMEOUT,
                 cwd=project_root,
             )
             if branch_result.returncode != 0 or not branch_result.stdout.strip():
@@ -305,7 +306,7 @@ class PRCommentsCheck(BaseCheck):
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=PROBE_TIMEOUT,
                 cwd=project_root,
             )
             if result.returncode != 0:
@@ -371,7 +372,7 @@ class PRCommentsCheck(BaseCheck):
                 ],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=QUICK_COMMAND_TIMEOUT,
                 cwd=project_root,
             )
 
@@ -473,7 +474,7 @@ class PRCommentsCheck(BaseCheck):
                 ],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=QUICK_COMMAND_TIMEOUT,
                 cwd=project_root,
             )
 

--- a/slopmop/checks/python/coverage.py
+++ b/slopmop/checks/python/coverage.py
@@ -34,6 +34,7 @@ from slopmop.checks.constants import (
     skip_reason_no_test_files,
 )
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.timeouts import QUICK_COMMAND_TIMEOUT
 from slopmop.constants import (
     COVERAGE_BELOW_THRESHOLD,
     COVERAGE_GUIDANCE_FOOTER,
@@ -270,7 +271,7 @@ class PythonCoverageCheck(BaseCheck, PythonCheckMixin):
                 "--fail-under=0",
             ],
             cwd=project_root,
-            timeout=30,
+            timeout=QUICK_COMMAND_TIMEOUT,
         )
 
         duration = time.time() - start_time
@@ -829,7 +830,7 @@ class PythonDiffCoverageCheck(BaseCheck, PythonCheckMixin):
                 "*.py",
             ],
             cwd=project_root,
-            timeout=30,
+            timeout=QUICK_COMMAND_TIMEOUT,
         )
         duration = time.time() - start_time
 

--- a/slopmop/checks/python/lint_format.py
+++ b/slopmop/checks/python/lint_format.py
@@ -31,6 +31,7 @@ from slopmop.checks.base import (
 from slopmop.checks.constants import COMMAND_NOT_FOUND
 from slopmop.checks.mixins import PythonCheckMixin
 from slopmop.checks.python._host_formatter import detect_host_python_formatter
+from slopmop.checks.timeouts import DEFAULT_TOOL_TIMEOUT
 from slopmop.constants import ISSUES_FOUND_TEMPLATE
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -233,7 +234,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         result = self._run_command(
             ["ruff", "format", "."],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
@@ -244,7 +245,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         result = self._run_command(
             ["ruff", "check", "--fix", "--select", "I,F401", "."],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
@@ -271,7 +272,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                 ".",
             ],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if result.success:
             fixed = True
@@ -289,7 +290,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                     target,
                 ],
                 cwd=project_root,
-                timeout=60,
+                timeout=DEFAULT_TOOL_TIMEOUT,
             )
             if result.success:
                 fixed = True
@@ -298,7 +299,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         isort_cmd = ["isort", "--profile", "black"]
         isort_cmd.extend(f"--skip={name}" for name in _DEFAULT_EXCLUDE_DIRS)
         isort_cmd.extend(["--skip-glob=.*", "."])
-        result = self._run_command(isort_cmd, cwd=project_root, timeout=60)
+        result = self._run_command(
+            isort_cmd, cwd=project_root, timeout=DEFAULT_TOOL_TIMEOUT
+        )
         if result.success:
             fixed = True
 
@@ -418,7 +421,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         result = self._run_command(
             ["ruff", "format", "--check", "."],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if not result.success:
             output = (result.output or "").strip()
@@ -432,7 +435,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         result = self._run_command(
             ["ruff", "check", "--select", "I", "."],
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
         if not result.success:
             output = (result.output or "").strip()
@@ -475,7 +478,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
                     target,
                 ],
                 cwd=project_root,
-                timeout=60,
+                timeout=DEFAULT_TOOL_TIMEOUT,
             )
             if not result.success:
                 output = (result.output or "").strip()
@@ -509,7 +512,9 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
         # Skip hidden directories (e.g. .claude/, .git/) that contain
         # tool infrastructure rather than project source code.
         isort_cmd.extend(["--skip-glob=.*", "."])
-        result = self._run_command(isort_cmd, cwd=project_root, timeout=60)
+        result = self._run_command(
+            isort_cmd, cwd=project_root, timeout=DEFAULT_TOOL_TIMEOUT
+        )
 
         if not result.success:
             # isort outputs "ERROR: file.py ..." or "Skipped X files"
@@ -576,7 +581,7 @@ class PythonLintFormatCheck(BaseCheck, PythonCheckMixin):
             ]
             + targets,
             cwd=project_root,
-            timeout=60,
+            timeout=DEFAULT_TOOL_TIMEOUT,
         )
 
         if not result.success and result.output.strip():

--- a/slopmop/checks/python/static_analysis.py
+++ b/slopmop/checks/python/static_analysis.py
@@ -19,6 +19,7 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.constants import COMMAND_NOT_FOUND
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 # mypy error code pattern: file.py:10: error: message  [code]
@@ -325,7 +326,7 @@ class PythonStaticAnalysisCheck(BaseCheck, PythonCheckMixin):
 
         source_dirs = self._detect_source_dirs(project_root)
         cmd = self._build_command(source_dirs, project_root)
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
 
         duration = time.time() - start_time
 

--- a/slopmop/checks/python/tests.py
+++ b/slopmop/checks/python/tests.py
@@ -26,6 +26,7 @@ from slopmop.checks.constants import (
     skip_reason_no_test_files,
 )
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.timeouts import HEAVY_TASK_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 # pytest's short-summary line format is stable across 6.x/7.x/8.x:
@@ -279,7 +280,7 @@ class PythonTestsCheck(BaseCheck, PythonCheckMixin):
                 "--tb=short",
             ]
 
-        result = self._run_command(cmd, cwd=project_root, timeout=300)
+        result = self._run_command(cmd, cwd=project_root, timeout=HEAVY_TASK_TIMEOUT)
         duration = time.time() - start_time
         return self._evaluate_pytest_result(result, duration, use_testmon)
 

--- a/slopmop/checks/python/type_checking.py
+++ b/slopmop/checks/python/type_checking.py
@@ -41,6 +41,7 @@ from slopmop.checks.base import (
     pip_cli_requirement,
 )
 from slopmop.checks.mixins import PythonCheckMixin, detect_venv_path
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 from slopmop.utils.jsonc import loads_jsonc
 
@@ -458,7 +459,7 @@ class PythonTypeCheckingCheck(BaseCheck, PythonCheckMixin):
             result = self._run_command(
                 [pyright_path, "--outputjson", "--project", str(config_path)],
                 cwd=project_root,
-                timeout=120,
+                timeout=SLOW_TOOL_TIMEOUT,
             )
 
             duration = time.time() - start_time

--- a/slopmop/checks/quality/complexity.py
+++ b/slopmop/checks/quality/complexity.py
@@ -28,6 +28,7 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.constants import COMMAND_NOT_FOUND
 from slopmop.checks.mixins import PythonCheckMixin
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 MAX_RANK = "C"
@@ -181,7 +182,7 @@ class ComplexityCheck(BaseCheck, PythonCheckMixin):
             "--ignore",
             ",".join(sorted(SCOPE_EXCLUDED_DIRS)),
         ] + dirs
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
         duration = time.time() - start_time
 
         # returncode 127 = shell "command not found"

--- a/slopmop/checks/quality/dead_code.py
+++ b/slopmop/checks/quality/dead_code.py
@@ -27,6 +27,7 @@ from slopmop.checks.base import (
     pip_cli_requirement,
 )
 from slopmop.checks.constants import COMMAND_NOT_FOUND
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.core.result import (
     CheckResult,
     CheckStatus,
@@ -253,7 +254,7 @@ class DeadCodeCheck(BaseCheck):
     def run(self, project_root: str) -> CheckResult:
         start_time = time.time()
         cmd = self._build_command(project_root)
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
         duration = time.time() - start_time
 
         # Handle tool not installed — warn but don't block

--- a/slopmop/checks/quality/duplication.py
+++ b/slopmop/checks/quality/duplication.py
@@ -31,6 +31,7 @@ from slopmop.checks.base import (
     count_source_scope,
     should_prune_dir,
 )
+from slopmop.checks.timeouts import HEAVY_TASK_TIMEOUT, QUICK_COMMAND_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 DEFAULT_THRESHOLD = 5.0  # Percent duplication allowed
@@ -203,7 +204,9 @@ class RepeatedCodeCheck(BaseCheck):
     def _check_jscpd_availability(self, project_root: str) -> Optional[str]:
         """Check if jscpd is available. Returns error message or None."""
         result = self._run_command(
-            ["npx", "--yes", "jscpd", "--version"], cwd=project_root, timeout=30
+            ["npx", "--yes", "jscpd", "--version"],
+            cwd=project_root,
+            timeout=QUICK_COMMAND_TIMEOUT,
         )
         if result.returncode != 0:
             return "jscpd not available"
@@ -372,7 +375,9 @@ class RepeatedCodeCheck(BaseCheck):
                 report_output, include_dirs, min_tokens, min_lines
             )
 
-            result = self._run_command(cmd, cwd=project_root, timeout=300)
+            result = self._run_command(
+                cmd, cwd=project_root, timeout=HEAVY_TASK_TIMEOUT
+            )
             duration = time.time() - start_time
 
             report_path = os.path.join(report_output, "jscpd-report.json")

--- a/slopmop/checks/quality/gate_dodging.py
+++ b/slopmop/checks/quality/gate_dodging.py
@@ -31,6 +31,7 @@ from slopmop.checks.base import (
     GateCategory,
     RemediationChurn,
 )
+from slopmop.checks.timeouts import PROBE_TIMEOUT
 from slopmop.constants import NOT_A_GIT_REPO
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -342,7 +343,7 @@ def _detect_pr_for_gate(project_root: str) -> Optional[int]:
             ["git", "branch", "--show-current"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=PROBE_TIMEOUT,
             cwd=project_root,
         )
         if branch_result.returncode != 0 or not branch_result.stdout.strip():

--- a/slopmop/checks/security/__init__.py
+++ b/slopmop/checks/security/__init__.py
@@ -33,6 +33,7 @@ from slopmop.checks.base import (
 )
 from slopmop.checks.mixins import PythonCheckMixin
 from slopmop.checks.security._detect_secrets import DetectSecretsMixin
+from slopmop.checks.timeouts import SLOW_TOOL_TIMEOUT
 from slopmop.constants import NO_ISSUES_FOUND
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
@@ -483,7 +484,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
             # B101 = assert usage, B110 = try-except-pass (common patterns)
             cmd.extend(["--skip", "B101,B110"])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
 
         # Try to parse JSON from stdout only - stderr contains warnings that aren't issues
         # Bandit returns non-zero for any findings including LOW severity
@@ -544,7 +545,7 @@ class SecurityLocalCheck(BaseCheck, PythonCheckMixin, DetectSecretsMixin):
         for d in self._get_exclude_dirs():
             cmd.extend(["--exclude", d])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
 
         if result.success:
             return SecuritySubResult("semgrep", True, NO_ISSUES_FOUND)
@@ -958,7 +959,7 @@ class SecurityCheck(SecurityLocalCheck):
             for req_file in req_files:
                 cmd.extend(["-r", req_file])
 
-        result = self._run_command(cmd, cwd=project_root, timeout=120)
+        result = self._run_command(cmd, cwd=project_root, timeout=SLOW_TOOL_TIMEOUT)
 
         if result.timed_out:
             return SecuritySubResult(

--- a/slopmop/checks/security/_detect_secrets.py
+++ b/slopmop/checks/security/_detect_secrets.py
@@ -16,6 +16,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
+from slopmop.checks.timeouts import DEFAULT_TOOL_TIMEOUT
 from slopmop.core.result import Finding, FindingLevel
 
 if TYPE_CHECKING:
@@ -356,7 +357,7 @@ class DetectSecretsMixin:
         # timeout — a flaky false failure, not a real finding (barnacle #244).
         scan_paths = self._detect_secrets_scan_paths(project_root)
         cmd.extend(scan_paths)
-        result = self._run_command(cmd, cwd=project_root, timeout=60)
+        result = self._run_command(cmd, cwd=project_root, timeout=DEFAULT_TOOL_TIMEOUT)
 
         if result.success:
             try:

--- a/slopmop/checks/timeouts.py
+++ b/slopmop/checks/timeouts.py
@@ -1,0 +1,39 @@
+"""Named subprocess-timeout tiers for the checks tree.
+
+Before this module, ``timeout=60`` appeared ~20 times and ``timeout=120``
+~16 times across the gates with no way to tell intent apart from accident
+(tech-debt audit #10). Gates should pick the tier that matches what the
+subprocess *does*; a repo-size problem that busts a tier is a reason to
+bump the gate to the next tier, not to invent a new number.
+
+The values are the historical ones — introducing this module changed no
+behavior. A handful of one-off literals (10s, 15s, 180s) remain in gates
+whose semantics didn't match a tier; normalize them opportunistically when
+touching those gates.
+"""
+
+from __future__ import annotations
+
+# Liveness/identity probes: `tool --version`, import checks. If a probe
+# takes longer than this, the tool is effectively broken.
+PROBE_TIMEOUT = 5
+
+# Small metadata commands with bounded output: `git ls-files`, `npx --yes
+# <tool> --version`, single-file parses.
+QUICK_COMMAND_TIMEOUT = 30
+
+# The standard single-tool analysis pass over a repo (linters, formatters
+# in check mode). The default choice for a new gate.
+DEFAULT_TOOL_TIMEOUT = 60
+
+# Heavier analyzers that resolve imports or build type graphs (mypy,
+# pyright, vulture over a large tree, security scanners).
+SLOW_TOOL_TIMEOUT = 120
+
+# Whole-suite invocations: running the project's tests, duplication scans
+# that hash every file.
+HEAVY_TASK_TIMEOUT = 300
+
+# The pathological-but-legitimate ceiling: full coverage runs on large
+# projects (e.g. flutter test --coverage). Anything beyond this is a hang.
+EXHAUSTIVE_TASK_TIMEOUT = 900

--- a/slopmop/checks/workflow/github_actions.py
+++ b/slopmop/checks/workflow/github_actions.py
@@ -20,6 +20,7 @@ from slopmop.checks.base import (
     Requirements,
     ToolContext,
 )
+from slopmop.checks.timeouts import QUICK_COMMAND_TIMEOUT
 from slopmop.core.result import CheckResult, CheckStatus, Finding, FindingLevel
 
 _WORKFLOW_EXTENSIONS = frozenset({".yml", ".yaml"})
@@ -554,7 +555,9 @@ class GitHubActionsHygieneCheck(BaseCheck):
     ) -> list[Finding]:
         if not actionlint:
             return []
-        result = self._runner.run([actionlint, str(path)], cwd=str(root), timeout=30)
+        result = self._runner.run(
+            [actionlint, str(path)], cwd=str(root), timeout=QUICK_COMMAND_TIMEOUT
+        )
         if result.returncode == 0:
             return []
         findings: list[Finding] = []

--- a/slopmop/cli/config.py
+++ b/slopmop/cli/config.py
@@ -13,6 +13,7 @@ from slopmop.core.config import (
     get_current_pr_number,
 )
 from slopmop.core.config import set_current_pr_number as set_current_pr_selection
+from slopmop.core.gate_config import GateRef, is_gate_enabled
 from slopmop.core.registry import get_registry
 from slopmop.utils import as_str_list
 
@@ -26,26 +27,20 @@ def _as_dict(value: Any) -> dict[str, Any] | None:
 
 
 def _is_gate_enabled(cfg: dict[str, Any], full_name: str) -> bool:
-    """Return whether a gate is enabled across both config representations."""
-    disabled = as_str_list(cfg.get("disabled_gates", []))
-    if full_name in disabled:
-        return False
-    if ":" not in full_name:
-        return True
+    """Delegate to the canonical enablement semantics.
 
-    category, gate = full_name.split(":", 1)
-    category_cfg = _as_dict(cfg.get(category))
-    gates_cfg = _as_dict(category_cfg.get("gates") if category_cfg else None)
-    gate_cfg = _as_dict(gates_cfg.get(gate) if gates_cfg else None)
-    if isinstance(gate_cfg, dict) and "enabled" in gate_cfg:
-        return bool(gate_cfg.get("enabled"))
-    return True
+    The previous local implementation ignored a category-level
+    ``enabled: false``, so ``sm config`` could report gates enabled that the
+    executor would skip. Delegating closes that divergence.
+    """
+    return is_gate_enabled(cfg, full_name)
 
 
 def _set_gate_enabled(cfg: dict[str, Any], full_name: str, enabled: bool) -> None:
     """Set gate enabled state in both nested and legacy config forms."""
-    if ":" in full_name:
-        category, gate = full_name.split(":", 1)
+    ref = GateRef.parse(full_name)
+    if ref.is_qualified:
+        category, gate = ref.category, ref.gate
         cat_any = _as_dict(cfg.get(category))
         cat: dict[str, Any]
         if cat_any is not None:
@@ -81,9 +76,10 @@ def _set_gate_enabled(cfg: dict[str, Any], full_name: str, enabled: bool) -> Non
 
 def _gate_cfg_dict(cfg: dict[str, Any], full_name: str) -> dict[str, Any] | None:
     """Return the nested gate config dict, creating parents as needed."""
-    if ":" not in full_name:
+    ref = GateRef.parse(full_name)
+    if not ref.is_qualified:
         return None
-    category, gate = full_name.split(":", 1)
+    category, gate = ref.category, ref.gate
     category_cfg = _as_dict(cfg.get(category))
     if category_cfg is None:
         category_cfg = {}
@@ -285,9 +281,9 @@ def _normalize_flat_keys(data: Dict[str, Any]) -> Dict[str, Any]:
     normalized: Dict[str, Any] = {}
 
     for key, value in data.items():
-        if ":" in key:
-            parts = key.split(":", 1)
-            category, gate_name = parts[0], parts[1]
+        ref = GateRef.parse(key)
+        if ref.is_qualified:
+            category, gate_name = ref.category, ref.gate
             if category in category_keys and isinstance(value, dict):
                 # Merge into hierarchical structure
                 if category not in normalized:
@@ -465,9 +461,10 @@ def _show_config(project_root: Path, config_file: Path, config: dict[str, Any]) 
     registry = get_registry()
 
     def _gate_cfg_view(full_name: str) -> dict[str, Any]:
-        if ":" not in full_name:
+        ref = GateRef.parse(full_name)
+        if not ref.is_qualified:
             return {}
-        category, gate = full_name.split(":", 1)
+        category, gate = ref.category, ref.gate
         category_cfg = _as_dict(config.get(category))
         gates_cfg = _as_dict(category_cfg.get("gates") if category_cfg else None)
         gate_cfg = _as_dict(gates_cfg.get(gate) if gates_cfg else None)

--- a/slopmop/cli/help.py
+++ b/slopmop/cli/help.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from slopmop.checks import ensure_checks_registered
 from slopmop.checks.base import GateCategory
 from slopmop.constants import ROLE_BADGES
+from slopmop.core.gate_config import GateRef
 from slopmop.core.registry import get_registry
 
 
@@ -100,7 +101,7 @@ def _show_all_gates() -> int:
             gates_by_category[check.category].append(name)
         else:
             # Fallback: parse category from gate name prefix (e.g. "laziness:sloppy-formatting.py")
-            cat_key = name.split(":")[0] if ":" in name else "general"
+            cat_key = GateRef.parse(name).category or "general"
             cat = GateCategory.from_key(cat_key)
             if cat:
                 gates_by_category[cat].append(name)

--- a/slopmop/cli/init.py
+++ b/slopmop/cli/init.py
@@ -13,6 +13,7 @@ from slopmop import __version__
 from slopmop.checks.base import SCOPE_EXCLUDED_DIRS
 from slopmop.cli.config import _as_dict, _deep_merge
 from slopmop.cli.detection import detect_project_type
+from slopmop.core.gate_config import GateRef
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -253,7 +254,8 @@ def _apply_user_config(base_config: Dict[str, Any], config: Dict[str, Any]) -> N
         if not isinstance(gate_full_name, str):
             continue
         if ":" in gate_full_name:
-            category, gate = gate_full_name.split(":", 1)
+            _ref = GateRef.parse(gate_full_name)
+            category, gate = _ref.category, _ref.gate
             section = _as_dict(base_config.get(category))
             if section is None:
                 continue
@@ -313,7 +315,8 @@ def _disable_checks_with_missing_tools(
         # Parse check name: "laziness:dead-code.py" -> category="laziness", gate="dead-code.py"
         if ":" not in check_name:
             continue
-        category, gate = check_name.split(":", 1)
+        _ref = GateRef.parse(check_name)
+        category, gate = _ref.category, _ref.gate
 
         section = _as_dict(base_config.get(category))
         if section is None:
@@ -381,7 +384,8 @@ def _disable_non_applicable_by_applicability(
             continue
         if ":" not in full_name:
             continue
-        category, gate_name = full_name.split(":", 1)
+        _ref = GateRef.parse(full_name)
+        category, gate_name = _ref.category, _ref.gate
         section = _as_dict(base_config.get(category))
         if section is None:
             continue
@@ -442,7 +446,8 @@ def _apply_gate_init_config(base_config: Dict[str, Any], project_root: Path) -> 
         if not isinstance(full_name_any, str) or ":" not in full_name_any:
             continue
         full_name = full_name_any
-        category, gate_name = full_name.split(":", 1)
+        _ref = GateRef.parse(full_name)
+        category, gate_name = _ref.category, _ref.gate
 
         section = _as_dict(base_config.get(category))
         if section is None:

--- a/slopmop/cli/refit.py
+++ b/slopmop/cli/refit.py
@@ -37,6 +37,7 @@ from slopmop.cli._refit_precheck import (
 )
 from slopmop.cli.buff import load_json_file
 from slopmop.cli.scan_triage import write_json_out
+from slopmop.core.gate_config import GateRef
 from slopmop.core.registry import get_registry
 from slopmop.reporting.envelope import Status, build_envelope
 from slopmop.utils import iso_now
@@ -420,7 +421,7 @@ def _save_plan(project_root: Path, plan: Dict[str, Any]) -> None:
 
 
 def _gate_family(name: str) -> str:
-    return name.split(":", 1)[1] if ":" in name else name
+    return GateRef.parse(name).gate
 
 
 def _phase_label_for_check(check: BaseCheck) -> str:

--- a/slopmop/cli/status.py
+++ b/slopmop/cli/status.py
@@ -42,6 +42,7 @@ _CATEGORY_ORDER = [
 # Marker written into slop-mop-managed git hooks.
 # Import the canonical marker from hooks.py to keep in sync.
 from slopmop.cli.hooks import SB_HOOK_MARKER as _SB_HOOK_MARKER
+from slopmop.core.gate_config import GateRef
 
 
 def _get_category_display(category_key: str) -> Tuple[str, str]:
@@ -202,7 +203,7 @@ def _print_gate_inventory(
         if not is_app:
             na_gates.append((gate, reason))
         else:
-            cat_key = gate.split(":")[0]
+            cat_key = GateRef.parse(gate).category
             by_category[cat_key].append(gate)
 
     sorted_cats = sorted(
@@ -221,7 +222,7 @@ def _print_gate_inventory(
         print(f"{emoji} {display}")
 
         for gate in gates:
-            gate_name = gate.split(":", 1)[1]
+            gate_name = GateRef.parse(gate).gate
 
             line = _format_gate_line(
                 gate_name,
@@ -237,7 +238,7 @@ def _print_gate_inventory(
             print(line)
 
     if na_gates:
-        names = [g.split(":", 1)[1] for g, _ in sorted(na_gates)]
+        names = [GateRef.parse(g).gate for g, _ in sorted(na_gates)]
         prefix = f"   ⊘ {len(na_gates)} n/a: "
         body = ", ".join(names)
         wrapped = textwrap.fill(

--- a/slopmop/core/config.py
+++ b/slopmop/core/config.py
@@ -164,12 +164,6 @@ class CategoryConfig:
         """Get configuration for a specific gate."""
         return self.gates.get(gate_name, GateConfig())
 
-    def is_gate_enabled(self, gate_name: str) -> bool:
-        """Check if a specific gate is enabled (requires language enabled too)."""
-        if not self.enabled:
-            return False
-        return self.get_gate_config(gate_name).enabled
-
 
 # Backward-compatible alias
 LanguageConfig = CategoryConfig
@@ -254,13 +248,6 @@ class SlopmopConfig:
 
     # Backward-compatible alias
     get_language_config = get_category_config
-
-    def is_gate_enabled(self, category_key: str, gate_name: str = "") -> bool:
-        """Check if a gate is enabled (category:gate format or separate args)."""
-        if ":" in category_key:
-            category_key, gate_name = category_key.split(":", 1)
-        cat_config = self.get_category_config(category_key)
-        return cat_config.is_gate_enabled(gate_name)
 
 
 def config_file_path(project_root: str | Path) -> Path:

--- a/slopmop/core/executor.py
+++ b/slopmop/core/executor.py
@@ -8,7 +8,7 @@ import concurrent.futures
 import logging
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from slopmop.checks.base import BaseCheck
 from slopmop.core.cache import (
@@ -18,6 +18,7 @@ from slopmop.core.cache import (
     save_cache,
     store_result,
 )
+from slopmop.core.gate_config import gate_enablement
 from slopmop.core.registry import CheckRegistry, get_registry
 from slopmop.core.result import (
     CheckResult,
@@ -37,38 +38,12 @@ def _is_gate_enabled_in_config(
 ) -> Tuple[bool, str]:
     """Check if a gate is enabled in the config.
 
-    Args:
-        check: The check instance
-        config: Configuration dictionary from .sb_config.json
-
-    Returns:
-        Tuple of (is_enabled, reason_if_disabled)
+    Thin wrapper over the canonical
+    :func:`slopmop.core.gate_config.gate_enablement` — the executor's
+    historical semantics ARE the canonical ones (it decides what actually
+    runs), so this delegates instead of re-deriving the nested-dict walk.
     """
-    # Check the disabled_gates list first (sm config --disable uses this)
-    disabled_gates_val: object = config.get("disabled_gates", [])
-    if isinstance(disabled_gates_val, list) and check.full_name in disabled_gates_val:
-        return False, f"{check.full_name} is in disabled_gates list"
-
-    category_key = check.category.key  # e.g., "overconfidence", "laziness", "myopia"
-    gate_name = check.name  # e.g., "lint-format", "dead-code.py"
-
-    # Check if language/category is enabled
-    category_val: object = config.get(category_key)
-    if isinstance(category_val, dict):
-        cat_dict = cast(Dict[str, Any], category_val)
-        if cat_dict.get("enabled") is False:
-            return False, f"{category_key} language is disabled in config"
-
-        # Check if specific gate is disabled
-        gates_val = cat_dict.get("gates")
-        if isinstance(gates_val, dict) and gate_name in gates_val:
-            gate_cfg = cast(Dict[str, Any], gates_val).get(gate_name)
-            if isinstance(gate_cfg, dict):
-                gate_dict = cast(Dict[str, Any], gate_cfg)
-                if gate_dict.get("enabled") is False:
-                    return False, f"{check.full_name} is disabled in config"
-
-    return True, ""
+    return gate_enablement(config, check.full_name)
 
 
 class CheckExecutor:

--- a/slopmop/core/gate_config.py
+++ b/slopmop/core/gate_config.py
@@ -29,8 +29,8 @@ import it without joining slop-mop's deferred-import circularity dance.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, cast
 
 

--- a/slopmop/core/gate_config.py
+++ b/slopmop/core/gate_config.py
@@ -1,0 +1,101 @@
+"""Canonical gate naming and gate-enablement semantics.
+
+Two things every layer of slop-mop needs and, historically, each re-derived
+for itself (tech-debt audit #4):
+
+- **``GateRef``** — the one parser for the stringly-typed ``category:gate``
+  format. Before this module, ``split(":", 1)`` appeared at 25+ call sites;
+  any change to the naming scheme meant hunting all of them.
+- **``gate_enablement()``** — the one answer to "is this gate enabled in
+  this raw config dict?". Before this module there were three raw-dict
+  implementations (executor, doctor preflight, cli config) with *divergent*
+  semantics: only the executor honored a category-level ``enabled: false``,
+  so doctor/preflight reported gates enabled that the executor would skip.
+
+The semantics here are the executor's — the implementation that decides
+what actually runs — and every other caller now delegates:
+
+1. ``disabled_gates`` list membership disables (``sm config --disable``).
+2. Category-level ``{"<category>": {"enabled": false}}`` disables the
+   whole category.
+3. Gate-level ``{"<category>": {"gates": {"<gate>": {"enabled": false}}}}``
+   disables the gate. Only an explicit ``false`` disables — an absent or
+   null ``enabled`` leaves the gate on.
+4. Everything else is enabled.
+
+This module is deliberately dependency-free (stdlib only) so any layer can
+import it without joining slop-mop's deferred-import circularity dance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Tuple, cast
+
+
+@dataclass(frozen=True)
+class GateRef:
+    """A parsed ``category:gate`` gate name.
+
+    ``parse`` accepts both qualified (``"myopia:dependency-risk.py"``) and
+    bare (``"dependency-risk.py"``) names; bare names round-trip with an
+    empty category and ``is_qualified`` False.
+    """
+
+    category: str
+    gate: str
+
+    @classmethod
+    def parse(cls, name: str) -> "GateRef":
+        category, sep, gate = name.partition(":")
+        if not sep:
+            return cls(category="", gate=name)
+        return cls(category=category, gate=gate)
+
+    @property
+    def is_qualified(self) -> bool:
+        return bool(self.category)
+
+    @property
+    def full_name(self) -> str:
+        if not self.category:
+            return self.gate
+        return f"{self.category}:{self.gate}"
+
+
+def _mapping_or_empty(value: object) -> Dict[str, Any]:
+    return cast(Dict[str, Any], value) if isinstance(value, dict) else {}
+
+
+def gate_enablement(config: Mapping[str, Any], full_name: str) -> Tuple[bool, str]:
+    """Return ``(enabled, reason_if_disabled)`` for a gate in a raw config.
+
+    ``reason`` is ``""`` when the gate is enabled. See the module docstring
+    for the precedence rules; the reason strings match what the executor has
+    always reported so skip explanations stay stable.
+    """
+    disabled_val: object = config.get("disabled_gates", [])
+    if isinstance(disabled_val, list) and full_name in cast(list[object], disabled_val):
+        return False, f"{full_name} is in disabled_gates list"
+
+    ref = GateRef.parse(full_name)
+    if not ref.is_qualified:
+        return True, ""
+
+    category_cfg = _mapping_or_empty(config.get(ref.category))
+    if category_cfg.get("enabled") is False:
+        return False, f"{ref.category} language is disabled in config"
+
+    gate_cfg = _mapping_or_empty(
+        _mapping_or_empty(category_cfg.get("gates")).get(ref.gate)
+    )
+    if gate_cfg.get("enabled") is False:
+        return False, f"{full_name} is disabled in config"
+
+    return True, ""
+
+
+def is_gate_enabled(config: Mapping[str, Any], full_name: str) -> bool:
+    """Boolean convenience wrapper over :func:`gate_enablement`."""
+    enabled, _reason = gate_enablement(config, full_name)
+    return enabled

--- a/slopmop/core/gate_config.py
+++ b/slopmop/core/gate_config.py
@@ -30,7 +30,8 @@ import it without joining slop-mop's deferred-import circularity dance.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Tuple, cast
+from collections.abc import Mapping
+from typing import Any, cast
 
 
 @dataclass(frozen=True)
@@ -46,7 +47,7 @@ class GateRef:
     gate: str
 
     @classmethod
-    def parse(cls, name: str) -> "GateRef":
+    def parse(cls, name: str) -> GateRef:
         category, sep, gate = name.partition(":")
         if not sep:
             return cls(category="", gate=name)
@@ -63,11 +64,11 @@ class GateRef:
         return f"{self.category}:{self.gate}"
 
 
-def _mapping_or_empty(value: object) -> Dict[str, Any]:
-    return cast(Dict[str, Any], value) if isinstance(value, dict) else {}
+def _mapping_or_empty(value: object) -> dict[str, Any]:
+    return cast(dict[str, Any], value) if isinstance(value, dict) else {}
 
 
-def gate_enablement(config: Mapping[str, Any], full_name: str) -> Tuple[bool, str]:
+def gate_enablement(config: Mapping[str, Any], full_name: str) -> tuple[bool, str]:
     """Return ``(enabled, reason_if_disabled)`` for a gate in a raw config.
 
     ``reason`` is ``""`` when the gate is enabled. See the module docstring

--- a/slopmop/core/registry.py
+++ b/slopmop/core/registry.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 from slopmop.checks.base import BaseCheck, GateLevel, RemediationChurn
 from slopmop.checks.metadata import builtin_reasoning_for_check_class
+from slopmop.core.gate_config import GateRef
 from slopmop.core.result import CheckDefinition
 from slopmop.utils import as_str_list, dedupe_str_list, normalize_path_filter
 
@@ -318,10 +319,11 @@ class CheckRegistry:
         Returns:
             Configuration dictionary for the specific gate
         """
-        if ":" not in name:
+        ref = GateRef.parse(name)
+        if not ref.is_qualified:
             return {}
 
-        category, gate_name = name.split(":", 1)
+        category, gate_name = ref.category, ref.gate
 
         # Get category config (e.g., python, javascript, security)
         cat_config = full_config.get(category, {})

--- a/slopmop/doctor/gate_preflight.py
+++ b/slopmop/doctor/gate_preflight.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Sequence, Tuple, cast
 from slopmop.checks import ensure_checks_registered
 from slopmop.checks.base import BaseCheck
 from slopmop.checks.custom import register_custom_gates
+from slopmop.core.gate_config import GateRef, is_gate_enabled
 from slopmop.core.registry import get_registry
 
 
@@ -67,20 +68,13 @@ def _as_dict_or_empty(value: Any) -> Dict[str, Any]:
 
 
 def _gate_enabled(config: Dict[str, Any], gate_name: str) -> bool:
-    disabled: list[Any] = config.get("disabled_gates", [])
-    if isinstance(disabled, list) and gate_name in [
-        v for v in disabled if isinstance(v, str)
-    ]:
-        return False
-    if ":" not in gate_name:
-        return True
-    category, gate = gate_name.split(":", 1)
-    category_cfg = _as_dict_or_empty(config.get(category))
-    gates_cfg = _as_dict_or_empty(category_cfg.get("gates"))
-    gate_cfg = _as_dict_or_empty(gates_cfg.get(gate))
-    if "enabled" not in gate_cfg:
-        return True
-    return bool(gate_cfg.get("enabled"))
+    """Delegate to the canonical enablement semantics.
+
+    The previous local implementation ignored a category-level
+    ``enabled: false`` — so preflight/doctor reported gates as enabled that
+    the executor would skip. Delegating closes that divergence.
+    """
+    return is_gate_enabled(config, gate_name)
 
 
 def _gate_config_fingerprint(config: Dict[str, Any], gate_name: str) -> str:
@@ -88,11 +82,11 @@ def _gate_config_fingerprint(config: Dict[str, Any], gate_name: str) -> str:
         "gate": gate_name,
         "enabled": _gate_enabled(config, gate_name),
     }
-    if ":" in gate_name:
-        category, gate = gate_name.split(":", 1)
-        category_cfg = _as_dict_or_empty(config.get(category))
+    ref = GateRef.parse(gate_name)
+    if ref.is_qualified:
+        category_cfg = _as_dict_or_empty(config.get(ref.category))
         gates_cfg = _as_dict_or_empty(category_cfg.get("gates"))
-        gate_cfg = _as_dict_or_empty(gates_cfg.get(gate))
+        gate_cfg = _as_dict_or_empty(gates_cfg.get(ref.gate))
         payload["gate_config"] = gate_cfg
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return sha256(encoded.encode("utf-8")).hexdigest()

--- a/slopmop/migrations/__init__.py
+++ b/slopmop/migrations/__init__.py
@@ -16,6 +16,8 @@ from typing import Any, Callable, Dict, Iterable, List, Sequence, cast
 
 from packaging.version import Version
 
+from slopmop.core.gate_config import GateRef
+
 # ---------------------------------------------------------------------------
 # Config file constant (matches slopmop.core.config.CONFIG_FILE)
 # ---------------------------------------------------------------------------
@@ -227,7 +229,7 @@ def find_stale_gate_references(
 
     for key, value in config.items():
         if ":" in key and isinstance(value, dict):
-            category = key.split(":", 1)[0]
+            category = GateRef.parse(key).category
             if category in _CONFIG_CATEGORY_KEYS:
                 _record(key, "flat gate config")
             continue
@@ -436,7 +438,8 @@ def _sync_built_in_gate_applicability(project_root: Path) -> None:
         if not isinstance(full_name_any, str) or ":" not in full_name_any:
             continue
         full_name = full_name_any
-        category, gate_name = full_name.split(":", 1)
+        ref = GateRef.parse(full_name)
+        category, gate_name = ref.category, ref.gate
 
         gate_configs: List[Dict[str, Any]] = []
         category_raw = data.get(category)

--- a/slopmop/reporting/display/dynamic.py
+++ b/slopmop/reporting/display/dynamic.py
@@ -11,6 +11,7 @@ import time
 from typing import Dict, List, Optional
 
 from slopmop.constants import ROLE_BADGES, STATUS_EMOJI
+from slopmop.core.gate_config import GateRef
 from slopmop.core.result import CheckResult, CheckStatus, ScopeInfo
 from slopmop.reporting.display import config
 from slopmop.reporting.display.colors import (
@@ -757,7 +758,7 @@ class DynamicDisplay:
         stats = info.timing_stats
         if stats and stats.median > 0:
             ratio = elapsed / stats.median
-            category = info.name.split(":")[0] if ":" in info.name else ""
+            category = GateRef.parse(info.name).category
             cat_color = category_header_color(category, self._colors_enabled) or None
 
             if ratio > 1.0:

--- a/slopmop/reporting/display/renderer.py
+++ b/slopmop/reporting/display/renderer.py
@@ -8,6 +8,7 @@ import shutil
 import unicodedata
 from typing import List, Optional
 
+from slopmop.core.gate_config import GateRef
 from slopmop.core.result import ScopeInfo
 from slopmop.reporting.display import config
 
@@ -495,6 +496,4 @@ def strip_category_prefix(check_name: str) -> str:
     Returns:
         Check name without category prefix
     """
-    if ":" in check_name:
-        return check_name.split(":", 1)[1]
-    return check_name
+    return GateRef.parse(check_name).gate

--- a/tests/unit/test_gate_config.py
+++ b/tests/unit/test_gate_config.py
@@ -1,0 +1,109 @@
+"""Tests for the canonical gate naming + enablement module.
+
+``gate_config`` exists to end the era of five divergent "is this gate
+enabled" implementations and 25+ ad-hoc ``split(":", 1)`` sites (tech-debt
+audit #4). These tests pin the canonical semantics, guard against a rival
+enablement API reappearing on the structured config classes (the old one
+had zero consumers and opposite defaults, so it was deleted, not
+reconciled), and cover the divergence the unification fixed:
+category-level disables that preflight/cli previously ignored.
+"""
+
+from __future__ import annotations
+
+from slopmop.core.config import SlopmopConfig
+from slopmop.core.gate_config import GateRef, gate_enablement, is_gate_enabled
+
+
+class TestGateRef:
+    def test_qualified_roundtrip(self):
+        ref = GateRef.parse("myopia:dependency-risk.py")
+        assert ref.category == "myopia"
+        assert ref.gate == "dependency-risk.py"
+        assert ref.is_qualified
+        assert ref.full_name == "myopia:dependency-risk.py"
+
+    def test_bare_name_roundtrip(self):
+        ref = GateRef.parse("dependency-risk.py")
+        assert ref.category == ""
+        assert ref.gate == "dependency-risk.py"
+        assert not ref.is_qualified
+        assert ref.full_name == "dependency-risk.py"
+
+    def test_only_first_colon_splits(self):
+        # Gate names may themselves contain colons someday; the category is
+        # everything before the FIRST colon, matching split(":", 1).
+        ref = GateRef.parse("a:b:c")
+        assert (ref.category, ref.gate) == ("a", "b:c")
+        assert ref.full_name == "a:b:c"
+
+
+class TestGateEnablement:
+    def test_default_is_enabled(self):
+        assert gate_enablement({}, "myopia:g") == (True, "")
+
+    def test_disabled_gates_list(self):
+        enabled, reason = gate_enablement({"disabled_gates": ["myopia:g"]}, "myopia:g")
+        assert enabled is False
+        assert "disabled_gates" in reason
+
+    def test_category_level_disable(self):
+        # The divergence the unification fixed: preflight/cli ignored this
+        # while the executor honored it.
+        enabled, reason = gate_enablement({"myopia": {"enabled": False}}, "myopia:g")
+        assert enabled is False
+        assert "myopia" in reason
+
+    def test_gate_level_disable(self):
+        cfg = {"myopia": {"gates": {"g": {"enabled": False}}}}
+        enabled, reason = gate_enablement(cfg, "myopia:g")
+        assert enabled is False
+        assert "myopia:g" in reason
+
+    def test_only_explicit_false_disables(self):
+        # Executor semantics: absent or null "enabled" leaves the gate on.
+        assert is_gate_enabled({"myopia": {"gates": {"g": {}}}}, "myopia:g")
+        assert is_gate_enabled(
+            {"myopia": {"gates": {"g": {"enabled": None}}}}, "myopia:g"
+        )
+
+    def test_bare_names_are_always_enabled(self):
+        assert is_gate_enabled({"disabled_gates": []}, "custom-gate")
+
+    def test_malformed_config_shapes_are_safe(self):
+        # Wrong types anywhere in the walk must not raise.
+        assert is_gate_enabled({"disabled_gates": "not-a-list"}, "a:b")
+        assert is_gate_enabled({"a": "not-a-dict"}, "a:b")
+        assert is_gate_enabled({"a": {"gates": "not-a-dict"}}, "a:b")
+        assert is_gate_enabled({"a": {"gates": {"b": "not-a-dict"}}}, "a:b")
+
+
+class TestCanonicalIsTheOnlyImplementation:
+    """The structured config classes must NOT grow a rival enablement API.
+
+    ``SlopmopConfig.is_gate_enabled``/``CategoryConfig.is_gate_enabled`` were
+    deleted during the unification: they had zero production consumers and
+    silently used the OPPOSITE default (enabled=False) from the executor. If
+    someone reintroduces an enablement method on the structured classes, this
+    test forces the conversation back to the canonical module.
+    """
+
+    def test_structured_classes_have_no_enablement_api(self):
+        from slopmop.core.config import CategoryConfig
+
+        assert not hasattr(SlopmopConfig, "is_gate_enabled")
+        assert not hasattr(CategoryConfig, "is_gate_enabled")
+
+
+class TestPreflightUsesCanonicalSemantics:
+    def test_category_disable_reaches_preflight(self):
+        # Regression: _gate_enabled previously ignored category-level
+        # disables, so doctor/refit readiness disagreed with the executor.
+        from slopmop.doctor.gate_preflight import _gate_enabled
+
+        assert _gate_enabled({"myopia": {"enabled": False}}, "myopia:g") is False
+
+    def test_category_disable_reaches_cli_config(self):
+        from slopmop.cli.config import _is_gate_enabled
+
+        assert _is_gate_enabled({"myopia": {"enabled": False}}, "myopia:g") is False


### PR DESCRIPTION
Phase 3 of the tech-debt audit: the config-unification arc that retires the divergence bug class, plus the agreed dogfood lead-in.

## 1. `GateRef` — one parser for `category:gate` (audit #4)
New `core/gate_config.py` hosts the single parser for the stringly-typed gate-name format. All **25+ ad-hoc `split(":", 1)` sites** across cli/core/doctor/reporting/migrations now go through it; a repo-wide grep confirms **zero remain**. Any future change to the naming scheme is one function.

## 2. One enablement truth — and it fixed another live divergence (audit #4)
`gate_enablement()` / `is_gate_enabled()` carry the executor's semantics (the implementation that decides what actually runs): `disabled_gates` → category-level `enabled: false` → gate-level explicit `false` → enabled. Executor, doctor preflight, and `sm config` all **delegate** now.

**The fix this surfaced:** preflight and `sm config` previously ignored a category-level `{"<category>": {"enabled": false}}` — reporting gates as enabled that the executor would skip. Same bug family as #310 and the Phase-1 preflight bug; regression tests pin both consumers.

**The deletion this justified:** `SlopmopConfig.is_gate_enabled` / `CategoryConfig.is_gate_enabled` had **zero production consumers** and defaulted to `enabled=False` — the *opposite* of the executor. Dead API with wrong semantics got deleted, not reconciled; a tombstone test blocks a rival API from reappearing.

## 3. Named timeout tiers (audit #10)
`checks/timeouts.py` defines six intent-named tiers (`PROBE_TIMEOUT` 5s → `EXHAUSTIVE_TASK_TIMEOUT` 900s). **61 literals across 28 gate files** migrated with **zero value changes** (exact-match only; the stray 10/15/180s literals are left for opportunistic normalization, documented in the module).

## 4. Dogfood exercises `project-install`
`action-dogfood.yml` now provisions the project venv through the action's own `project-install` input instead of a hand-rolled workflow step — so the v2 input added in action #6 is tested on every PR.

## Poetic footnote
Mid-commit, the `ambiguity-mines` gate blocked me for defining a second `_as_dict` with different semantics than an existing one — the tooling enforcing this PR's own thesis. Renamed to `_mapping_or_empty`.

Full suite: **3,386 green** (+14 gate_config tests), swab clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Unified gate parsing and enablement semantics, and standardized subprocess timeouts across the checks tree.

- Added `core/gate_config.py` with `GateRef`, `gate_enablement()`, and `is_gate_enabled()`.
- Replaced ad hoc `category:gate` splitting across core, CLI, doctor, migrations, reporting, and registry code.
- Removed legacy `is_gate_enabled` methods from config classes and added regression tests.
- Centralized timeout literals into `checks/timeouts.py` and migrated checks to the new named tiers without changing values.
- Updated dogfood workflow to use the action’s `project-install` v2 input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->