### PR TITLE
docs(case-study): correct the rulebook-ai test baseline

### DIFF
--- a/.willville.json
+++ b/.willville.json
@@ -1,7 +1,7 @@
 {
   "agent": {
-    "status": "Ran slop-mop cold on a stranger's repo (rulebook-ai) as a case study and drove it from failing to a clean bill of health — the run shook out four of our own bugs, up on PR #332",
-    "direction": "Write the case study up for the site now that we have the before and after numbers",
-    "last_update": "2026-08-10T21:45:00Z"
+    "status": "Wrote up the rulebook-ai run as the site's second case study — PR #13 on the website, plus a small honesty fix to our own notes in #333",
+    "direction": "Both are waiting on a merge; after that the story is live and we can look for the next repo to try this on",
+    "last_update": "2026-08-11T08:00:00Z"
   }
 }

--- a/DOCS/case-studies/rulebook-ai-BARNACLES.md
+++ b/DOCS/case-studies/rulebook-ai-BARNACLES.md
@@ -178,4 +178,4 @@ summariser describes the failed result instead of `results[0]`.
 
 **Final: A+ — shipshape, 0 findings, 21 gates passing.** (Baseline: 8 failing.)
 
-Their own suite went 53 passing / 3 failing → **81 passing / 0 failing**.
+Their own suite: **56 passing at the merge-base, 81 passing at the end** (25 added). An earlier draft of this line read "53 passing / 3 failing → 81 passing", which implied we inherited three broken tests. We did not — those three were *our* regression, from the scheme validation in step 1, and the `git stash` baseline that appeared to clear us only removed *uncommitted* work. See barnacle 10's neighbours in the ledger.

--- a/DOCS/case-studies/rulebook-ai-BARNACLES.md
+++ b/DOCS/case-studies/rulebook-ai-BARNACLES.md
@@ -178,4 +178,13 @@ summariser describes the failed result instead of `results[0]`.
 
 **Final: A+ — shipshape, 0 findings, 21 gates passing.** (Baseline: 8 failing.)
 
-Their own suite: **56 passing at the merge-base, 81 passing at the end** (25 added). An earlier draft of this line read "53 passing / 3 failing → 81 passing", which implied we inherited three broken tests. We did not — those three were *our* regression, from the scheme validation in step 1, and the `git stash` baseline that appeared to clear us only removed *uncommitted* work. See barnacle 10's neighbours in the ledger.
+Their own suite: **56 passing at the merge-base, 81 passing at the end**
+(25 added).
+
+An earlier draft of this line read "53 passing / 3 failing → 81 passing",
+which implied we inherited three broken tests. We did not. Those three were
+*our* regression — the URL-scheme validation from step 1 dropped `file:`
+support, which their community-index tests depend on — and the `git stash`
+check that appeared to clear us only removes *uncommitted* work, so the
+already-committed break survived it. Step 10 in the log above is where it
+was found and fixed.


### PR DESCRIPTION
The rulebook-ai progress log claimed their suite went "53 passing / 3 failing → 81 passing". That reads as though we inherited three broken tests and fixed them. We did not.

At the merge-base (`7bc8531`) all **56** of their tests pass. The three failures were our own regression — the URL-scheme validation added for bandit B310 removed `file:` support, which their community-index integration tests rely on. The `git stash` check that appeared to prove the failures were pre-existing only removes *uncommitted* work, so the already-committed breakage survived it and every "baseline" run reproduced it.

Corrected to **56 passing at the merge-base → 81 at the end** (25 added), with the reason stated inline. Leaving the old number would have credited us with a repair we never made, in the document that argues for reporting our own defects.

Surfaced while writing the number up for the website case study.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the rulebook-ai case study to correct the test baseline: 56 tests passed at merge-base and 81 passed at completion. Clarifies that the three earlier failures came from a project regression removing `file:` URL support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->