### PR TITLE
fix(deps): ignore mcp server-transport advisories (no upgrade path)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,11 +180,33 @@ exclude = ["tests/**", "venv/**", "build/**", "dist/**"]
 [tool.slopmop.myopia.gates."dependency-risk.py"]
 pip_audit_ignore_vulns = [
     "GHSA-5239-wwwm-4pmq",  # pygments ReDoS (CVE-2026-4539), low severity, no fix available
+    # mcp 1.23.3 server-transport advisories, reachable only if you RUN an MCP
+    # server: cross-client task access (3481), HTTP transports not verifying the
+    # authenticated principal (3482), WebSocket Host/Origin validation (3483).
+    # slop-mop never imports mcp — it arrives transitively via semgrep, which we
+    # only ever invoke as a CLI scanner, so none of these code paths execute.
+    # No upgrade path: semgrep pins mcp==1.23.3 exactly (still true on 1.172.0),
+    # so a floor-pin like the pyjwt/python-multipart ones above is unsatisfiable.
+    # Re-check when semgrep unpins mcp, then drop these three.
+    "PYSEC-2026-3481",
+    "PYSEC-2026-3482",
+    "PYSEC-2026-3483",
 ]
 
 [tool.slopmop.myopia.gates."vulnerability-blindness.py"]
 pip_audit_ignore_vulns = [
     "GHSA-5239-wwwm-4pmq",  # pygments ReDoS (CVE-2026-4539), low severity, no fix available
+    # mcp 1.23.3 server-transport advisories, reachable only if you RUN an MCP
+    # server: cross-client task access (3481), HTTP transports not verifying the
+    # authenticated principal (3482), WebSocket Host/Origin validation (3483).
+    # slop-mop never imports mcp — it arrives transitively via semgrep, which we
+    # only ever invoke as a CLI scanner, so none of these code paths execute.
+    # No upgrade path: semgrep pins mcp==1.23.3 exactly (still true on 1.172.0),
+    # so a floor-pin like the pyjwt/python-multipart ones above is unsatisfiable.
+    # Re-check when semgrep unpins mcp, then drop these three.
+    "PYSEC-2026-3481",
+    "PYSEC-2026-3482",
+    "PYSEC-2026-3483",
 ]
 
 [tool.slopmop.myopia.gates."github-actions-hygiene"]


### PR DESCRIPTION
The weekly scheduled scan has failed every Sunday since **Jul 20** (Jul 20, Jul 27, Aug 3) with **no code change** — three advisories were published against `mcp 1.23.3`: **PYSEC-2026-3481/3482/3483**. That's the gate working exactly as intended: a scheduled scan on untouched `main` caught newly-published advisories.

## Why ignore rather than fix
**No upgrade path exists.** `mcp` arrives transitively via **semgrep**, which pins it *exactly*: `mcp==1.23.3` — and still does on the latest semgrep (1.172.0; we're on 1.149.0). So the floor-pin trick used for `pyjwt` and `python-multipart` two lines above would be **unsatisfiable** here.

**And they don't apply to how we use it.** All three are MCP **server-side transport** flaws:
- 3481 — experimental task handlers let any client access/cancel another's tasks
- 3482 — HTTP transports serve session requests without verifying the authenticated principal
- 3483 — WebSocket server transport lacks Host/Origin validation

Verified: slop-mop **never imports `mcp`**, and only ever invokes semgrep as a CLI scanner. None of those code paths execute.

Same pattern (and same file) as the existing pygments entry: real advisory, no fix available, not reachable in our usage → documented ignore with an explicit **re-check trigger** — drop all three when semgrep unpins mcp.

## Verification
A/B tested locally: **without** the entries pip-audit reports `mcp 1.23.3` with all three advisories; **with** them, zero mcp findings.

*(Note: a local run still shows unrelated findings from my stale dev venv — click, cryptography, msgpack, etc. CI does a fresh `pip install -e ".[all]"` and flagged **only** mcp, so those are a local-environment artifact, not something this PR needs to address.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `pip_audit_ignore_vulns` for both audit configurations to ignore three MCP advisories affecting `mcp==1.23.3`.

Added comments that Semgrep installs this version transitively, the project does not use MCP server transports, and no upgrade path exists. Included a re-check trigger for when Semgrep unpins `mcp`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->